### PR TITLE
Feat/harden actions runner controller

### DIFF
--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "actions-runner-controller.labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -23,7 +23,7 @@ authSecret:
 image:
   repository: summerwind/actions-runner-controller
   tag: "v0.17.0"
-  dindSidecarRepositoryAndTag: "docker:dind"
+  dindSidecarRepositoryAndTag: "docker:20.10-dind-rootless"
   pullPolicy: IfNotPresent
 
 kube_rbac_proxy:
@@ -47,17 +47,15 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  fsGroup: 1000
 
 securityContext:
-  {}
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-  # runAsUser: 1000
+  runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -44,7 +44,7 @@ if [ ! -d /runner ]; then
   exit 1
 fi
 
-sudo chown -R runner:docker /runner
+chown -R runner:docker /runner
 mv /runnertmp/* /runner/
 
 cd /runner


### PR DESCRIPTION
This PR hardens the actions runner controller with some best practices - running as non-root, using default `seccomp` profile and removing `sudo` from entrypoint script for the runner.