### PR TITLE
chore: bump kube-rbac-proxy version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ acceptance/kind:
 # See https://kind.sigs.k8s.io/docs/user/known-issues/#docker-installed-with-snap
 acceptance/load:
 	kind load docker-image ${NAME}:${VERSION} --name acceptance
-	kind load docker-image quay.io/brancz/kube-rbac-proxy:v0.8.0 --name acceptance
+	kind load docker-image quay.io/brancz/kube-rbac-proxy:v0.10.0 --name acceptance
 	kind load docker-image ${RUNNER_NAME}:${RUNNER_TAG} --name acceptance
 	kind load docker-image docker:dind --name acceptance
 	kind load docker-image quay.io/jetstack/cert-manager-controller:v1.0.4 --name acceptance
@@ -175,7 +175,7 @@ acceptance/load:
 
 # Pull the docker images for acceptance
 acceptance/pull:
-	docker pull quay.io/brancz/kube-rbac-proxy:v0.8.0
+	docker pull quay.io/brancz/kube-rbac-proxy:v0.10.0
 	docker pull docker:dind
 	docker pull quay.io/jetstack/cert-manager-controller:v1.0.4
 	docker pull quay.io/jetstack/cert-manager-cainjector:v1.0.4

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -71,7 +71,7 @@ metrics:
     enabled: true
     image:
       repository: quay.io/brancz/kube-rbac-proxy
-      tag: v0.8.0
+      tag: v0.10.0
 
 resources:
   {}

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Addresses #590
We have been running on version 0.10.0 of kube-rbac-proxy for the last week using kustomize to tweak the image version. Figured I could run the find/replace at least.