### PR TITLE
feat: adding pip to base image

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -26,6 +26,7 @@ RUN apt update -y \
     netcat \
     openssh-client \
     parallel \
+    python3-pip \
     rsync \
     shellcheck \
     sudo \
@@ -37,7 +38,6 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    python3-pip \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -43,8 +43,8 @@ RUN apt update -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-  && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} \
-  && chmod +x /usr/local/bin/dumb-init
+    && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} \
+    && chmod +x /usr/local/bin/dumb-init
 
 # Docker download supports arm64 as aarch64 & amd64 as x86_64
 RUN set -vx; \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -37,7 +37,9 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    python-is-python3 \
+    python3-pip \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -6,7 +6,6 @@ RUN apt update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt update -y \
     && apt install -y --no-install-recommends \
-    software-properties-common \
     build-essential \
     curl \
     ca-certificates \
@@ -15,6 +14,7 @@ RUN apt update -y \
     git \
     iproute2 \
     iputils-ping \
+    iptables \
     jq \
     libunwind8 \
     locales \
@@ -23,6 +23,8 @@ RUN apt update -y \
     parallel \
     rsync \
     shellcheck \
+    supervisor \
+    software-properties-common \
     sudo \
     telnet \
     time \
@@ -32,8 +34,6 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    iptables \
-    supervisor \
     python3-pip \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -37,7 +37,7 @@ RUN apt update -y \
     python3-pip \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
-    && rm -rf /var/lib/apt/list/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Runner user
 RUN adduser --disabled-password --gecos "" --uid 1000 runner \

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -21,6 +21,7 @@ RUN apt update -y \
     netcat \
     openssh-client \
     parallel \
+    python3-pip \
     rsync \
     shellcheck \
     supervisor \
@@ -34,7 +35,6 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    python3-pip \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -32,9 +32,11 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    python-is-python3 \
     iptables \
     supervisor \
+    python3-pip \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/list/*
 
 # Runner user

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -37,7 +37,9 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    && cd /usr/bin && ln -sf python3 python \
+    python3-pip \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -26,6 +26,7 @@ RUN apt update -y \
     netcat \
     openssh-client \
     parallel \
+    python3-pip \
     rsync \
     shellcheck \
     sudo \
@@ -37,7 +38,6 @@ RUN apt update -y \
     wget \
     zip \
     zstd \
-    python3-pip \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adding pip as requested by https://github.com/actions-runner-controller/actions-runner-controller/pull/536

Binaries are searched in PATH order, as a result including this shouldn't break anything as the `actions/setup-python` action bolts onto the front of the PATH. The Python env configured by the action should always be resolved over the built in python and pip installs due to this, see below for evidence.

I have also removed the `python-is-python3` package as we are now symlinking pip manually. I thought it was more consistent if we were symlinking both the interpreter and pip rather than letting a package do it for interpreter and manually doing it for pip.

![image](https://user-images.githubusercontent.com/15716903/119410228-6b127500-bce0-11eb-86c0-a5317bb866f0.png)

![image](https://user-images.githubusercontent.com/15716903/119410245-72d21980-bce0-11eb-92d6-27323f5ada41.png)
