### PR TITLE
chore: updating to use non-deprecated env var

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -84,7 +84,7 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && apt-get install -y libyaml-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 RUN mkdir /opt/hostedtoolcache \
     && chgrp docker /opt/hostedtoolcache \
     && chmod g+rwx /opt/hostedtoolcache

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -92,7 +92,7 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && apt-get install -y libyaml-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 RUN mkdir /opt/hostedtoolcache \
     && chgrp docker /opt/hostedtoolcache \
     && chmod g+rwx /opt/hostedtoolcache

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -84,7 +84,7 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && apt-get install -y libyaml-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 RUN mkdir /opt/hostedtoolcache \
     && chgrp docker /opt/hostedtoolcache \
     && chmod g+rwx /opt/hostedtoolcache


### PR DESCRIPTION
Fixes: https://github.com/actions-runner-controller/actions-runner-controller/issues/659