### PR TITLE
Locally build runner image instead of pulling it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,14 +127,6 @@ docker-buildx:
 		-f Dockerfile \
 		. ${PUSH_ARG}
 
-# Pull the docker images for acceptance
-docker-pull: docker-build
-	docker pull quay.io/brancz/kube-rbac-proxy:v0.8.0
-	docker pull docker:dind
-	docker pull quay.io/jetstack/cert-manager-controller:v1.0.4
-	docker pull quay.io/jetstack/cert-manager-cainjector:v1.0.4
-	docker pull quay.io/jetstack/cert-manager-webhook:v1.0.4
-
 # Push the docker image
 docker-push:
 	docker push ${NAME}:${VERSION}
@@ -151,7 +143,7 @@ release/clean:
 	rm -rf release
 
 .PHONY: acceptance
-acceptance: release/clean docker-pull release
+acceptance: release/clean acceptance/pull release
 	ACCEPTANCE_TEST_SECRET_TYPE=token make acceptance/kind acceptance/setup acceptance/tests acceptance/teardown
 	ACCEPTANCE_TEST_SECRET_TYPE=app make acceptance/kind acceptance/setup acceptance/tests acceptance/teardown
 	ACCEPTANCE_TEST_DEPLOYMENT_TOOL=helm ACCEPTANCE_TEST_SECRET_TYPE=token make acceptance/kind acceptance/setup acceptance/tests acceptance/teardown
@@ -167,6 +159,14 @@ acceptance/kind:
 	kind load docker-image quay.io/jetstack/cert-manager-cainjector:v1.0.4 --name acceptance
 	kind load docker-image quay.io/jetstack/cert-manager-webhook:v1.0.4 --name acceptance
 	kubectl cluster-info --context kind-acceptance
+
+# Pull the docker images for acceptance
+acceptance/pull: docker-build
+        docker pull quay.io/brancz/kube-rbac-proxy:v0.8.0
+        docker pull docker:dind
+        docker pull quay.io/jetstack/cert-manager-controller:v1.0.4
+        docker pull quay.io/jetstack/cert-manager-cainjector:v1.0.4
+        docker pull quay.io/jetstack/cert-manager-webhook:v1.0.4
 
 acceptance/setup:
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml	#kubectl create namespace actions-runner-system

--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ the acceptance test:
 # This sets `VERSION` envvar to some appropriate value
 . hack/make-env.sh
 
-USERNAME=$DOCKER_USER \
+DOCKER_USER=*** \
   GITHUB_TOKEN=*** \
   APP_ID=*** \
   PRIVATE_KEY_FILE_PATH=path/to/pem/file \
@@ -782,7 +782,7 @@ If you prefer to test in a non-kind cluster, you can instead run:
 
 ```shell script
 KUBECONFIG=path/to/kubeconfig \
-USERNAME=$DOCKER_USER \
+  DOCKER_USER=*** \
   GITHUB_TOKEN=*** \
   APP_ID=*** \
   PRIVATE_KEY_FILE_PATH=path/to/pem/file \

--- a/README.md
+++ b/README.md
@@ -762,12 +762,12 @@ the acceptance test:
 # This sets `VERSION` envvar to some appropriate value
 . hack/make-env.sh
 
-NAME=$DOCKER_USER/actions-runner-controller \
+USERNAME=$DOCKER_USER \
   GITHUB_TOKEN=*** \
   APP_ID=*** \
   PRIVATE_KEY_FILE_PATH=path/to/pem/file \
   INSTALLATION_ID=*** \
-  make docker-build acceptance
+  make acceptance
 ```
 
 Please follow the instructions explained in [Using Personal Access Token](#using-personal-access-token) to obtain
@@ -782,7 +782,7 @@ If you prefer to test in a non-kind cluster, you can instead run:
 
 ```shell script
 KUBECONFIG=path/to/kubeconfig \
-NAME=$DOCKER_USER/actions-runner-controller \
+USERNAME=$DOCKER_USER \
   GITHUB_TOKEN=*** \
   APP_ID=*** \
   PRIVATE_KEY_FILE_PATH=path/to/pem/file \

--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -41,5 +41,4 @@ fi
 # Adhocly wait for some time until actions-runner-controller's admission webhook gets ready
 sleep 20
 
-kubectl apply \
-  -f acceptance/testdata/runnerdeploy.yaml
+cat acceptance/testdata/runnerdeploy.yaml | envsubst | kubectl apply -f -

--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -27,7 +27,9 @@ if [ "${tool}" == "helm" ]; then
     -n actions-runner-system \
     --create-namespace \
     --set syncPeriod=5m \
-    --set authSecret.create=false
+    --set authSecret.create=false \
+    --set image.repository=${NAME} \
+    --set image.tag=${VERSION}
   kubectl -n actions-runner-system wait deploy/actions-runner-controller --for condition=available --timeout 60s
 else
   kubectl apply \

--- a/acceptance/testdata/runnerdeploy.yaml
+++ b/acceptance/testdata/runnerdeploy.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       repository: ${NAME}
-      image: summerwind/actions-runner:${VERSION}
+      image: ${USERNAME}/actions-runner:${VERSION}
       imagePullPolicy: IfNotPresent
 
       #

--- a/acceptance/testdata/runnerdeploy.yaml
+++ b/acceptance/testdata/runnerdeploy.yaml
@@ -6,7 +6,9 @@ spec:
 #  replicas: 1
   template:
     spec:
-      repository: mumoshu/actions-runner-controller-ci
+      repository: ${NAME}
+      image: summerwind/actions-runner:${VERSION}
+
       #
       # dockerd within runner container
       #

--- a/acceptance/testdata/runnerdeploy.yaml
+++ b/acceptance/testdata/runnerdeploy.yaml
@@ -6,8 +6,8 @@ spec:
 #  replicas: 1
   template:
     spec:
-      repository: ${NAME}
-      image: ${USERNAME}/actions-runner:${VERSION}
+      repository: ${TEST_REPO}
+      image: ${RUNNER_NAME}:${VERSION}
       imagePullPolicy: IfNotPresent
 
       #

--- a/acceptance/testdata/runnerdeploy.yaml
+++ b/acceptance/testdata/runnerdeploy.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       repository: ${NAME}
       image: summerwind/actions-runner:${VERSION}
+      imagePullPolicy: IfNotPresent
 
       #
       # dockerd within runner container

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -520,7 +520,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 
 	runnerImagePullPolicy := runner.Spec.ImagePullPolicy
 	if runnerImagePullPolicy == "" {
-		runnerImagePullPolicy = corev1.PullAlways
+		runnerImagePullPolicy = corev1.PullIfNotPresent
 	}
 
 	env := []corev1.EnvVar{

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -520,7 +520,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 
 	runnerImagePullPolicy := runner.Spec.ImagePullPolicy
 	if runnerImagePullPolicy == "" {
-		runnerImagePullPolicy = corev1.PullIfNotPresent
+		runnerImagePullPolicy = corev1.PullAlways
 	}
 
 	env := []corev1.EnvVar{

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -67,7 +67,7 @@ ENV RUNNER_ASSETS_DIR=/runnertmp
 # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
 # to avoid rerunning apt-update on its own.
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "amd64" ]; then export ARCH=x64 ; fi \
+    && if [ "$ARCH" = "amd64" -o "$ARCH" = "x86_64" ]; then export ARCH=x64 ; fi \
     && mkdir -p "$RUNNER_ASSETS_DIR" \
     && cd "$RUNNER_ASSETS_DIR" \
     && curl -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -78,7 +78,7 @@ ENV RUNNER_ASSETS_DIR=/runnertmp
 # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
 # to avoid rerunning apt-update on its own.
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "amd64" ]; then export ARCH=x64 ; fi \
+    && if [ "$ARCH" = "amd64" -o "$ARCH" = "x86_64" ]; then export ARCH=x64 ; fi \
     && mkdir -p "$RUNNER_ASSETS_DIR" \
     && cd "$RUNNER_ASSETS_DIR" \
     && curl -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -67,7 +67,7 @@ ENV RUNNER_ASSETS_DIR=/runnertmp
 # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
 # to avoid rerunning apt-update on its own.
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "amd64" ]; then export ARCH=x64 ; fi \
+    && if [ "$ARCH" = "amd64" -o "$ARCH" = "x86_64" ]; then export ARCH=x64 ; fi \
     && mkdir -p "$RUNNER_ASSETS_DIR" \
     && cd "$RUNNER_ASSETS_DIR" \
     && curl -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \


### PR DESCRIPTION
This PR changes `make acceptance` to locally build the actions-runner image, instead of pulling it from dockerhub.
This is done by adding the building of the runner image to the docker-build target.
This should make it easier to test changes to the runner.
The name of the actions runner image defaults to `DOCKER_USER/actions-runner`, where `DOCKER_USER` is either specified as a environment variable, or inferred from `NAME`.
The docker-push target also pushes the runner image.

This PR also Fixes #464.

Unlike my previous PRs this one does make the acceptance build target take longer.