### PR TITLE
Add pip3 and cmake to default runner image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ acceptance/teardown:
 	kind delete cluster --name acceptance
 
 acceptance/deploy:
-	NAME=${NAME} DOCKER_USER=${DOCKER_USER} VERSION=${VERSION} RUNNER_NAME=${RUNNER_NAME} RUNNER_TAG=${RUNNER_TAG} TEST_REPO=${TEST_REPO} acceptance/deploy.sh
+	NAME=${NAME} DOCKER_USER=${DOCKER_USER} VERSION=${VERSION} RUNNER_NAME=${RUNNER_NAME} RUNNER_TAG=${RUNNER_TAG} TEST_REPO=${TEST_REPO} SYNC_PERIOD=${SYNC_PERIOD} acceptance/deploy.sh
 
 acceptance/tests:
 	acceptance/checks.sh

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -40,6 +40,7 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -13,8 +13,9 @@ RUN apt update -y \
     && apt update -y \
     && apt install -y --no-install-recommends \
     build-essential \
-    curl \
     ca-certificates \
+    cmake \
+    curl \
     dnsutils \
     ftp \
     git \
@@ -26,6 +27,8 @@ RUN apt update -y \
     netcat \
     openssh-client \
     parallel \
+    python3-pip \
+    python-is-python3 \
     rsync \
     shellcheck \
     sudo \
@@ -37,12 +40,13 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    python-is-python3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
   && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} \
   && chmod +x /usr/local/bin/dumb-init
+
+ENV PATH="${HOME}/.local/bin:${PATH}"
 
 # Docker download supports arm64 as aarch64 & amd64 as x86_64
 RUN set -vx; \

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -37,6 +37,7 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/list/*
 
 ENV PATH="${HOME}/.local/bin:${PATH}"

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -8,12 +8,14 @@ RUN apt update -y \
     && apt install -y --no-install-recommends \
     software-properties-common \
     build-essential \
-    curl \
     ca-certificates \
+    cmake \
+    curl \
     dnsutils \
     ftp \
     git \
     iproute2 \
+    iptables \
     iputils-ping \
     jq \
     libunwind8 \
@@ -21,9 +23,12 @@ RUN apt update -y \
     netcat \
     openssh-client \
     parallel \
+    python3-pip
+    python-is-python3 \
     rsync \
     shellcheck \
     sudo \
+    supervisor \
     telnet \
     time \
     tzdata \
@@ -32,10 +37,9 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    python-is-python3 \
-    iptables \
-    supervisor \
     && rm -rf /var/lib/apt/list/*
+
+ENV PATH="${HOME}/.local/bin:${PATH}"
 
 # Runner user
 RUN adduser --disabled-password --gecos "" --uid 1000 runner \

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -39,7 +39,8 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    && cd /usr/bin && ln -sf python3 python \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -13,8 +13,9 @@ RUN apt update -y \
     && apt update -y \
     && apt install -y --no-install-recommends \
     build-essential \
-    curl \
     ca-certificates \
+    curl \
+    cmake \
     dnsutils \
     ftp \
     git \
@@ -26,6 +27,7 @@ RUN apt update -y \
     netcat \
     openssh-client \
     parallel \
+    python3-pip \
     rsync \
     shellcheck \
     sudo \
@@ -43,6 +45,8 @@ RUN apt update -y \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} \
     && chmod +x /usr/local/bin/dumb-init
+
+ENV PATH="${HOME}/.local/bin:${PATH}"
 
 # Docker download supports arm64 as aarch64 & amd64 as x86_64
 RUN set -vx; \


### PR DESCRIPTION
Pip is used for alot of things in github runners, and using the python setup action to get it is both needlessly slow, and doesn't work on arm.
This whole PR is more of a suggestion, implemented as a PR, then anything else, so feel free to close this PR if this isn't intended for the default image.
CMake is only added for convenience, and I would understand if it isn't wanted, in that case just let me know and i will remove it.
This PR adds pip by installing pip3, adding pip installed things to the path, and creating a symlink to make pip use pip3.
This pr also fixes the helm acceptance tests.
Fix #533
This PR also sorts the packets to be installed alphabetically, as this seems to be how it has been until recently.
I don't think using ENV for the path is ideal, but it works and is from what i could find pretty much the best solution there is.