### PR TITLE
Update Dockerfile

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -60,8 +60,8 @@ RUN set -vx; \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/docker /usr/local/bin/docker \
     && rm -rf docker docker.tgz \
-    && adduser --disabled-password --gecos "" --uid 1000 runner \
-    && groupadd docker \
+    && adduser --disabled-password --gecos "" --uid 1001 runner \
+    && groupadd -g 121 docker \
     && usermod -aG sudo runner \
     && usermod -aG docker runner \
     && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers


### PR DESCRIPTION
The purpose of these changes is to match GitHub-managed runner's user id (1001) and `docker` group id (121)

From `runs-on: ubuntu-20.04`:
![image](https://user-images.githubusercontent.com/24782123/131463083-e4471c7c-f9f5-43bb-b1b7-e431678f8bdd.png)
