### PR TITLE
feat: allow autoscaler to scale down to 0

### DIFF
--- a/controllers/horizontalrunnerautoscaler_controller.go
+++ b/controllers/horizontalrunnerautoscaler_controller.go
@@ -19,8 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/summerwind/actions-runner-controller/github"
 	"k8s.io/apimachinery/pkg/types"
@@ -186,7 +187,7 @@ func (r *HorizontalRunnerAutoscalerReconciler) SetupWithManager(mgr ctrl.Manager
 
 func (r *HorizontalRunnerAutoscalerReconciler) computeReplicasWithCache(log logr.Logger, now time.Time, rd v1alpha1.RunnerDeployment, hra v1alpha1.HorizontalRunnerAutoscaler) (int, int, *int, error) {
 	minReplicas := defaultReplicas
-	if hra.Spec.MinReplicas != nil && *hra.Spec.MinReplicas > 0 {
+	if hra.Spec.MinReplicas != nil && *hra.Spec.MinReplicas >= 0 {
 		minReplicas = *hra.Spec.MinReplicas
 	}
 


### PR DESCRIPTION
This is a tiny change which allows horizontalrunnerautoscalers to be able to scale down a deployment to "0".

We utilize on our Google Cloud instance the autoscaler with webhooks and this scaler to dynamically scale down and up when a build is requested. The deployments are run on dedicated servers which are dynamically scaled up and down when needed.

In this scenario and if no build runs at all in our account we want to be able to scale down to "0".


Tested on a google cloud cluster, the change seems to work as expected.