### PR TITLE
Use https connection when metrics enabled for githubwebhook server

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.7
+version: 0.12.8
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
 appVersion: 0.19.0

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.8
+version: 0.12.7
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
 appVersion: 0.19.0

--- a/charts/actions-runner-controller/templates/githubwebhook.role.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.role.yaml
@@ -67,4 +67,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 {{- end }}

--- a/charts/actions-runner-controller/templates/githubwebhook.serviceMonitor.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.serviceMonitor.yaml
@@ -12,6 +12,12 @@ spec:
   endpoints:
     - path: /metrics
       port: metrics-port
+      {{- if .Values.metrics.proxy.enabled }}
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- end }}
   selector:
     matchLabels:
       {{- include "actions-runner-controller-github-webhook-server.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
This PR matches #625 and adds necessary RBAC permissions to fix the 401 issue first reported [here](https://github.com/actions-runner-controller/actions-runner-controller/issues/656). I've tested this locally and Prometheus seems to be able to read from the servicemonitor as expected now.