### PR TITLE
Rename string in README: GitHub calls it `admin:enterprise`, not `enterprise:admin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Log-in to a GitHub account that has `admin` privileges for the repository, and [
 
 **Required Scopes for Enterprise Runners**
 
-* enterprise:admin (Full control)
+* admin:enterprise (Full control)
 
 _Note: When you deploy enterprise runners they will get access to organisations, however, access to the repositories themselves is **NOT** allowed by default. Each GitHub organisation must allow enterprise runner groups to be used in repositories as an initial one time configuration step, this  only needs to be done once after which it is permanent for that runner group._
 


### PR DESCRIPTION
<img width="516" alt="Screen Shot 2021-08-23 at 2 51 25 PM" src="https://user-images.githubusercontent.com/319655/130501670-0bf6ac4b-2aeb-4d4e-869d-c643c7238652.png">

Thanks for the thorough, helpful docs! 👋 