### PR TITLE
chore: adding stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,63 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - feature
+  - refactor
+  - "[Status] Maybe Later"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,8 +14,11 @@ onlyLabels: []
 exemptLabels:
   - pinned
   - security
-  - feature
+  - enhancement
   - refactor
+  - documentation
+  - chore
+  - needs-investigation
   - "[Status] Maybe Later"
 
 # Set to true to ignore issues in a project (defaults to false)

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,7 +19,7 @@ exemptLabels:
   - documentation
   - chore
   - needs-investigation
-  - "[Status] Maybe Later"
+  - bug
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Relates to https://github.com/summerwind/actions-runner-controller/issues/443

This is a config for https://github.com/apps/stale. We have many many many many issues in the backlog where people have raised them and never returned. We need a bot to prune the issues over time to keep the repository maintained.

@mumoshu I think this is worth having, please read through the config as I have just put in some basic boilerplate and request any changes e.g. more / different labels. Additionally, any issues we wish to keep need some labels applied to them to stop the bot closing them before this is merged. We have a number of old tickets which are legitimate features worth keeping.

This requires the stale app installed into the repo to work https://github.com/apps/stale

If merged we will need to make use of labels going forward.