### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
@callum-tait-pbx Automatically labeling it a `bug` on creating a bug-report issue doesn't seem to work, as too many people seem to call it a bug without much information like expected behavior, steps to reproduce, etc.

Shall we let people just report it and a maintainer label it a s a `bug` with confidence?
