### PR TITLE
feat: Support for scaling from/to zero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,10 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests
-	go test ./... -coverprofile cover.out
+	TEST_ASSET_KUBE_APISERVER=$(KUBE_APISERVER_BIN) \
+	TEST_ASSET_ETCD=$(ETCD_BIN) \
+	TEST_ASSET_KUBECTL=$(KUBECTL_BIN) \
+	  go test ./... -coverprofile cover.out
 
 test-with-deps: kube-apiserver etcd kubectl
 	# See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest#pkg-constants

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,7 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests
-	TEST_ASSET_KUBE_APISERVER=$(KUBE_APISERVER_BIN) \
-	TEST_ASSET_ETCD=$(ETCD_BIN) \
-	TEST_ASSET_KUBECTL=$(KUBECTL_BIN) \
-	  go test ./... -coverprofile cover.out
+	go test ./... -coverprofile cover.out
 
 test-with-deps: kube-apiserver etcd kubectl
 	# See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest#pkg-constants
@@ -224,6 +221,7 @@ OS_NAME := $(shell uname -s | tr A-Z a-z)
 
 # find or download etcd
 etcd:
+ifeq (, $(shell which etcd))
 ifeq (, $(wildcard $(TEST_ASSETS)/etcd))
 	@{ \
 	set -xe ;\
@@ -241,9 +239,13 @@ ETCD_BIN=$(TEST_ASSETS)/etcd
 else
 ETCD_BIN=$(TEST_ASSETS)/etcd
 endif
+else
+ETCD_BIN=$(shell which etcd)
+endif
 
 # find or download kube-apiserver
 kube-apiserver:
+ifeq (, $(shell which kube-apiserver))
 ifeq (, $(wildcard $(TEST_ASSETS)/kube-apiserver))
 	@{ \
 	set -xe ;\
@@ -261,10 +263,13 @@ KUBE_APISERVER_BIN=$(TEST_ASSETS)/kube-apiserver
 else
 KUBE_APISERVER_BIN=$(TEST_ASSETS)/kube-apiserver
 endif
-
+else
+KUBE_APISERVER_BIN=$(shell which kube-apiserver)
+endif
 
 # find or download kubectl
 kubectl:
+ifeq (, $(shell which kubectl))
 ifeq (, $(wildcard $(TEST_ASSETS)/kubectl))
 	@{ \
 	set -xe ;\
@@ -281,4 +286,7 @@ ifeq (, $(wildcard $(TEST_ASSETS)/kubectl))
 KUBECTL_BIN=$(TEST_ASSETS)/kubectl
 else
 KUBECTL_BIN=$(TEST_ASSETS)/kubectl
+endif
+else
+KUBECTL_BIN=$(shell which kubectl)
 endif

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
-docker-build: test
+docker-build:
 	docker build . -t ${NAME}:${VERSION}
 
 # Push the docker image
@@ -163,7 +163,7 @@ acceptance/pull:
 
 acceptance/setup:
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml	#kubectl create namespace actions-runner-system
-	kubectl -n cert-manager wait deploy/cert-manager-cainjector --for condition=available --timeout 60s
+	kubectl -n cert-manager wait deploy/cert-manager-cainjector --for condition=available --timeout 90s
 	kubectl -n cert-manager wait deploy/cert-manager-webhook --for condition=available --timeout 60s
 	kubectl -n cert-manager wait deploy/cert-manager --for condition=available --timeout 60s
 	kubectl create namespace actions-runner-system || true

--- a/README.md
+++ b/README.md
@@ -808,3 +808,30 @@ NAME=$DOCKER_USER/actions-runner make \
 
 **Runner Tests**<br />
 A set of example pipelines (./acceptance/pipelines) are provided in this repository which you can use to validate your runners are working as expected. When raising a PR please run the relevant suites to prove your change hasn't broken anything.
+
+**Running Ginkgo Tests**
+
+You can run the integration test suite that is written in Ginkgo with:
+
+```bash
+make test-with-deps
+```
+
+This will firstly install a few binaries required to setup the integration test environment and then runs `go test` to start the Ginkgo test.
+
+If you don't want to use `make`, like when you're running tests from your IDE, install required binaries to `/usr/local/kubebuilder/bin`. That's the directory in which controller-runtime's `envtest` framework locates the binaries.
+
+```bash
+sudo mkdir -p /usr/local/kubebuilder/bin
+make kube-apiserver etcd
+sudo mv test-assets/{etcd,kube-apiserver} /usr/local/kubebuilder/bin/
+go test -v -run TestAPIs github.com/summerwind/actions-runner-controller/controllers
+```
+
+To run Ginkgo tests selectively, set the pattern of target test names to `GINKGO_FOCUS`.
+All the Ginkgo test that matches `GINKGO_FOCUS` will be run.
+
+```bash
+GINKGO_FOCUS='[It] should create a new Runner resource from the specified template, add a another Runner on replicas increased, and removes all the replicas when set to 0' \
+  go test -v -run TestAPIs github.com/summerwind/actions-runner-controller/controllers
+```

--- a/README.md
+++ b/README.md
@@ -788,5 +788,23 @@ NAME=$DOCKER_USER/actions-runner-controller \
        acceptance/tests
 ```
 
+**Development Tips**
+
+If you've already deployed actions-runner-controller and only want to recreate pods to use the newer image, you can run:
+
+```
+NAME=$DOCKER_USER/actions-runner-controller \
+  make docker-build docker-push && \
+  kubectl -n actions-runner-system delete po $(kubectl -n actions-runner-system get po -ojsonpath={.items[*].metadata.name})
+```
+
+Similary, if you'd like to recreate runner pods with the newer runner image,
+
+```
+NAME=$DOCKER_USER/actions-runner make \
+  -C runner docker-{build,push}-ubuntu && \
+  (kubectl get po -ojsonpath={.items[*].metadata.name} | xargs -n1 kubectl delete po)
+```
+
 **Runner Tests**<br />
 A set of example pipelines (./acceptance/pipelines) are provided in this repository which you can use to validate your runners are working as expected. When raising a PR please run the relevant suites to prove your change hasn't broken anything.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ToC:
   - [Organization Runners](#organization-runners)
   - [Enterprise Runners](#enterprise-runners)
   - [Runner Deployments](#runnerdeployments)
+    - [Note on scaling to/from 0](#note-on-scaling-to-from-zero)
     - [Autoscaling](#autoscaling)
       - [Faster Autoscaling with GitHub Webhook](#faster-autoscaling-with-github-webhook)
   - [Runner with DinD](#runner-with-dind)
@@ -278,6 +279,22 @@ NAME                             REPOSITORY                             STATUS
 example-runnerdeploy2475h595fr   mumoshu/actions-runner-controller-ci   Running
 example-runnerdeploy2475ht2qbr   mumoshu/actions-runner-controller-ci   Running
 ```
+
+##### Note on scaling to/from 0
+
+You can either delete the runner deployment, or update it to have `replicas: 0`, so that there will be 0 runner pods in the cluster. This, in combination with e.g. `cluster-autoscaler`, enables you to save your infrastructure cost when there's no need to run Actions jobs.
+
+```yaml
+# runnerdeployment.yaml
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: example-runnerdeploy
+spec:
+  replicas: 0
+```
+
+The implication of setting `replicas: 0` instead of deleting the runner depoyment is that you can let GitHub Actions queue jobs until there will be one or more runners. See [#465](https://github.com/actions-runner-controller/actions-runner-controller/pull/465) for more information.
 
 #### Autoscaling
 

--- a/acceptance/testdata/runnerdeploy.yaml
+++ b/acceptance/testdata/runnerdeploy.yaml
@@ -6,7 +6,13 @@ spec:
 #  replicas: 1
   template:
     spec:
-      repository: mumoshu/actions-runner-controller-ci
+      repository: mumoshu/actions-test
+      
+      #
+      # Custom runner image
+      #
+      image: mumoshu/actions-runner:dev
+
       #
       # dockerd within runner container
       #
@@ -18,3 +24,13 @@ spec:
       # Set the MTU used by dockerd-managed network interfaces (including docker-build-ubuntu)
       #
       #dockerMTU: 1450
+
+      #Runner group
+      # labels:
+      # - "mylabel 1"
+      # - "mylabel 2"
+
+      #
+      # Non-standard working directory
+      #
+      # workDir: "/"

--- a/acceptance/testdata/runnerdeploy.yaml
+++ b/acceptance/testdata/runnerdeploy.yaml
@@ -11,7 +11,7 @@ spec:
       #
       # Custom runner image
       #
-      image: mumoshu/actions-runner:dev
+      #image: mumoshu/actions-runner:dev
 
       #
       # dockerd within runner container

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: summerwind/actions-runner-controller
-  newTag: latest
+  newName: mumoshu/actions-runner-controller
+  newTag: dev

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -449,7 +449,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -492,7 +492,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1)
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3)
-				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 				env.SyncRunnerRegistrations()
 				ExpectRunnerCountEventuallyEquals(ctx, ns.Name, 3)
 			}
@@ -502,7 +502,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				env.SendOrgCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1, "runner sets after webhook")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 4, "runners after first webhook event")
-				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
 				env.SyncRunnerRegistrations()
 				ExpectRunnerCountEventuallyEquals(ctx, ns.Name, 4)
 			}
@@ -511,7 +511,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			{
 				env.SendOrgCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 5, "runners after second webhook event")
-				env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(6, "count of fake list runners")
 				env.SyncRunnerRegistrations()
 				ExpectRunnerCountEventuallyEquals(ctx, ns.Name, 5)
 			}
@@ -557,7 +557,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -598,7 +598,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 2 replicas on first check_run create webhook event
@@ -609,7 +609,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas on second check_run create webhook event
@@ -618,7 +618,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3, "runners after second webhook event")
 			}
 
-			env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
+			env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 		})
 
 		It("should create and scale user's repository runners on pull_request event", func() {
@@ -887,7 +887,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -933,7 +933,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(4 "count of fake list runners")
 			}
 
 			// Scale-up to 4 replicas on first check_run create webhook event
@@ -944,7 +944,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
 			}
 
 			// Scale-up to 5 replicas on second check_run create webhook event
@@ -953,7 +953,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 5, "runners after second webhook event")
 			}
 
-			env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
+			env.ExpectRegisteredNumberCountEventuallyEquals(6, "count of fake list runners")
 		})
 
 		It("should create and scale user's repository runners only on check_run event", func() {
@@ -996,7 +996,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -1037,7 +1037,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 2 replicas on first check_run create webhook event
@@ -1048,7 +1048,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas on second check_run create webhook event
@@ -1057,7 +1057,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3, "runners after second webhook event")
 			}
 
-			env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
+			env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 		})
 
 	})

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -446,10 +446,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				ExpectCreate(ctx, rd, "test RunnerDeployment")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1)
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 1)
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -492,7 +489,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1)
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3)
-				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
 				env.SyncRunnerRegistrations()
 				ExpectRunnerCountEventuallyEquals(ctx, ns.Name, 3)
 			}
@@ -502,7 +499,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				env.SendOrgCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1, "runner sets after webhook")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 4, "runners after first webhook event")
-				env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 				env.SyncRunnerRegistrations()
 				ExpectRunnerCountEventuallyEquals(ctx, ns.Name, 4)
 			}
@@ -511,7 +508,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			{
 				env.SendOrgCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 5, "runners after second webhook event")
-				env.ExpectRegisteredNumberCountEventuallyEquals(6, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
 				env.SyncRunnerRegistrations()
 				ExpectRunnerCountEventuallyEquals(ctx, ns.Name, 5)
 			}
@@ -554,10 +551,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				ExpectCreate(ctx, rd, "test RunnerDeployment")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1)
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 1)
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -595,10 +589,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1)
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 1)
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
 			}
 
 			// Scale-up to 2 replicas on first check_run create webhook event
@@ -606,19 +597,15 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				env.SendOrgCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1, "runner sets after webhook")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 2, "runners after first webhook event")
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas on second check_run create webhook event
 			{
 				env.SendOrgCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3, "runners after second webhook event")
+				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
 			}
-
-			env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 		})
 
 		It("should create and scale user's repository runners on pull_request event", func() {
@@ -884,10 +871,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				ExpectCreate(ctx, rd, "test RunnerDeployment")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1)
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 1)
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -930,10 +914,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1)
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3)
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
 			}
 
 			// Scale-up to 4 replicas on first check_run create webhook event
@@ -941,19 +922,15 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				env.SendUserCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1, "runner sets after webhook")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 4, "runners after first webhook event")
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 			}
 
 			// Scale-up to 5 replicas on second check_run create webhook event
 			{
 				env.SendUserCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 5, "runners after second webhook event")
+				env.ExpectRegisteredNumberCountEventuallyEquals(5, "count of fake list runners")
 			}
-
-			env.ExpectRegisteredNumberCountEventuallyEquals(6, "count of fake list runners")
 		})
 
 		It("should create and scale user's repository runners only on check_run event", func() {
@@ -996,7 +973,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas by the default TotalNumberOfQueuedAndInProgressWorkflowRuns-based scaling
@@ -1037,7 +1014,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(1, "count of fake list runners")
 			}
 
 			// Scale-up to 2 replicas on first check_run create webhook event
@@ -1045,19 +1022,15 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 				env.SendUserCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsCountEventuallyEquals(ctx, ns.Name, 1, "runner sets after webhook")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 2, "runners after first webhook event")
-			}
-
-			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(2, "count of fake list runners")
 			}
 
 			// Scale-up to 3 replicas on second check_run create webhook event
 			{
 				env.SendUserCheckRunEvent("test", "valid", "pending", "created")
 				ExpectRunnerSetsManagedReplicasCountEventuallyEquals(ctx, ns.Name, 3, "runners after second webhook event")
+				env.ExpectRegisteredNumberCountEventuallyEquals(3, "count of fake list runners")
 			}
-
-			env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 		})
 
 	})

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -933,7 +933,7 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 			}
 
 			{
-				env.ExpectRegisteredNumberCountEventuallyEquals(4 "count of fake list runners")
+				env.ExpectRegisteredNumberCountEventuallyEquals(4, "count of fake list runners")
 			}
 
 			// Scale-up to 4 replicas on first check_run create webhook event

--- a/controllers/runnerdeployment_controller.go
+++ b/controllers/runnerdeployment_controller.go
@@ -188,7 +188,7 @@ func (r *RunnerDeploymentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		return ctrl.Result{}, err
 	}
 
-	// Do we old runner replica sets that should eventually deleted?
+	// Do we have old runner replica sets that should eventually deleted?
 	if len(oldSets) > 0 {
 		readyReplicas := newestSet.Status.ReadyReplicas
 

--- a/controllers/runnerreplicaset_controller.go
+++ b/controllers/runnerreplicaset_controller.go
@@ -68,6 +68,32 @@ func (r *RunnerReplicaSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		return ctrl.Result{}, nil
 	}
 
+	if err := r.Get(
+		ctx,
+		req.NamespacedName,
+		&v1alpha1.Runner{},
+	); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+
+		runnerForScaleFromToZero, err := r.newRunner(rs)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("Failed to create runner for scale from/to zero: %v", err)
+		}
+
+		runnerForScaleFromToZero.ObjectMeta.Name = rs.Name
+		runnerForScaleFromToZero.ObjectMeta.GenerateName = ""
+		runnerForScaleFromToZero.ObjectMeta.Labels = nil
+		runnerForScaleFromToZero.ObjectMeta.Annotations[annotationKeyRegistrationOnly] = "true"
+
+		if err := r.Client.Create(ctx, &runnerForScaleFromToZero); err != nil {
+			log.Error(err, "Failed to create runner for scale from/to zero")
+
+			return ctrl.Result{}, err
+		}
+	}
+
 	selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controllers/runnerreplicaset_controller.go
+++ b/controllers/runnerreplicaset_controller.go
@@ -71,7 +71,7 @@ func (r *RunnerReplicaSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	registrationOnlyRunnerNeeded := rs.Spec.Replicas != nil && *rs.Spec.Replicas == 0
 	registrationOnlyRunner := v1alpha1.Runner{}
 	registrationOnlyRunnerNsName := req.NamespacedName
-	registrationOnlyRunnerNsName.Name = rs.Name + "-registration-only"
+	registrationOnlyRunnerNsName.Name = registrationOnlyRunnerNameFor(rs.Name)
 
 	registrationOnlyRunnerExists := false
 	if err := r.Get(
@@ -323,4 +323,8 @@ func (r *RunnerReplicaSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&v1alpha1.Runner{}).
 		Named(name).
 		Complete(r)
+}
+
+func registrationOnlyRunnerNameFor(rsName string) string {
+	return rsName + "-registration-only"
 }

--- a/controllers/runnerreplicaset_controller.go
+++ b/controllers/runnerreplicaset_controller.go
@@ -79,13 +79,13 @@ func (r *RunnerReplicaSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 
 		runnerForScaleFromToZero, err := r.newRunner(rs)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("Failed to create runner for scale from/to zero: %v", err)
+			return ctrl.Result{}, fmt.Errorf("failed to create runner for scale from/to zero: %v", err)
 		}
 
 		runnerForScaleFromToZero.ObjectMeta.Name = rs.Name
 		runnerForScaleFromToZero.ObjectMeta.GenerateName = ""
 		runnerForScaleFromToZero.ObjectMeta.Labels = nil
-		runnerForScaleFromToZero.ObjectMeta.Annotations[annotationKeyRegistrationOnly] = "true"
+		metav1.SetMetaDataAnnotation(&runnerForScaleFromToZero.ObjectMeta, annotationKeyRegistrationOnly, "true")
 
 		if err := r.Client.Create(ctx, &runnerForScaleFromToZero); err != nil {
 			log.Error(err, "Failed to create runner for scale from/to zero")

--- a/controllers/runnerreplicaset_controller_test.go
+++ b/controllers/runnerreplicaset_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"net/http/httptest"
 	"time"
@@ -268,6 +269,28 @@ var _ = Context("Inside of a new namespace", func() {
 							},
 						})
 						Expect(err).ToNot(HaveOccurred())
+
+						var regOnly actionsv1alpha1.Runner
+						if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: registrationOnlyRunnerNameFor(name)}, &regOnly); err != nil {
+							logf.Log.Info(fmt.Sprintf("Failed getting registration-only runner in test: %v", err))
+							return -1
+						} else {
+							updated := regOnly.DeepCopy()
+							updated.Status.Phase = "Completed"
+
+							if err := k8sClient.Status().Patch(ctx, updated, client.MergeFrom(&regOnly)); err != nil {
+								logf.Log.Info(fmt.Sprintf("Failed updating registration-only runner in test: %v", err))
+								return -1
+							}
+
+							runnersList.Add(&github.Runner{
+								ID:     pointer.Int64Ptr(1001),
+								Name:   pointer.StringPtr(regOnly.Name),
+								OS:     pointer.StringPtr("linux"),
+								Status: pointer.StringPtr("offline"),
+								Busy:   pointer.BoolPtr(false),
+							})
+						}
 
 						if err := k8sClient.List(ctx, &runners, client.InNamespace(ns.Name), client.MatchingLabelsSelector{Selector: selector}); err != nil {
 							logf.Log.Error(err, "list runners")

--- a/controllers/runnerreplicaset_controller_test.go
+++ b/controllers/runnerreplicaset_controller_test.go
@@ -262,8 +262,14 @@ var _ = Context("Inside of a new namespace", func() {
 
 				Eventually(
 					func() int {
-						err := k8sClient.List(ctx, &runners, client.InNamespace(ns.Name))
-						if err != nil {
+						selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						})
+						Expect(err).ToNot(HaveOccurred())
+
+						if err := k8sClient.List(ctx, &runners, client.InNamespace(ns.Name), client.MatchingLabelsSelector{Selector: selector}); err != nil {
 							logf.Log.Error(err, "list runners")
 							return -1
 						}

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -56,6 +56,35 @@ cd /runner
   --labels "${RUNNER_LABELS}" \
   --work "${RUNNER_WORKDIR}"
 
+if [ -f /runner/.runner ]; then
+  echo Runner has successfully been configured with the following data.
+  cat /runner/.runner
+  # Note: the `.runner` file's content should be something like the below:
+  #
+  # $ cat /runner/.runner
+  # {
+  # "agentId": 117, #=> corresponds to the ID of the runner
+  # "agentName": "THE_RUNNER_POD_NAME",
+  # "poolId": 1,
+  # "poolName": "Default",
+  # "serverUrl": "https://pipelines.actions.githubusercontent.com/SOME_RANDOM_ID",
+  # "gitHubUrl": "https://github.com/USER/REPO",
+  # "workFolder": "/some/work/dir" #=> corresponds to Runner.Spec.WorkDir
+  # }
+  #
+  # Especially `agentId` is important, as other than listing all the runners in the repo,
+  # this is the only change we could get the exact runnner ID which can be useful for further
+  # GitHub API call like the below. Note that 171 is the agentId seen above.
+  #   curl \
+  #     -H "Accept: application/vnd.github.v3+json" \
+  #     -H "Authorization: bearer ${GITHUB_TOKEN}"
+  #     https://api.github.com/repos/USER/REPO/actions/runners/171
+fi
+
+if [ -n "${RUNNER_REGISTRATION_ONLY}" ]; then
+  exit 0
+fi
+
 mkdir ./externals
 # Hack due to the DinD volumes
 mv ./externalstmp/* ./externals/

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -82,6 +82,8 @@ if [ -f /runner/.runner ]; then
 fi
 
 if [ -n "${RUNNER_REGISTRATION_ONLY}" ]; then
+  echo
+  echo "This runner is configured to be registration-only. Existing without starting the runner service..."
   exit 0
 fi
 


### PR DESCRIPTION
This is an attempt to support scaling from/to zero.

The basic idea is that we create a one-off "registration-only" runner pod on RunnerReplicaSet being scaled to zero, so that there is one "offline" runner, which enables GitHub Actions to queue jobs instead of discarding those.

GitHub Actions seems to immediately throw away the new job when there are no runners at all. Generally, having runners of any status, `busy`, `idle`, or `offline` would prevent GitHub actions from failing jobs. But retaining `busy` or `idle` runners means that we need to keep runner pods running, which conflicts with our desired to scale to/from zero, hence we retain `offline` runners.

In this change, I enhanced the runnerreplicaset controller to create a registration-only runner on very beginning of its reconciliation logic, only when a runnerreplicaset is scaled to zero. The runner controller creates the registration-only runner pod, waits for it to become "offline", and then removes the runner pod. The runner on GitHub stays `offline`, until the runner resource on K8s is deleted. As we remove the registration-only runner pod as soon as it registers, this doesn't block cluster-autoscaler.

Related to #447