### PR TITLE
Add .dockerignore for controller to accelerate image rebuild in local dev env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+Makefile
+acceptance
+runner
+hack
+test-assets
+config
+charts
+.github
+.envrc
+*.md
+*.txt
+*.sh


### PR DESCRIPTION
Previously any non-go changes resulted in `make docker-build` rerunning time-consufming `go build`. This fixes that by adding clearly unnecessary files .dockerignore

cc/ @ToMe25 You may also find this useful :)