### PR TITLE
chore: deprecate STARTUP_DELAY

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+# TODO: Later remove `STARTUP_DELAY` entirely. `STARTUP_DELAY` is deprecated
 if [ ! -z "${STARTUP_DELAY}" ]; then
   echo "Delaying startup by ${STARTUP_DELAY} seconds" 1>&2
   sleep ${STARTUP_DELAY}
+elif  [ ! -z "${STARTUP_DELAY_IN_SECONDS}" ]; then
+  echo "Delaying startup by ${STARTUP_DELAY_IN_SECONDS} seconds" 1>&2
+  sleep ${STARTUP_DELAY_IN_SECONDS}
 fi
 
 if [ -z "${GITHUB_URL}" ]; then

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -5,7 +5,7 @@
 if [ ! -z "${STARTUP_DELAY}" ]; then
   echo "Delaying startup by ${STARTUP_DELAY} seconds" 1>&2
   sleep ${STARTUP_DELAY}
-elif  [ ! -z "${STARTUP_DELAY_IN_SECONDS}" ]; then
+elif [ ! -z "${STARTUP_DELAY_IN_SECONDS}" ]; then
   echo "Delaying startup by ${STARTUP_DELAY_IN_SECONDS} seconds" 1>&2
   sleep ${STARTUP_DELAY_IN_SECONDS}
 fi

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# TODO: Later remove `STARTUP_DELAY` entirely. `STARTUP_DELAY` is deprecated
+# TODO: Remove `STARTUP_DELAY` entirely. `STARTUP_DELAY` is deprecated
+# Issue #673, PR #678
 if [ ! -z "${STARTUP_DELAY}" ]; then
   echo "Delaying startup by ${STARTUP_DELAY} seconds" 1>&2
   sleep ${STARTUP_DELAY}


### PR DESCRIPTION
Fixes: https://github.com/actions-runner-controller/actions-runner-controller/issues/673

Once this is merged a PR needs to be raised for the docs. This can't be done in this PR because we provide both mutable and immutable tags. We don't know what the immutable tag is until this PR is merged.

Docs to be updated are:
- Update the references to `STARTUP_DELAY` to be `STARTUP_DELAY_IN_SECONDS` instead
- Highlight that in `actions-runner` images older than X date and X tag only look for `STARTUP_DELAY`
- Highlight `STARTUP_DELAY` will be removed entirely from the codebase down the road so those using it must migrate to the new env var name