### PR TITLE
feat: avoid setting privileged flag if seLinuxOptions is not null

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,16 @@ spec:
     spec:
       nodeSelector:
         node-role.kubernetes.io/test: ""
-
+      
+      securityContext:
+        #All level/role/type/user values will vary based on your SELinux policies.
+        #See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/container_security_guide/docker_selinux_security_policy for information about SELinux with containers
+        seLinuxOptions: 
+          level: "s0"
+          role: "system_r"
+          type: "super_t"
+          user: "system_u"
+          
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/test

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -674,6 +674,14 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 		r.GitHubClient.GithubBaseURL,
 	)
 
+	var seLinuxOptions *corev1.SELinuxOptions
+	if runner.Spec.SecurityContext != nil {
+		seLinuxOptions = runner.Spec.SecurityContext.SELinuxOptions
+		if seLinuxOptions != nil {
+			privileged = false
+		}
+	}
+
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        runner.Name,
@@ -821,7 +829,8 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: &privileged,
+				Privileged:     &privileged,
+				SELinuxOptions: seLinuxOptions,
 			},
 			Resources: runner.Spec.DockerdContainerResources,
 		})

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -564,10 +564,11 @@ func (r *RunnerReconciler) updateRegistrationToken(ctx context.Context, runner v
 
 func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 	var (
-		privileged      bool = true
-		dockerdInRunner bool = runner.Spec.DockerdWithinRunnerContainer != nil && *runner.Spec.DockerdWithinRunnerContainer
-		dockerEnabled   bool = runner.Spec.DockerEnabled == nil || *runner.Spec.DockerEnabled
-		ephemeral       bool = runner.Spec.Ephemeral == nil || *runner.Spec.Ephemeral
+		privileged      		  bool = true
+		dockerdInRunner 		  bool = runner.Spec.DockerdWithinRunnerContainer != nil && *runner.Spec.DockerdWithinRunnerContainer
+		dockerEnabled  		      bool = runner.Spec.DockerEnabled == nil || *runner.Spec.DockerEnabled
+		ephemeral      		      bool = runner.Spec.Ephemeral == nil || *runner.Spec.Ephemeral
+		dockerdInRunnerPrivileged bool = dockerdInRunner
 	)
 
 	runnerImage := runner.Spec.Image
@@ -679,6 +680,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 		seLinuxOptions = runner.Spec.SecurityContext.SELinuxOptions
 		if seLinuxOptions != nil {
 			privileged = false
+			dockerdInRunnerPrivileged = false
 		}
 	}
 
@@ -700,7 +702,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 					EnvFrom:         runner.Spec.EnvFrom,
 					SecurityContext: &corev1.SecurityContext{
 						// Runner need to run privileged if it contains DinD
-						Privileged: runner.Spec.DockerdWithinRunnerContainer,
+						Privileged: &dockerdInRunnerPrivileged,
 					},
 					Resources: runner.Spec.Resources,
 				},

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -564,10 +564,10 @@ func (r *RunnerReconciler) updateRegistrationToken(ctx context.Context, runner v
 
 func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 	var (
-		privileged      		  bool = true
-		dockerdInRunner 		  bool = runner.Spec.DockerdWithinRunnerContainer != nil && *runner.Spec.DockerdWithinRunnerContainer
-		dockerEnabled  		      bool = runner.Spec.DockerEnabled == nil || *runner.Spec.DockerEnabled
-		ephemeral      		      bool = runner.Spec.Ephemeral == nil || *runner.Spec.Ephemeral
+		privileged                bool = true
+		dockerdInRunner           bool = runner.Spec.DockerdWithinRunnerContainer != nil && *runner.Spec.DockerdWithinRunnerContainer
+		dockerEnabled             bool = runner.Spec.DockerEnabled == nil || *runner.Spec.DockerEnabled
+		ephemeral                 bool = runner.Spec.Ephemeral == nil || *runner.Spec.Ephemeral
 		dockerdInRunnerPrivileged bool = dockerdInRunner
 	)
 


### PR DESCRIPTION
This PR sets the privileged flag to false if SELinuxOptions are present/defined. This is needed because containerd treats SELinux and Privileged controls as mutually exclusive - see https://github.com/containerd/cri/blob/aa2d5a97c/pkg/server/container_create.go#L164 . 

This allows users who use SELinux for managing privileged processes to use GH Actions - otherwise, based on the SELinux policy, the Docker in Docker container might not be privileged enough. 

Signed-off-by: Jonah Back <jonah@jonahback.com>