### PR TITLE
Change `move` command to `copy` to prevent issues

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -50,7 +50,7 @@ if [ ! -d /runner ]; then
 fi
 
 sudo chown -R runner:docker /runner
-mv /runnertmp/* /runner/
+cp -r /runnertmp/* /runner/
 
 cd /runner
 ./config.sh --unattended --replace \


### PR DESCRIPTION
Prevents issues when /runner and /runnertmp are in different devices
Fixes #686