### PR TITLE
feat: Allow Percentage runner busy minimum 1

### DIFF
--- a/controllers/autoscaling.go
+++ b/controllers/autoscaling.go
@@ -348,6 +348,12 @@ func (r *HorizontalRunnerAutoscalerReconciler) suggestReplicasByPercentageRunner
 	// - num_runners can be as twice as large as replicas_desired_before while
 	//   the runnerdeployment controller is replacing RunnerReplicaSet for runner update.
 
+	if desiredReplicas <= 0 {
+		// desiredReplicas of 0 never scale up for the replicas by PercentageRunnersBusy. Force setting
+		// it to 1 when scaling with this metric.
+		desiredReplicas = 1
+	}
+
 	r.Log.V(1).Info(
 		fmt.Sprintf("Suggested desired replicas of %d by PercentageRunnersBusy", desiredReplicas),
 		"replicas_desired_before", desiredReplicasBefore,

--- a/controllers/horizontalrunnerautoscaler_controller.go
+++ b/controllers/horizontalrunnerautoscaler_controller.go
@@ -19,8 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/summerwind/actions-runner-controller/github"
 	"k8s.io/apimachinery/pkg/types"
@@ -186,7 +187,7 @@ func (r *HorizontalRunnerAutoscalerReconciler) SetupWithManager(mgr ctrl.Manager
 
 func (r *HorizontalRunnerAutoscalerReconciler) computeReplicasWithCache(log logr.Logger, now time.Time, rd v1alpha1.RunnerDeployment, hra v1alpha1.HorizontalRunnerAutoscaler) (int, int, *int, error) {
 	minReplicas := defaultReplicas
-	if hra.Spec.MinReplicas != nil && *hra.Spec.MinReplicas > 0 {
+	if hra.Spec.MinReplicas != nil && *hra.Spec.MinReplicas >= 0 {
 		minReplicas = *hra.Spec.MinReplicas
 	}
 


### PR DESCRIPTION
This is a PR which is built on top of https://github.com/summerwind/actions-runner-controller/pull/447 and ensures the `PercentageRunnersBusy` to always return 1 when scaling if it is lower than 0. Please refer to the original PR for further details.