### PR TITLE
fix: fixing mising pip PATH

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -89,9 +89,8 @@ RUN echo AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache > .env \
 COPY entrypoint.sh /
 COPY --chown=runner:docker patched $RUNNER_ASSETS_DIR/patched
 
-# Add the Python "User Site Directory" and "User Script Directory" to the PATH
-# The "User Site Directory" is python version specific so it will need changing with Python bumps
-ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/.local/lib/python3.8/site-packages"
+# Add the Python "User Script Directory" to the PATH
+ENV PATH="${PATH}:${HOME}/.local/bin"
 
 USER runner
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -62,6 +62,7 @@ RUN set -vx; \
     && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
+ENV HOME=/home/runner
 
 # Runner download supports amd64 as x64. Externalstmp is needed for making mount points work inside DinD.
 #
@@ -87,6 +88,10 @@ RUN echo AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache > .env \
 
 COPY entrypoint.sh /
 COPY --chown=runner:docker patched $RUNNER_ASSETS_DIR/patched
+
+# Add the Python "User Site Directory" and "User Script Directory" to the PATH
+# The "User Site Directory" is python version specific so it will need changing with Python bumps
+ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/.local/lib/python3.8/site-packages"
 
 USER runner
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -111,9 +111,8 @@ VOLUME /var/lib/docker
 
 COPY --chown=runner:docker patched $RUNNER_ASSETS_DIR/patched
 
-# Add the Python "User Site Directory" and "User Script Directory" to the PATH
-# The "User Site Directory" is python version specific so it will need changing with Python bumps
-ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/.local/lib/python3.8/site-packages"
+# Add the Python "User Script Directory" to the PATH
+ENV PATH="${PATH}:${HOME}/.local/bin"
 
 # No group definition, as that makes it harder to run docker.
 USER runner

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -73,6 +73,7 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
 	docker --version
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
+ENV HOME=/home/runner
 
 # Runner download supports amd64 as x64
 #
@@ -109,6 +110,10 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
 VOLUME /var/lib/docker
 
 COPY --chown=runner:docker patched $RUNNER_ASSETS_DIR/patched
+
+# Add the Python "User Site Directory" and "User Script Directory" to the PATH
+# The "User Site Directory" is python version specific so it will need changing with Python bumps
+ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/.local/lib/python3.8/site-packages"
 
 # No group definition, as that makes it harder to run docker.
 USER runner

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -89,9 +89,8 @@ RUN echo AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache > .env \
 COPY entrypoint.sh /
 COPY --chown=runner:docker patched $RUNNER_ASSETS_DIR/patched
 
-# Add the Python "User Site Directory" and "User Script Directory" to the PATH
-# The "User Site Directory" is python version specific so it will need changing with Python bumps
-ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/.local/lib/python3.8/site-packages"
+# Add the Python "User Script Directory" to the PATH
+ENV PATH="${PATH}:${HOME}/.local/bin"
 
 USER runner
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -62,6 +62,7 @@ RUN set -vx; \
     && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
+ENV HOME=/home/runner
 
 # Runner download supports amd64 as x64. Externalstmp is needed for making mount points work inside DinD.
 #
@@ -87,6 +88,10 @@ RUN echo AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache > .env \
 
 COPY entrypoint.sh /
 COPY --chown=runner:docker patched $RUNNER_ASSETS_DIR/patched
+
+# Add the Python "User Site Directory" and "User Script Directory" to the PATH
+# The "User Site Directory" is python version specific so it will need changing with Python bumps
+ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/.local/lib/python3.8/site-packages"
 
 USER runner
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]


### PR DESCRIPTION
Conversation is on #573

**Notes**

- We aren't setting the `HOME` var in the Dockerfile. When using `summerwind/actions-runner:latest` on Actions, `HOME` seems to get set as `/github/home` for some reason. `HOME` is a common var used and assumed to be the home directory of the user running the process so we should be setting this in the Dockerfile to ensure consistency. Interestingly when I run up the runner image locally with docker, `HOME` appears to be set correctly so it must be something Actions is doing in the background, I assume if we have it explicitly set they will honour it:

current behaviour:

```yaml
name: On Manual 1 Public Runner

on:
  workflow_dispatch:

jobs:
    my_job:
      runs-on: ['self-hosted', 'Linux']
      container: 
        image: summerwind/actions-runner:latest
      steps:
      - run: |
          echo $HOME
```



![image](https://user-images.githubusercontent.com/15716903/120012096-f8064880-bfd6-11eb-894d-5fda1d99581a.png)

- Adding the User Script Directory to the end of the PATH https://www.python.org/dev/peps/pep-0370/

after change:

```shell
$ docker run -it runner:test sh
$ echo $HOME
/home/runner
$ echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/runner/.local/bin
```