### PR TITLE
Fix markdown header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-l# actions-runner-controller
+# actions-runner-controller
 
 [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
 


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/actions-runner-controller/actions-runner-controller/commit/39484063746373ebe088796e57bcbaeb6fd4812e
