### PR TITLE
Update actions/runner by Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,18 @@
+{
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["actions/runner"],
+      "extractVersion": "^v(?<version>.*)$"
+    }
+  ],
+  "regexManagers": [
+    // runner version in https://github.com/actions/runner/releases
+    {
+      "fileMatch": [".github/workflows/build-and-release-runners.yml"],
+      "matchStrings": ["RUNNER_VERSION: +(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "actions/runner",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,13 +2,15 @@
   "extends": ["config:base"],
   "packageRules": [
     {
+      // automatically merge an update of runner
       "matchPackageNames": ["actions/runner"],
-      "extractVersion": "^v(?<version>.*)$"
+      "extractVersion": "^v(?<version>.*)$",
+      "automerge": true
     }
   ],
   "regexManagers": [
-    // runner version in https://github.com/actions/runner/releases
     {
+      // use https://github.com/actions/runner/releases
       "fileMatch": [".github/workflows/build-and-release-runners.yml"],
       "matchStrings": ["RUNNER_VERSION: +(?<currentValue>.*?)\\n"],
       "depNameTemplate": "actions/runner",


### PR DESCRIPTION
This will add a config to continuously update `actions/runner` by Renovate.
- https://github.com/actions-runner-controller/actions-runner-controller/issues/416

## Test

I tested this config in my forked repository as https://github.com/int128/actions-runner-controller/pull/21.
Note that Renovate will send pull requests besides `actions/runner`.
See also the pull requests https://github.com/int128/actions-runner-controller/pulls.

## For maintainers

You can install Renovate GitHub App into the organization from https://github.com/apps/renovate.
Thanks.
