### PR TITLE
Adding retry after config and formatted logging

### DIFF
--- a/.github/workflows/test-entrypoint.yaml
+++ b/.github/workflows/test-entrypoint.yaml
@@ -1,0 +1,21 @@
+name: Unit tests for entrypoint
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'runner/**'
+      - 'test/entrypoint/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test entrypoint
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run unit tests for entrypoint.sh
+      run: |
+        cd test/entrypoint
+        bash entrypoint_unittest.sh

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -1,23 +1,40 @@
 #!/bin/bash
 
+LIGHTGREEN="\e[0;32m"
+LIGHTRED="\e[0;31m"
+WHITE="\e[0;97m"
+RESET="\e[0m"
+
+log(){
+  echo -e "${WHITE}${@}${RESET}" 1>&2
+}
+
+success(){
+  echo -e "${LIGHTGREEN}${@}${RESET}" 1>&2
+}
+
+error(){
+  echo -e "${LIGHTRED}${@}${RESET}" 1>&2
+}
+
 if [ ! -z "${STARTUP_DELAY_IN_SECONDS}" ]; then
-  echo "Delaying startup by ${STARTUP_DELAY_IN_SECONDS} seconds" 1>&2
+  log "Delaying startup by ${STARTUP_DELAY_IN_SECONDS} seconds"
   sleep ${STARTUP_DELAY_IN_SECONDS}
 fi
 
 if [ -z "${GITHUB_URL}" ]; then
-  echo "Working with public GitHub" 1>&2
+  log "Working with public GitHub"
   GITHUB_URL="https://github.com/"
 else
   length=${#GITHUB_URL}
   last_char=${GITHUB_URL:length-1:1}
 
   [[ $last_char != "/" ]] && GITHUB_URL="$GITHUB_URL/"; :
-  echo "Github endpoint URL ${GITHUB_URL}"
+  log "Github endpoint URL ${GITHUB_URL}"
 fi
 
 if [ -z "${RUNNER_NAME}" ]; then
-  echo "RUNNER_NAME must be set" 1>&2
+  error "RUNNER_NAME must be set"
   exit 1
 fi
 
@@ -30,12 +47,12 @@ elif [ -n "${RUNNER_REPO}" ]; then
 elif [ -n "${RUNNER_ENTERPRISE}" ]; then
   ATTACH="enterprises/${RUNNER_ENTERPRISE}"
 else
-  echo "At least one of RUNNER_ORG or RUNNER_REPO or RUNNER_ENTERPRISE must be set" 1>&2
+  error "At least one of RUNNER_ORG or RUNNER_REPO or RUNNER_ENTERPRISE must be set"
   exit 1
 fi
 
 if [ -z "${RUNNER_TOKEN}" ]; then
-  echo "RUNNER_TOKEN must be set" 1>&2
+  error "RUNNER_TOKEN must be set"
   exit 1
 fi
 
@@ -45,7 +62,7 @@ fi
 
 # Hack due to https://github.com/actions-runner-controller/actions-runner-controller/issues/252#issuecomment-758338483
 if [ ! -d /runner ]; then
-  echo "/runner should be an emptyDir mount. Please fix the pod spec." 1>&2
+  error "/runner should be an emptyDir mount. Please fix the pod spec."
   exit 1
 fi
 
@@ -60,42 +77,56 @@ if [ "${RUNNER_FEATURE_FLAG_EPHEMERAL:-}" == "true" -a "${RUNNER_EPHEMERAL}" != 
   echo "Passing --ephemeral to config.sh to enable the ephemeral runner."
 fi
 
-./config.sh --unattended --replace \
-  --name "${RUNNER_NAME}" \
-  --url "${GITHUB_URL}${ATTACH}" \
-  --token "${RUNNER_TOKEN}" \
-  --runnergroup "${RUNNER_GROUPS}" \
-  --labels "${RUNNER_LABELS}" \
-  --work "${RUNNER_WORKDIR}" "${config_args[@]}"
+retries_left=10
+while [[ ${retries_left} -gt 0 ]]; do
+  log "Configuring the runner."
+  ./config.sh --unattended --replace \
+    --name "${RUNNER_NAME}" \
+    --url "${GITHUB_URL}${ATTACH}" \
+    --token "${RUNNER_TOKEN}" \
+    --runnergroup "${RUNNER_GROUPS}" \
+    --labels "${RUNNER_LABELS}" \
+    --work "${RUNNER_WORKDIR}" "${config_args[@]}"
 
-if [ -f /runner/.runner ]; then
-  echo Runner has successfully been configured with the following data.
-  cat /runner/.runner
-  # Note: the `.runner` file's content should be something like the below:
-  #
-  # $ cat /runner/.runner
-  # {
-  # "agentId": 117, #=> corresponds to the ID of the runner
-  # "agentName": "THE_RUNNER_POD_NAME",
-  # "poolId": 1,
-  # "poolName": "Default",
-  # "serverUrl": "https://pipelines.actions.githubusercontent.com/SOME_RANDOM_ID",
-  # "gitHubUrl": "https://github.com/USER/REPO",
-  # "workFolder": "/some/work/dir" #=> corresponds to Runner.Spec.WorkDir
-  # }
-  #
-  # Especially `agentId` is important, as other than listing all the runners in the repo,
-  # this is the only change we could get the exact runnner ID which can be useful for further
-  # GitHub API call like the below. Note that 171 is the agentId seen above.
-  #   curl \
-  #     -H "Accept: application/vnd.github.v3+json" \
-  #     -H "Authorization: bearer ${GITHUB_TOKEN}"
-  #     https://api.github.com/repos/USER/REPO/actions/runners/171
+  if [ -f /runner/.runner ]; then
+    success "Runner successfully configured."
+    break
+  fi
+
+  retries_left=$((retries_left - 1))
+  sleep 1
+done
+
+if [ ! -f /runner/.runner ]; then
+  # we couldn't configure and register the runner; no point continuing
+  error "Configuration failed!"
+  exit 2
 fi
 
+cat .runner
+# Note: the `.runner` file's content should be something like the below:
+#
+# $ cat /runner/.runner
+# {
+# "agentId": 117, #=> corresponds to the ID of the runner
+# "agentName": "THE_RUNNER_POD_NAME",
+# "poolId": 1,
+# "poolName": "Default",
+# "serverUrl": "https://pipelines.actions.githubusercontent.com/SOME_RANDOM_ID",
+# "gitHubUrl": "https://github.com/USER/REPO",
+# "workFolder": "/some/work/dir" #=> corresponds to Runner.Spec.WorkDir
+# }
+#
+# Especially `agentId` is important, as other than listing all the runners in the repo,
+# this is the only change we could get the exact runnner ID which can be useful for further
+# GitHub API call like the below. Note that 171 is the agentId seen above.
+#   curl \
+#     -H "Accept: application/vnd.github.v3+json" \
+#     -H "Authorization: bearer ${GITHUB_TOKEN}"
+#     https://api.github.com/repos/USER/REPO/actions/runners/171
+
 if [ -n "${RUNNER_REGISTRATION_ONLY}" ]; then
-  echo
-  echo "This runner is configured to be registration-only. Exiting without starting the runner service..."
+  success "This runner is configured to be registration-only. Exiting without starting the runner service..."
   exit 0
 fi
 

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -64,13 +64,13 @@ if [ -z "${RUNNER_REPO}" ] && [ -n "${RUNNER_GROUP}" ];then
 fi
 
 # Hack due to https://github.com/actions-runner-controller/actions-runner-controller/issues/252#issuecomment-758338483
-if [ ! -d ${RUNNER_HOME} ]; then
+if [ ! -d "${RUNNER_HOME}" ]; then
   error "${RUNNER_HOME} should be an emptyDir mount. Please fix the pod spec."
   exit 1
 fi
 
 # if this is not a testing environment
-if [ -z "$UNITTEST" ]; then
+if [ -z "${UNITTEST:-}" ]; then
   sudo chown -R runner:docker ${RUNNER_HOME}
   mv /runnertmp/* ${RUNNER_HOME}/
 fi
@@ -138,7 +138,7 @@ if [ -n "${RUNNER_REGISTRATION_ONLY}" ]; then
   exit 0
 fi
 
-if [ -z "$UNITTEST" ]; then
+if [ -z "${UNITTEST:-}" ]; then
   mkdir ./externals
   # Hack due to the DinD volumes
   mv ./externalstmp/* ./externals/

--- a/test/entrypoint/entrypoint_unittest.sh
+++ b/test/entrypoint/entrypoint_unittest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+source logging.sh
+
+for unittest in ./should*; do
+  log "**********************************"
+  log " UNIT TEST: ${unittest}"
+  log "**********************************"
+  log ""
+
+  cd ${unittest}
+  ./test.sh
+  ret_code=$?
+  cd ..
+
+  log ""
+  log ""
+  if [ "${ret_code}" = "0" ]; then
+    success "Completed: unit test ${unittest}"
+  else
+    error "Completed: unit test ${unittest} with errors"
+    failed="true"
+  fi
+done
+
+if [ -n "${failed:-}" ]; then
+  error ""
+  error "*************************************"
+  error "All unit tests completed, with errors"
+  error "*************************************"
+  exit 1
+else
+  success ""
+  success "***************************************"
+  success "All unit tests completed with no errors"
+  success "***************************************"
+fi

--- a/test/entrypoint/logging.sh
+++ b/test/entrypoint/logging.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+export LIGHTGREEN='\e[0;32m'
+export LIGHTRED='\e[0;31m'
+export WHITE='\e[0;97m'
+export RESET='\e[0m'
+
+log(){
+  printf "${WHITE}$@${RESET}\n" 2>&1
+}
+
+success(){
+  printf "${LIGHTGREEN}$@${RESET}\n" 2>&1
+}
+
+error(){
+  printf "${LIGHTRED}$@${RESET}\n" 2>&1
+}

--- a/test/entrypoint/should_retry_configuring/config.sh
+++ b/test/entrypoint/should_retry_configuring/config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export LIGHTGREEN='\e[0;32m'
+export LIGHTRED='\e[0;31m'
+export WHITE='\e[0;97m'
+export RESET='\e[0m'
+
+log(){
+  printf "\t${WHITE}$@${RESET}\n" 2>&1
+}
+
+success(){
+  printf "\t${LIGHTGREEN}$@${RESET}\n" 2>&1
+}
+
+error(){
+  printf "\t${LIGHTRED}$@${RESET}\n" 2>&1
+  exit 1
+}
+
+success "I'm pretending the configuration is not successful"
+# increasing a counter to measure how many times we restarted
+count=`cat counter 2>/dev/null|| echo "0"`
+count=$((count + 1))
+echo ${count} > counter
+

--- a/test/entrypoint/should_retry_configuring/runsvc.sh
+++ b/test/entrypoint/should_retry_configuring/runsvc.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export LIGHTGREEN='\e[0;32m'
+export LIGHTRED='\e[0;31m'
+export WHITE='\e[0;97m'
+export RESET='\e[0m'
+
+log(){
+  printf "\t${WHITE}$@${RESET}\n" 2>&1
+}
+
+success(){
+  printf "\t${LIGHTGREEN}$@${RESET}\n" 2>&1
+}
+
+error(){
+  printf "\t${LIGHTRED}$@${RESET}\n" 2>&1
+  exit 1
+}
+
+success ""
+success "Running the service..."
+# SHOULD NOT HAPPEN
+# creating a file to show this script has run
+touch runsvc_ran
+success "...successful"
+success ""
+
+

--- a/test/entrypoint/should_retry_configuring/test.sh
+++ b/test/entrypoint/should_retry_configuring/test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# UNITTEST: retry config
+# Will simulate a configuration failure and expects:
+# - the configuration step to be run 10 times
+# - the entrypoint script to exit with error code 2
+# - the runsvc.sh script to never run.
+
+source ../logging.sh
+
+entrypoint_log() {
+  while read I; do
+    printf "\tentrypoint.sh: $I\n"
+  done
+}
+
+log "Setting up the test"
+export UNITTEST=true
+export RUNNER_HOME=localhome
+export RUNNER_NAME="example_runner_name"
+export RUNNER_REPO="myorg/myrepo"
+export RUNNER_TOKEN="xxxxxxxxxxxxx"
+
+mkdir -p ${RUNNER_HOME}/bin
+# add up the config.sh and runsvc.sh
+ln -s ../config.sh ${RUNNER_HOME}/config.sh
+ln -s ../../runsvc.sh ${RUNNER_HOME}/bin/runsvc.sh
+
+cleanup() {
+  rm -rf ${RUNNER_HOME}
+  unset UNITTEST
+  unset RUNNERHOME
+  unset RUNNER_NAME
+  unset RUNNER_REPO
+  unset RUNNER_TOKEN
+}
+
+trap cleanup SIGINT SIGTERM SIGQUIT EXIT
+
+log "Running the entrypoint"
+log ""
+
+../../../runner/entrypoint.sh 2> >(entrypoint_log)
+
+if [ "$?" != "2" ]; then
+  error "========================================="
+  error "Configuration should have thrown an error"
+  exit 1
+fi
+success "Entrypoint didn't complete successfully"
+success ""
+
+log "Checking the counter, should have 10 iterations"
+count=`cat ${RUNNER_HOME}/counter || "notfound"`
+if [ "${count}" != "10" ]; then
+  error "============================================="
+  error "The retry loop should have done 10 iterations"
+  exit 1
+fi
+success "Retry loop went up to 10"
+success
+
+log "Checking that runsvc never ran"
+if [ -f ${RUNNER_HOME}/runsvc_ran ]; then
+  error "================================================================="
+  error "runsvc was invoked, entrypoint.sh should have failed before that."
+  exit 1
+fi
+
+success "runsvc.sh never ran"
+success
+success "==========================="
+success "Test completed successfully"
+exit 0

--- a/test/entrypoint/should_work_non_ephemeral/config.sh
+++ b/test/entrypoint/should_work_non_ephemeral/config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+export LIGHTGREEN='\e[0;32m'
+export LIGHTRED='\e[0;31m'
+export WHITE='\e[0;97m'
+export RESET='\e[0m'
+
+log(){
+  printf "\t${WHITE}$@${RESET}\n" 2>&1
+}
+
+success(){
+  printf "\t${LIGHTGREEN}$@${RESET}\n" 2>&1
+}
+
+error(){
+  printf "\t${LIGHTRED}$@${RESET}\n" 2>&1
+}
+
+success "I'm configured normally"
+touch .runner
+success "created a dummy config file"
+success
+# adding a counter to see how many times we've gone through a configuration step
+count=`cat counter 2>/dev/null|| echo "0"`
+count=$((count + 1))
+echo ${count} > counter
+

--- a/test/entrypoint/should_work_non_ephemeral/runsvc.sh
+++ b/test/entrypoint/should_work_non_ephemeral/runsvc.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export LIGHTGREEN='\e[0;32m'
+export LIGHTRED='\e[0;31m'
+export WHITE='\e[0;97m'
+export RESET='\e[0m'
+
+log(){
+  printf "\t${WHITE}$@${RESET}\n" 2>&1
+}
+
+success(){
+  printf "\t${LIGHTGREEN}$@${RESET}\n" 2>&1
+}
+
+error(){
+  printf "\t${LIGHTRED}$@${RESET}\n" 2>&1
+  exit 1
+}
+
+success ""
+success "Running the service..."
+# test if --once is present as a parameter
+echo "$*" | grep -q 'once' && error "Should not include --once in the parameters"
+success "...successful"
+touch runsvc_ran
+success ""
+
+

--- a/test/entrypoint/should_work_non_ephemeral/test.sh
+++ b/test/entrypoint/should_work_non_ephemeral/test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# UNITTEST: should work as non ephemeral
+# Will simulate a scenario where ephemeral=false. expects:
+# - the configuration step to be run exactly once
+# - the entrypoint script to exit with no error
+# - the runsvc.sh script to run without the --once flag
+
+source ../logging.sh
+
+entrypoint_log() {
+  while read I; do
+    printf "\tentrypoint.sh: $I\n"
+  done
+}
+
+log "Setting up the test"
+export UNITTEST=true
+export RUNNER_HOME=localhome
+export RUNNER_NAME="example_runner_name"
+export RUNNER_REPO="myorg/myrepo"
+export RUNNER_TOKEN="xxxxxxxxxxxxx"
+export RUNNER_EPHEMERAL=false
+
+mkdir -p ${RUNNER_HOME}/bin
+# add up the config.sh and runsvc.sh
+ln -s ../config.sh ${RUNNER_HOME}/config.sh
+ln -s ../../runsvc.sh ${RUNNER_HOME}/bin/runsvc.sh
+
+cleanup() {
+  rm -rf ${RUNNER_HOME}
+  unset UNITTEST
+  unset RUNNERHOME
+  unset RUNNER_NAME
+  unset RUNNER_REPO
+  unset RUNNER_TOKEN
+  unset RUNNER_EPHEMERAL
+}
+
+trap cleanup SIGINT SIGTERM SIGQUIT EXIT
+
+log "Running the entrypoint"
+log ""
+
+../../../runner/entrypoint.sh 2> >(entrypoint_log)
+
+if [ "$?" != "0" ]; then
+  error "==========================================="
+  error "Entrypoint script did not exit successfully"
+  exit 1
+fi
+
+log "Testing if we went through the configuration step only once"
+count=`cat ${RUNNER_HOME}/counter || echo "not_found"`
+if [ ${count} != "1" ]; then
+  error "==============================================="
+  error "The configuration step was not run exactly once"
+  exit 1
+fi
+
+success "The configuration ran ${count} time(s)"
+
+log "Testing if runsvc ran"
+if [ ! -f "${RUNNER_HOME}/runsvc_ran" ]; then
+  error "=============================="
+  error "The runner service has not run"
+  exit 1
+fi
+success "The service ran"
+success ""
+success "==========================="
+success "Test completed successfully"

--- a/test/entrypoint/should_work_normally/config.sh
+++ b/test/entrypoint/should_work_normally/config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+export LIGHTGREEN='\e[0;32m'
+export LIGHTRED='\e[0;31m'
+export WHITE='\e[0;97m'
+export RESET='\e[0m'
+
+log(){
+  printf "\t${WHITE}$@${RESET}\n" 2>&1
+}
+
+success(){
+  printf "\t${LIGHTGREEN}$@${RESET}\n" 2>&1
+}
+
+error(){
+  printf "\t${LIGHTRED}$@${RESET}\n" 2>&1
+}
+
+success "I'm configured normally"
+touch .runner
+success "created a dummy config file"
+success
+# Adding a counter to see how many times we've gone through the configuration step
+count=`cat counter 2>/dev/null|| echo "0"`
+count=$((count + 1))
+echo ${count} > counter
+

--- a/test/entrypoint/should_work_normally/runsvc.sh
+++ b/test/entrypoint/should_work_normally/runsvc.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export LIGHTGREEN='\e[0;32m'
+export LIGHTRED='\e[0;31m'
+export WHITE='\e[0;97m'
+export RESET='\e[0m'
+
+log(){
+  printf "\t${WHITE}$@${RESET}\n" 2>&1
+}
+
+success(){
+  printf "\t${LIGHTGREEN}$@${RESET}\n" 2>&1
+}
+
+error(){
+  printf "\t${LIGHTRED}$@${RESET}\n" 2>&1
+  exit 1
+}
+
+success ""
+success "Running the service..."
+# test if --once is present as a parameter
+echo "$*" | grep -q 'once' || error "Should include --once in the parameters"j
+success "...successful"
+touch runsvc_ran
+success ""
+
+

--- a/test/entrypoint/should_work_normally/test.sh
+++ b/test/entrypoint/should_work_normally/test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# UNITTEST: should work normally
+# Will simulate a normal execution scenario. expects:
+# - the configuration step to be run exactly once
+# - the entrypoint script to exit with no error
+# - the runsvc.sh script to run with the --once flag activated.
+
+source ../logging.sh
+
+entrypoint_log() {
+  while read I; do
+    printf "\tentrypoint.sh: $I\n"
+  done
+}
+
+log "Setting up the test"
+export UNITTEST=true
+export RUNNER_HOME=localhome
+export RUNNER_NAME="example_runner_name"
+export RUNNER_REPO="myorg/myrepo"
+export RUNNER_TOKEN="xxxxxxxxxxxxx"
+
+mkdir -p ${RUNNER_HOME}/bin
+# add up the config.sh and runsvc.sh
+ln -s ../config.sh ${RUNNER_HOME}/config.sh
+ln -s ../../runsvc.sh ${RUNNER_HOME}/bin/runsvc.sh
+
+cleanup() {
+  rm -rf ${RUNNER_HOME}
+  unset UNITTEST
+  unset RUNNERHOME
+  unset RUNNER_NAME
+  unset RUNNER_REPO
+  unset RUNNER_TOKEN
+}
+
+trap cleanup SIGINT SIGTERM SIGQUIT EXIT
+
+log "Running the entrypoint"
+log ""
+
+../../../runner/entrypoint.sh 2> >(entrypoint_log)
+
+if [ "$?" != "0" ]; then
+  error "=========================="
+  error "Test completed with errors"
+  exit 1
+fi
+
+log "Testing if the configuration step was run only once"
+count=`cat ${RUNNER_HOME}/counter || echo "not_found"`
+if [ ${count} != "1" ]; then
+  error "==============================================="
+  error "The configuration step was not run exactly once"
+  exit 1
+fi
+
+success "The configuration ran ${count} time(s)"
+
+log "Testing if runsvc ran"
+if [ ! -f "${RUNNER_HOME}/runsvc_ran" ]; then
+  error "=============================="
+  error "The runner service has not run"
+  exit 1
+fi
+
+success "The service ran"
+success ""
+success "==========================="
+success "Test completed successfully"


### PR DESCRIPTION
Adding a basic retry loop during configuration. If configuration fails,
the runner will just straight into a retry loop and will continuously
fail until it dies after a while.

This change will retry 10 times and will exit if the configuration
wasn't successful.

Also, changed the logging format, adding a bit of color in the event of
success or failure.
