### PR TITLE
Add configuration for "Lock" app

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,25 @@
+# Configuration for Lock Threads
+# Repo: https://github.com/dessant/lock-threads-app
+# App: https://github.com/apps/lock
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 7
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true


### PR DESCRIPTION
To prevent people from writing related and unrelated things to already closed issues.

As a maitainer, that kind of situation only makes it harder to effectively provide user support.

Please create another issue with a concrete description of "your issue" and the reproduction steps, rather than commenting "me too" on unrelated issues!

I've already enabled the bot via https://github.com/apps/lock so hopefully it starts working without any issues once this PR gets merged.