### PR TITLE
Update README.md to fix scaleUp/Down examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,8 @@ spec:
   - type: PercentageRunnersBusy
     scaleUpThreshold: '0.75'    # The percentage of busy runners at which the number of desired runners are re-evaluated to scale up
     scaleDownThreshold: '0.3'   # The percentage of busy runners at which the number of desired runners are re-evaluated to scale down
-    scaleUpAdjustment: 2      # The scale up runner count added to desired count
-    scaleDownAdjustment: 1    # The scale down runner count subtracted from the desired count
+    scaleUpAdjustment: 2        # The scale up runner count added to desired count
+    scaleDownAdjustment: 1      # The scale down runner count subtracted from the desired count
 ```
 
 Like the previous metric, the scale down factor respects the anti-flapping configuration is applied to the `HorizontalRunnerAutoscaler` as mentioned previously:

--- a/README.md
+++ b/README.md
@@ -469,8 +469,8 @@ spec:
   - type: PercentageRunnersBusy
     scaleUpThreshold: '0.75'    # The percentage of busy runners at which the number of desired runners are re-evaluated to scale up
     scaleDownThreshold: '0.3'   # The percentage of busy runners at which the number of desired runners are re-evaluated to scale down
-    ScaleUpAdjustment: '2'      # The scale up runner count added to desired count
-    ScaleDownAdjustment: '1'    # The scale down runner count subtracted from the desired count
+    scaleUpAdjustment: 2      # The scale up runner count added to desired count
+    scaleDownAdjustment: 1    # The scale down runner count subtracted from the desired count
 ```
 
 Like the previous metric, the scale down factor respects the anti-flapping configuration is applied to the `HorizontalRunnerAutoscaler` as mentioned previously:


### PR DESCRIPTION
The examples for scaleDownAdjustment and scaleUpAdjustment were incorrect. The first letter should not have been capitalized, and the value should have been an integer instead of a string.

Links to the CRDs:
[scaleDownAdjustment](https://github.com/actions-runner-controller/actions-runner-controller/blob/f19e7ea8a8bce21bf66d2ee9eaaabb245c7992fa/charts/actions-runner-controller/crds/actions.summerwind.dev_horizontalrunnerautoscalers.yaml#L84)
[scaleUpAdjustment](https://github.com/actions-runner-controller/actions-runner-controller/blob/f19e7ea8a8bce21bf66d2ee9eaaabb245c7992fa/charts/actions-runner-controller/crds/actions.summerwind.dev_horizontalrunnerautoscalers.yaml#L99)