### PR TITLE
docs: watch namespace feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+ # actions-runner-controller
+
 [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
 
 This controller operates self-hosted runners for GitHub Actions on your Kubernetes cluster.

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ Configure your values.yaml, see the chart's [README](./charts/actions-runner-con
 
 > This feature requires controller version => [v0.18.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.18.0)
 
-> **_INFO:_**  Be aware when using this feature that CRDs are cluster wide and so you should upgrade all of your controllers (and your CRDs) as the same time if you are doing an upgrade. Do not mix and match CRD versions with different controller versions. Doing so risks out of control scaling.
+> **_INFO:_** Be aware when using this feature that CRDs are cluster wide and so you should upgrade all of your controllers (and your CRDs) as the same time if you are doing an upgrade. Do not mix and match CRD versions with different controller versions. Doing so risks out of control scaling.
 
-By default the controller will look for runners in all namespaces, the watch namespace feature allows you to restrict the controller to monitoring a single namespace. This then lets you deploy mutiple controllers in a single cluster. You may want to do this either because you wish to scale beyond the API rate limit of a single PAT / GitHub App configuration or to support multiple GitHub organizations with runners installed at the organization level in a single cluster.
+By default the controller will look for runners in all namespaces, the watch namespace feature allows you to restrict the controller to monitoring a single namespace. This then lets you deploy multiple controllers in a single cluster. You may want to do this either because you wish to scale beyond the API rate limit of a single PAT / GitHub App configuration or to support multiple GitHub organizations with runners installed at the organization level in a single cluster.
 
 This feature is configured via the `--watch-namespace` flag (see Helm values documentation for configuring with Helm). When a namespace is provided via this flag the controller will only monitor runners in that namespace.
 

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ Configure your values.yaml, see the chart's [README](./charts/actions-runner-con
 
 **_Note: Be aware when using this feature that CRDs are cluster wide and so you should upgrade all of your controllers (and your CRDs) as the same time if you are doing an upgrade. Do not mix and match CRD versions with different controller versions. Doing so risks out of control scaling._**
 
-By default the controller will look for runners in all namespaces, the watch namespace feature allows you to restrict the controller to monitoring a single namespace. This then lets you deploy multiple controllers in a single cluster. You may want to do this either because you wish to scale beyond the API rate limit of a single PAT / GitHub App configuration or to support multiple GitHub organizations with runners installed at the organization level in a single cluster.
+By default the controller will look for runners in all namespaces, the watch namespace feature allows you to restrict the controller to monitoring a single namespace. This then lets you deploy multiple controllers in a single cluster. You may want to do this either because you wish to scale beyond the API rate limit of a single PAT / GitHub App configuration or you wish to support multiple GitHub organizations with runners installed at the organization level in a single cluster.
 
 This feature is configured via the controller `--watch-namespace` flag. When a namespace is provided via this flag the controller will only monitor runners in that namespace.
 
-You should install each controller in the same namespace as the runners it is in charge of as defined with the `--watch-namespace` flag.
+If you plan on installing all instances of the controller stack into a single namespace you will need to make the names of the resources are unique for each stack. In the case of Helm this can be done via the `fullnameOverride` properties. Alternatively, you can install each controller stack into its own unique namespace (relative to other controller stacks in the cluster), avoiding the need to uniquely prefix resources.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # actions-runner-controller
+# actions-runner-controller
 
 [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# actions-runner-controller
+- [Scheduled Overrides](#scheduled-overrides)# actions-runner-controller
 
 [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
 
@@ -22,6 +22,7 @@ ToC:
     - [Faster Autoscaling with GitHub Webhook](#faster-autoscaling-with-github-webhook)
     - [Autoscaling to/from 0](#autoscaling-tofrom-0)
     - [Scheduled Overrides](#scheduled-overrides)
+  - [Deploying Multiple Controllers](#deploying-multiple-controllers)
   - [Runner with DinD](#runner-with-dind)
   - [Additional Tweaks](#additional-tweaks)
   - [Runner Labels](#runner-labels)
@@ -331,7 +332,7 @@ example-runnerdeploy2475ht2qbr   mumoshu/actions-runner-controller-ci   Running
 
 ##### Note on scaling to/from 0
 
-> This feature is available since actions-runner-controller v0.19.0
+> This feature requires controller version => [v0.19.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.19.0)
 
 You can either delete the runner deployment, or update it to have `replicas: 0`, so that there will be 0 runner pods in the cluster. This, in combination with e.g. `cluster-autoscaler`, enables you to save your infrastructure cost when there's no need to run Actions jobs.
 
@@ -656,7 +657,7 @@ You must not include `spec.metrics` like `PercentageRunnersBusy` when using this
 
 #### Autoscaling to/from 0
 
-> This feature is available since actions-runner-controller v0.19.0
+> This feature requires controller version => [v0.19.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.19.0)
 
 Previously, we've discussed about [how to scale a RunnerDeployment to/from 0](#note-on-scaling-tofrom-0)
 
@@ -678,7 +679,7 @@ Similarly, Webhook-based autoscaling works regardless of there are active runner
 
 #### Scheduled Overrides
 
-> This feature is available since actions-runner-controller v0.19.0
+> This feature requires controller version => [v0.19.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.19.0)
 
 `Scheduled Overrides` allows you to configure HorizontalRunnerAutoscaler so that its Spec gets updated only during a certain period of time.
 
@@ -747,6 +748,18 @@ Do note that you have enough slack for `untilTime`, so that a delayed or offline
 In case you have a more complex scenarios, try writing two or more entries under `scheduledOverrides`.
 
 The earlier entry is prioritized higher than later entries. So you usually define one-time overrides in the top of your list, then yearly, monthly, weekly, and lastly daily overrides.
+
+### Deploying Multiple Controllers
+
+> This feature requires controller version => [v0.18.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.18.0)
+
+> **_INFO:_**  Be aware when using this feature that CRDs are cluster wide and so you should upgrade all of your controllers (and your CRDs) as the same time if you are doing an upgrade. Do not mix and match CRD versions with different controller versions. Doing so risks out of control scaling.
+
+By default the controller will look for runners in all namespaces, the watch namespace feature allows you to restrict the controller to monitoring a single namespace. This then lets you deploy mutiple controllers in a single cluster. You may want to do this either because you wish to scale beyond the API rate limit of a single PAT / GitHub App configuration or to support multiple GitHub organizations with runners installed at the organization level in a single cluster.
+
+This feature is configured via the `--watch-namespace` flag (see Helm values documentation for configuring with Helm). When a namespace is provided via this flag the controller will only monitor runners in that namespace.
+
+You should install each controller in the same namespace as the runners it is in charge of as defined with the `--watch-namespace` flag.
 
 ### Runner with DinD
 
@@ -965,7 +978,7 @@ spec:
 
 ### Using IRSA (IAM Roles for Service Accounts) in EKS
 
-`actions-runner-controller` v0.15.0 or later has support for IRSA in EKS.
+> This feature requires controller version => [v0.15.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.15.0)
 
 As similar as for regular pods and deployments, you firstly need an existing service account with the IAM role associated.
 Create one using e.g. `eksctl`. You can refer to [the EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for more details.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Configure your values.yaml, see the chart's [README](./charts/actions-runner-con
 
 By default the controller will look for runners in all namespaces, the watch namespace feature allows you to restrict the controller to monitoring a single namespace. This then lets you deploy multiple controllers in a single cluster. You may want to do this either because you wish to scale beyond the API rate limit of a single PAT / GitHub App configuration or to support multiple GitHub organizations with runners installed at the organization level in a single cluster.
 
-This feature is configured via the `--watch-namespace` flag (see Helm values documentation for configuring with Helm). When a namespace is provided via this flag the controller will only monitor runners in that namespace.
+This feature is configured via the controller `--watch-namespace` flag. When a namespace is provided via this flag the controller will only monitor runners in that namespace.
 
 You should install each controller in the same namespace as the runners it is in charge of as defined with the `--watch-namespace` flag.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-- [Scheduled Overrides](#scheduled-overrides)# actions-runner-controller
-
 [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
 
 This controller operates self-hosted runners for GitHub Actions on your Kubernetes cluster.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Configure your values.yaml, see the chart's [README](./charts/actions-runner-con
 
 > This feature requires controller version => [v0.18.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.18.0)
 
-> **_INFO:_** Be aware when using this feature that CRDs are cluster wide and so you should upgrade all of your controllers (and your CRDs) as the same time if you are doing an upgrade. Do not mix and match CRD versions with different controller versions. Doing so risks out of control scaling.
+**_Note: Be aware when using this feature that CRDs are cluster wide and so you should upgrade all of your controllers (and your CRDs) as the same time if you are doing an upgrade. Do not mix and match CRD versions with different controller versions. Doing so risks out of control scaling._**
 
 By default the controller will look for runners in all namespaces, the watch namespace feature allows you to restrict the controller to monitoring a single namespace. This then lets you deploy multiple controllers in a single cluster. You may want to do this either because you wish to scale beyond the API rate limit of a single PAT / GitHub App configuration or to support multiple GitHub organizations with runners installed at the organization level in a single cluster.
 
@@ -1006,7 +1006,7 @@ spec:
 
 Istio 1.7.0 or greater has `holdApplicationUntilProxyStarts` added in https://github.com/istio/istio/pull/24737, which enables you to delay the `runner` container startup until the injected `istio-proxy` container finish starting. Try using it if you need to use Istio. Otherwise the runner is unlikely to work, because it fails to call any GitHub API to register itself due to `istio-proxy` being not up and running yet.
 
-Note that there's no official Istio integration in actions-runner-controller. It should work, but it isn't covered by our acceptance test(contribution is welcomed). In addition to that, none of the actions-runner-controller maintainers use Istio daily. If you need more information, or have any issues using it, refer to the following links:
+Note that there's no official Istio integration in actions-runner-controller. It should work, but it isn't covered by our acceptance test (a contribution to resolve this is welcomed). In addition to that, none of the actions-runner-controller maintainers use Istio daily. If you need more information, or have any issues using it, refer to the following links:
 
 - https://github.com/actions-runner-controller/actions-runner-controller/issues/591
 - https://github.com/actions-runner-controller/actions-runner-controller/pull/592


### PR DESCRIPTION
Fixes: https://github.com/actions-runner-controller/actions-runner-controller/issues/455

I wasn't sure if the controller needs to be installed in the same namespace as the runners themselves due to how garbage collection works https://kubernetes.io/docs/concepts/architecture/garbage-collection/#owners-dependents

```
Cross-namespace owner references are disallowed by design. Namespaced dependents can specify cluster-scoped 
or namespaced owners. A namespaced owner must exist in the same namespace as the dependent. If it does not, 
the owner reference is treated as absent, and the dependent is subject to deletion once all owners are verified 
absent.
```

I've said same namespace installtion is required, if this is not a requirement please comment on the PR and I'll update the docs to reflect this in this PR @mumoshu 