### PR TITLE
Add HRA support for RunnerSet

### DIFF
--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -50,6 +50,7 @@ sleep 20
 if [ -n "${TEST_REPO}" ]; then
   if [ -n "USE_RUNNERSET" ]; then
       cat acceptance/testdata/repo.runnerset.yaml | envsubst | kubectl apply -f -
+      cat acceptance/testdata/repo.runnerset.hra.yaml | envsubst | kubectl apply -f -
   else
     echo 'Deploying runnerdeployment and hra. Set USE_RUNNERSET if you want to deploy runnerset instead.'
     cat acceptance/testdata/repo.runnerdeploy.yaml | envsubst | kubectl apply -f -

--- a/acceptance/testdata/repo.runnerset.hra.yaml
+++ b/acceptance/testdata/repo.runnerset.hra.yaml
@@ -1,0 +1,27 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: example-runnerset
+spec:
+  scaleTargetRef:
+    kind: RunnerSet
+    name: example-runnerset
+  scaleUpTriggers:
+  - githubEvent:
+      checkRun:
+        types: ["created"]
+        status: "queued"
+    amount: 1
+    duration: "1m"
+  # RunnerSet doesn't support scale from/to zero yet
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: PercentageRunnersBusy
+    scaleUpThreshold: '0.75'
+    scaleDownThreshold: '0.3'
+    scaleUpFactor: '2'
+    scaleDownFactor: '0.5'
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - ${TEST_REPO}

--- a/api/v1alpha1/horizontalrunnerautoscaler_types.go
+++ b/api/v1alpha1/horizontalrunnerautoscaler_types.go
@@ -106,6 +106,12 @@ type CapacityReservation struct {
 }
 
 type ScaleTargetRef struct {
+	// Kind is the type of resource being referenced
+	// +optional
+	// +kubebuilder:validation:Enum=RunnerDeployment;RunnerSet
+	Kind string `json:"kind,omitempty"`
+
+	// Name is the name of resource being referenced
 	Name string `json:"name,omitempty"`
 }
 

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
@@ -129,7 +129,14 @@ spec:
                 description: ScaleTargetRef sis the reference to scaled resource like
                   RunnerDeployment
                 properties:
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    enum:
+                    - RunnerDeployment
+                    - RunnerSet
+                    type: string
                   name:
+                    description: Name is the name of resource being referenced
                     type: string
                 type: object
               scaleUpTriggers:

--- a/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
+++ b/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
@@ -129,7 +129,14 @@ spec:
                 description: ScaleTargetRef sis the reference to scaled resource like
                   RunnerDeployment
                 properties:
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    enum:
+                    - RunnerDeployment
+                    - RunnerSet
+                    type: string
                   name:
+                    description: Name is the name of resource being referenced
                     type: string
                 type: object
               scaleUpTriggers:

--- a/controllers/autoscaling_test.go
+++ b/controllers/autoscaling_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -231,7 +232,9 @@ func TestDetermineDesiredReplicas_RepositoryRunner(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			got, _, _, err := h.computeReplicasWithCache(log, metav1Now.Time, rd, hra, minReplicas)
+			st := h.scaleTargetFromRD(context.Background(), rd)
+
+			got, _, _, err := h.computeReplicasWithCache(log, metav1Now.Time, st, hra, minReplicas)
 			if err != nil {
 				if tc.err == "" {
 					t.Fatalf("unexpected error: expected none, got %v", err)
@@ -497,7 +500,9 @@ func TestDetermineDesiredReplicas_OrganizationalRunner(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			got, _, _, err := h.computeReplicasWithCache(log, metav1Now.Time, rd, hra, minReplicas)
+			st := h.scaleTargetFromRD(context.Background(), rd)
+
+			got, _, _, err := h.computeReplicasWithCache(log, metav1Now.Time, st, hra, minReplicas)
 			if err != nil {
 				if tc.err == "" {
 					t.Fatalf("unexpected error: expected none, got %v", err)


### PR DESCRIPTION
`HRA.Spec.ScaleTargetRef.Kind` is added to denote that the scale-target is a RunnerSet.

It defaults to `RunnerDeployment` for backward compatibility.

```
apiVersion: actions.summerwind.dev/v1alpha1
kind: HorizontalRunnerAutoscaler
metadata:
  name: myhra
spec:
  scaleTargetRef:
    kind: RunnerSet
    name: myrunnerset
```

Ref #629
Ref #613
Ref #612