### PR TITLE
Add PreserveUnknownFields marker

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -106,6 +106,7 @@ type RunnerPodSpec struct {
 	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
 
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// +optional
@@ -118,6 +119,7 @@ type RunnerPodSpec struct {
 	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
 
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
 
 	// +optional
@@ -136,6 +138,7 @@ type RunnerPodSpec struct {
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	EphemeralContainers []corev1.EphemeralContainer `json:"ephemeralContainers,omitempty"`
 
 	// +optional

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -784,6 +784,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         group:
                           type: string
                         hostAliases:
@@ -821,6 +822,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         labels:
                           items:
                             type: string
@@ -954,6 +956,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         terminationGracePeriodSeconds:
                           format: int64
                           type: integer

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -781,6 +781,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         group:
                           type: string
                         hostAliases:
@@ -818,6 +819,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         labels:
                           items:
                             type: string
@@ -951,6 +953,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         terminationGracePeriodSeconds:
                           format: int64
                           type: integer

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -727,6 +727,7 @@ spec:
                       - name
                     type: object
                   type: array
+                  x-kubernetes-preserve-unknown-fields: true
                 group:
                   type: string
                 hostAliases:
@@ -764,6 +765,7 @@ spec:
                       - name
                     type: object
                   type: array
+                  x-kubernetes-preserve-unknown-fields: true
                 labels:
                   items:
                     type: string
@@ -897,6 +899,7 @@ spec:
                       - name
                     type: object
                   type: array
+                  x-kubernetes-preserve-unknown-fields: true
                 terminationGracePeriodSeconds:
                   format: int64
                   type: integer

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -784,6 +784,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         group:
                           type: string
                         hostAliases:
@@ -821,6 +822,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         labels:
                           items:
                             type: string
@@ -954,6 +956,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         terminationGracePeriodSeconds:
                           format: int64
                           type: integer

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -781,6 +781,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         group:
                           type: string
                         hostAliases:
@@ -818,6 +819,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         labels:
                           items:
                             type: string
@@ -951,6 +953,7 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         terminationGracePeriodSeconds:
                           format: int64
                           type: integer

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -727,6 +727,7 @@ spec:
                       - name
                     type: object
                   type: array
+                  x-kubernetes-preserve-unknown-fields: true
                 group:
                   type: string
                 hostAliases:
@@ -764,6 +765,7 @@ spec:
                       - name
                     type: object
                   type: array
+                  x-kubernetes-preserve-unknown-fields: true
                 labels:
                   items:
                     type: string
@@ -897,6 +899,7 @@ spec:
                       - name
                     type: object
                   type: array
+                  x-kubernetes-preserve-unknown-fields: true
                 terminationGracePeriodSeconds:
                   format: int64
                   type: integer


### PR DESCRIPTION
Add `+kubebuilder:pruning:PreserveUnknownFields` processing marker to preserve `initContainers`, `sidecarContainers` and `ephemeralContainers` fields from being [pruned](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning).


Resolves #772