### PR TITLE
ci: only run latest tag job on push / release

### DIFF
--- a/.github/workflows/build-and-release-runners.yml
+++ b/.github/workflows/build-and-release-runners.yml
@@ -76,7 +76,7 @@ jobs:
             ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-ubuntu-${{ matrix.os-version }}-${{ steps.vars.outputs.sha_short }}
 
   latest-tags:
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
     runs-on: ubuntu-latest
     name: Build ${{ matrix.name }}-latest
     strategy:
@@ -105,7 +105,6 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -116,7 +115,7 @@ jobs:
           context: ./runner
           file: ./runner/${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           build-args: |
             RUNNER_VERSION=${{ env.RUNNER_VERSION }}
             DOCKER_VERSION=${{ env.DOCKER_VERSION }}

--- a/.github/workflows/build-and-release-runners.yml
+++ b/.github/workflows/build-and-release-runners.yml
@@ -76,6 +76,7 @@ jobs:
             ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-ubuntu-${{ matrix.os-version }}-${{ steps.vars.outputs.sha_short }}
 
   latest-tags:
+    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     name: Build ${{ matrix.name }}-latest
     strategy:


### PR DESCRIPTION
We don't need to run the latest tag job on pull request activity? I don't think we even care about release activity do we? I've kept it as we had that logic in there originally but I think that can be removed too so the latest tag job only runs on pushes? (pull request merges create a push event) @mumoshu