### PR TITLE
feat: allow ephemeral runner to be optional

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -48,6 +48,8 @@ type RunnerSpec struct {
 	// +optional
 	DockerdContainerResources corev1.ResourceRequirements `json:"dockerdContainerResources,omitempty"`
 	// +optional
+	DockerVolumeMounts []corev1.VolumeMount `json:"dockerVolumeMounts,omitempty"`
+	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// +optional
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -595,6 +595,13 @@ func (in *RunnerSpec) DeepCopyInto(out *RunnerSpec) {
 		}
 	}
 	in.DockerdContainerResources.DeepCopyInto(&out.DockerdContainerResources)
+	if in.DockerVolumeMounts != nil {
+		in, out := &in.DockerVolumeMounts, &out.DockerVolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.4
+version: 0.10.5
 
 home: https://github.com/summerwind/actions-runner-controller
 

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -436,6 +436,33 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerVolumeMounts:
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is beta in 1.15.
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
                     dockerdContainerResources:
                       description: ResourceRequirements describes the compute resource requirements.
                       properties:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -436,6 +436,33 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerVolumeMounts:
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is beta in 1.15.
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
                     dockerdContainerResources:
                       description: ResourceRequirements describes the compute resource requirements.
                       properties:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -401,6 +401,33 @@ spec:
             dockerMTU:
               format: int64
               type: integer
+            dockerVolumeMounts:
+              items:
+                description: VolumeMount describes a mounting of a Volume within a container.
+                properties:
+                  mountPath:
+                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                    type: string
+                  mountPropagation:
+                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                    type: string
+                  name:
+                    description: This must match the Name of a Volume.
+                    type: string
+                  readOnly:
+                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                    type: boolean
+                  subPath:
+                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                    type: string
+                  subPathExpr:
+                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is beta in 1.15.
+                    type: string
+                required:
+                  - mountPath
+                  - name
+                type: object
+              type: array
             dockerdContainerResources:
               description: ResourceRequirements describes the compute resource requirements.
               properties:

--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.githubWebhookServer.ingress.enabled -}}
 {{- $fullName := include "actions-runner-controller-github-webhook-server.fullname" . -}}
-{{- $svcPort := .Values.githubWebhookServer.service.port -}}
+{{- $svcPort := (index .Values.githubWebhookServer.service.ports 0).port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -436,6 +436,33 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerVolumeMounts:
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is beta in 1.15.
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
                     dockerdContainerResources:
                       description: ResourceRequirements describes the compute resource requirements.
                       properties:

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -436,6 +436,33 @@ spec:
                     dockerMTU:
                       format: int64
                       type: integer
+                    dockerVolumeMounts:
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is beta in 1.15.
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
                     dockerdContainerResources:
                       description: ResourceRequirements describes the compute resource requirements.
                       properties:

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -401,6 +401,33 @@ spec:
             dockerMTU:
               format: int64
               type: integer
+            dockerVolumeMounts:
+              items:
+                description: VolumeMount describes a mounting of a Volume within a container.
+                properties:
+                  mountPath:
+                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                    type: string
+                  mountPropagation:
+                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                    type: string
+                  name:
+                    description: This must match the Name of a Volume.
+                    type: string
+                  readOnly:
+                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                    type: boolean
+                  subPath:
+                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                    type: string
+                  subPathExpr:
+                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is beta in 1.15.
+                    type: string
+                required:
+                  - mountPath
+                  - name
+                type: object
+              type: array
             dockerdContainerResources:
               description: ResourceRequirements describes the compute resource requirements.
               properties:

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	gogithub "github.com/google/go-github/v33/github"
 	"github.com/summerwind/actions-runner-controller/hash"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -700,23 +701,31 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 				Value: "/certs/client",
 			},
 		}...)
-		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
-			Name:  "docker",
-			Image: r.DockerImage,
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "work",
-					MountPath: workDir,
-				},
-				{
-					Name:      runnerVolumeName,
-					MountPath: runnerVolumeMountPath,
-				},
-				{
-					Name:      "certs-client",
-					MountPath: "/certs/client",
-				},
+
+		// Determine the volume mounts assigned to the docker sidecar. In case extra mounts are included in the RunnerSpec, append them to the standard
+		// set of mounts. See https://github.com/summerwind/actions-runner-controller/issues/435 for context.
+		dockerVolumeMounts := []corev1.VolumeMount{
+			{
+				Name:      "work",
+				MountPath: workDir,
 			},
+			{
+				Name:      runnerVolumeName,
+				MountPath: runnerVolumeMountPath,
+			},
+			{
+				Name:      "certs-client",
+				MountPath: "/certs/client",
+			},
+		}
+		if extraDockerVolumeMounts := runner.Spec.DockerVolumeMounts; extraDockerVolumeMounts != nil {
+			dockerVolumeMounts = append(dockerVolumeMounts, extraDockerVolumeMounts...)
+		}
+
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+			Name:         "docker",
+			Image:        r.DockerImage,
+			VolumeMounts: dockerVolumeMounts,
 			Env: []corev1.EnvVar{
 				{
 					Name:  "DOCKER_TLS_CERTDIR",

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -67,7 +67,7 @@ for f in runsvc.sh RunnerService.js; do
 done
 
 args=()
-if [ "${RUNNER_EPHEMERAL}" == "true" ]; then
+if [ "${RUNNER_EPHEMERAL}" != "false" ]; then
   args+=(--once)
 fi
 


### PR DESCRIPTION
# Changes
- add `ephemeral` option to `runner.spec` 
    
    ```
      ....
      template:
         spec:
             ephemeral: false
             repository: mumoshu/actions-runner-controller-ci
      ....
    ```
- defaults to `true`
- `entrypoint.sh` in runner/Dockerfile modified to read `RUNNER_EPHEMERAL` flag

## Fixes
- #457 
