### PR TITLE
chart: Allow to disabling kube-rbac-proxy and expose metrics

### DIFF
--- a/charts/actions-runner-controller/templates/auth_proxy_service.yaml
+++ b/charts/actions-runner-controller/templates/auth_proxy_service.yaml
@@ -7,8 +7,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
+  {{- if .Values.kube_rbac_proxy.enabled }}
   - name: https
     port: 8443
     targetPort: https
+  {{- else }}
+  - name: http
+    port: 8080
+    targetPort: http
+  {{- end }}
   selector:
     {{- include "actions-runner-controller.selectorLabels" . | nindent 4 }}

--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -74,8 +74,8 @@ spec:
           name: webhook-server
           protocol: TCP
         {{- if not .Values.kube_rbac_proxy.enabled }}
-        - containerPort: 9443
-          name: https
+        - containerPort: 8080
+          name: http
           protocol: TCP
         {{- end }}
         resources:


### PR DESCRIPTION
corrections to PR
chart: Allow to disabling kube-rbac-proxy and expose metrics #511

this chart will allow setting in the values.yaml 
```
        kube_rbac_proxy:
            enabled: false
```
then metrics will be accessible via 
http://actions-runner-controller-mojanalytics-metrics-service.actions-runner-system:8080/metrics
assumming the actions-runnner-controller is deployed at namespace actions-runner-system

this is an alternative to
chart: Add service monitor and remove kube_rbac_proxy leftovers #527
which i could not get to work. 

sorry. just thought i would submit this as an alternative. you folks decide what you want to do. I'm just trying to get a metrics endpoint to work -)   

