### PR TITLE
Add shortNames to crd api resouces

### DIFF
--- a/api/v1alpha1/horizontalrunnerautoscaler_types.go
+++ b/api/v1alpha1/horizontalrunnerautoscaler_types.go
@@ -223,6 +223,7 @@ type CacheEntry struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=hra
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".spec.minReplicas",name=Min,type=number
 // +kubebuilder:printcolumn:JSONPath=".spec.maxReplicas",name=Max,type=number

--- a/api/v1alpha1/runnerdeployment_types.go
+++ b/api/v1alpha1/runnerdeployment_types.go
@@ -67,6 +67,7 @@ type RunnerDeploymentStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=rdeploy
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".spec.replicas",name=Desired,type=number
 // +kubebuilder:printcolumn:JSONPath=".status.replicas",name=Current,type=number

--- a/api/v1alpha1/runnerreplicaset_types.go
+++ b/api/v1alpha1/runnerreplicaset_types.go
@@ -55,6 +55,7 @@ type RunnerTemplate struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=rrs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".spec.replicas",name=Desired,type=number
 // +kubebuilder:printcolumn:JSONPath=".status.replicas",name=Current,type=number

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
@@ -13,6 +13,8 @@ spec:
     kind: HorizontalRunnerAutoscaler
     listKind: HorizontalRunnerAutoscalerList
     plural: horizontalrunnerautoscalers
+    shortNames:
+    - hra
     singular: horizontalrunnerautoscaler
   scope: Namespaced
   versions:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -11,6 +11,8 @@ spec:
     kind: RunnerDeployment
     listKind: RunnerDeploymentList
     plural: runnerdeployments
+    shortNames:
+      - rdeploy
     singular: runnerdeployment
   scope: Namespaced
   versions:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -11,6 +11,8 @@ spec:
     kind: RunnerReplicaSet
     listKind: RunnerReplicaSetList
     plural: runnerreplicasets
+    shortNames:
+      - rrs
     singular: runnerreplicaset
   scope: Namespaced
   versions:

--- a/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
+++ b/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
@@ -13,6 +13,8 @@ spec:
     kind: HorizontalRunnerAutoscaler
     listKind: HorizontalRunnerAutoscalerList
     plural: horizontalrunnerautoscalers
+    shortNames:
+    - hra
     singular: horizontalrunnerautoscaler
   scope: Namespaced
   versions:

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -11,6 +11,8 @@ spec:
     kind: RunnerDeployment
     listKind: RunnerDeploymentList
     plural: runnerdeployments
+    shortNames:
+      - rdeploy
     singular: runnerdeployment
   scope: Namespaced
   versions:

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -11,6 +11,8 @@ spec:
     kind: RunnerReplicaSet
     listKind: RunnerReplicaSetList
     plural: runnerreplicasets
+    shortNames:
+      - rrs
     singular: runnerreplicaset
   scope: Namespaced
   versions:


### PR DESCRIPTION
Adding `shortNames` to kube api-resource CRDs. Short-names make it easier when interacting/troubleshooting api-resources with kubectl. 

I have tried to follow the naming convention similar to what K8s uses which should help with avoiding any naming conflicts as well. For example:
* `Deployment` has a shortName of deploy, so added rdeploy for `runnerdeployment`
* `HorizontalPodAutoscaler` has a shortName of hpa, so added hra for `HorizontalRunnerAutoscaler`
*  `ReplicaSets` has a shortName of rs, so added rrs for `runnerreplicaset`

Please feel free to let me know if this needs to go somewhere else, or if you would like me to use different `shortNames`
