### PR TITLE
chore: bump dumb-init

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:20.04
 
 ARG TARGETPLATFORM
 ARG RUNNER_VERSION=2.279.0
+ARG DOCKER_CHANNEL=stable
 ARG DOCKER_VERSION=19.03.12
+ARG DUMB_INIT_VERSION=1.2.5
 
 RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)
 
@@ -46,7 +48,7 @@ RUN apt update -y \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} \
+    && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
     && chmod +x /usr/local/bin/dumb-init
 
 # Docker download supports arm64 as aarch64 & amd64 / i386 as x86_64
@@ -54,7 +56,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -L -o docker.tgz https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz \
+    && curl -L -o docker.tgz https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/docker /usr/local/bin/docker \
     && rm -rf docker docker.tgz \

--- a/runner/Dockerfile.dindrunner
+++ b/runner/Dockerfile.dindrunner
@@ -1,5 +1,13 @@
 FROM ubuntu:20.04
 
+ARG TARGETPLATFORM
+ARG RUNNER_VERSION=2.279.0
+ARG DOCKER_CHANNEL=stable
+ARG DOCKER_VERSION=19.03.13
+ARG DUMB_INIT_VERSION=1.2.5
+
+RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)
+
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y \
     && apt install -y software-properties-common \
@@ -47,14 +55,7 @@ RUN adduser --disabled-password --gecos "" --uid 1000 runner \
     && usermod -aG docker runner \
     && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
 
-ARG TARGETPLATFORM
-ARG RUNNER_VERSION=2.279.0
-ARG DOCKER_CHANNEL=stable
-ARG DOCKER_VERSION=19.03.13
-ARG DEBUG=false
-
-RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)
-
+# arch command on OS X reports "i386" for Intel CPUs regardless of bitness
 # Docker download supports arm64 as aarch64 & amd64 / i386 as x86_64
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
@@ -108,7 +109,7 @@ RUN chmod +x /usr/local/bin/startup.sh /usr/local/bin/entrypoint.sh /usr/local/b
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} \
+    && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
     && chmod +x /usr/local/bin/dumb-init
 
 VOLUME /var/lib/docker

--- a/runner/Dockerfile.ubuntu.1804
+++ b/runner/Dockerfile.ubuntu.1804
@@ -2,7 +2,9 @@ FROM ubuntu:18.04
 
 ARG TARGETPLATFORM
 ARG RUNNER_VERSION=2.279.0
+ARG DOCKER_CHANNEL=stable
 ARG DOCKER_VERSION=19.03.12
+ARG DUMB_INIT_VERSION=1.2.5
 
 RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)
 
@@ -46,7 +48,7 @@ RUN apt update -y \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH} \
+    && curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
     && chmod +x /usr/local/bin/dumb-init
 
 # Docker download supports arm64 as aarch64 & amd64 / i386 as x86_64
@@ -54,7 +56,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -L -o docker.tgz https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz \
+    && curl -L -o docker.tgz https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/docker /usr/local/bin/docker \
     && rm -rf docker docker.tgz \

--- a/runner/Makefile
+++ b/runner/Makefile
@@ -23,8 +23,8 @@ else
 endif
 
 docker-build-ubuntu:
-	docker build --build-arg TARGETPLATFORM=amd64 --build-arg RUNNER_VERSION=${RUNNER_VERSION} --build-arg DOCKER_VERSION=${DOCKER_VERSION} -t ${NAME}:${TAG} .
-	docker build --build-arg TARGETPLATFORM=amd64 --build-arg RUNNER_VERSION=${RUNNER_VERSION} --build-arg DOCKER_VERSION=${DOCKER_VERSION} -t ${DIND_RUNNER_NAME}:${TAG} -f Dockerfile.dindrunner .
+	docker build --build-arg TARGETPLATFORM=$(shell arch) --build-arg RUNNER_VERSION=${RUNNER_VERSION} --build-arg DOCKER_VERSION=${DOCKER_VERSION} -t ${NAME}:${TAG} .
+	docker build --build-arg TARGETPLATFORM=$(shell arch) --build-arg RUNNER_VERSION=${RUNNER_VERSION} --build-arg DOCKER_VERSION=${DOCKER_VERSION} -t ${DIND_RUNNER_NAME}:${TAG} -f Dockerfile.dindrunner .
 
 docker-push-ubuntu:
 	docker push ${NAME}:${TAG}


### PR DESCRIPTION
- bump dumb-init to 1.2.5 (latest) https://github.com/Yelp/dumb-init
- align Dockerfile's to be consistent
- align runner Makefile with root Makefile

my integration tests passed, we need to sort out something proper for these changes long term though, bump the docker version next

![image](https://user-images.githubusercontent.com/52924845/127911179-bca7e6dd-1eee-425b-8a36-1ab761dd7460.png)
