### PR TITLE
Added support to enable and disable enableServiceLinks.

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -101,6 +101,9 @@ type RunnerPodSpec struct {
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// +optional
+	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
+
+	// +optional
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -624,6 +624,11 @@ func (in *RunnerPodSpec) DeepCopyInto(out *RunnerPodSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EnableServiceLinks != nil {
+		in, out := &in.EnableServiceLinks, &out.EnableServiceLinks
+		*out = new(bool)
+		**out = **in
+	}
 	if in.InitContainers != nil {
 		in, out := &in.InitContainers, &out.InitContainers
 		*out = make([]v1.Container, len(*in))

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -632,6 +632,8 @@ spec:
                           type: object
                         dockerdWithinRunnerContainer:
                           type: boolean
+                        enableServiceLinks:
+                          type: boolean
                         enterprise:
                           pattern: ^[^/]+$
                           type: string

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -629,6 +629,8 @@ spec:
                           type: object
                         dockerdWithinRunnerContainer:
                           type: boolean
+                        enableServiceLinks:
+                          type: boolean
                         enterprise:
                           pattern: ^[^/]+$
                           type: string

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -577,6 +577,8 @@ spec:
                   type: object
                 dockerdWithinRunnerContainer:
                   type: boolean
+                enableServiceLinks:
+                  type: boolean
                 enterprise:
                   pattern: ^[^/]+$
                   type: string

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -632,6 +632,8 @@ spec:
                           type: object
                         dockerdWithinRunnerContainer:
                           type: boolean
+                        enableServiceLinks:
+                          type: boolean
                         enterprise:
                           pattern: ^[^/]+$
                           type: string

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -629,6 +629,8 @@ spec:
                           type: object
                         dockerdWithinRunnerContainer:
                           type: boolean
+                        enableServiceLinks:
+                          type: boolean
                         enterprise:
                           pattern: ^[^/]+$
                           type: string

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -577,6 +577,8 @@ spec:
                   type: object
                 dockerdWithinRunnerContainer:
                   type: boolean
+                enableServiceLinks:
+                  type: boolean
                 enterprise:
                   pattern: ^[^/]+$
                   type: string

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -622,6 +622,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 	}
 
 	template.Spec.SecurityContext = runner.Spec.SecurityContext
+	template.Spec.EnableServiceLinks = runner.Spec.EnableServiceLinks
 
 	registrationOnly := metav1.HasAnnotation(runner.ObjectMeta, annotationKeyRegistrationOnly)
 


### PR DESCRIPTION
This option expose internally some `KUBERNETES_*` environment variables
that doesn't allow the runner to use KinD (Kubernetes in Docker) since it will
try to connect to the Kubernetes cluster where the runner it's running.

This option it's set by default to `true` in any Kubernetes deployment.

For more information on this option you can visit: 
https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service

This fix #626 by adding the option to control the behavior 

Signed-off-by: Jonathan Gonzalez V <jonathan.abdiel@gmail.com>