### PR TITLE
Add GitHub runner metrics

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -173,6 +173,8 @@ func (c *Client) ListRunners(ctx context.Context, enterprise, org, repo string) 
 		opts.Page = res.NextPage
 	}
 
+	metrics.SetRunnerStatus(runners, enterprise, org, repo)
+
 	return runners, nil
 }
 

--- a/github/metrics/runner.go
+++ b/github/metrics/runner.go
@@ -1,0 +1,73 @@
+// Package metrics provides monitoring of the GitHub related metrics.
+//
+// This depends on the metrics exporter of kubebuilder.
+// See https://book.kubebuilder.io/reference/metrics.html for details.
+package metrics
+
+import (
+	"github.com/google/go-github/v37/github"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		metricRunnerActiveCount,
+		metricRunnerIdleCount,
+		metricRunnerOfflineCount,
+	)
+}
+
+var (
+	metricRunnerActiveCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_active_runner_count",
+			Help: "Number of currently active runner registered on GitHub",
+		},
+		[]string{"repository", "organization", "enterprise"},
+	)
+	metricRunnerIdleCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_idle_runner_count",
+			Help: "Number of idling runner registered on GitHub",
+		},
+		[]string{"repository", "organization", "enterprise"},
+	)
+	metricRunnerOfflineCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_offline_runner_count",
+			Help: "Number of offline runner registered on GitHub",
+		},
+		[]string{"repository", "organization", "enterprise"},
+	)
+)
+
+func SetRunnerStatus(runners []*github.Runner, enterprise, org, repo string) {
+	var countActive, countIdle, countOffline float64
+
+	for _, runner := range runners {
+		status := runner.GetStatus()
+		if status == "offline" {
+			countOffline++
+			continue
+		}
+
+		isBusy := runner.GetBusy()
+		if isBusy {
+			countActive++
+			continue
+		}
+
+		countIdle++
+	}
+
+	labels := prometheus.Labels{
+		"enterprise":   enterprise,
+		"organization": org,
+		"repository":   repo,
+	}
+
+	metricRunnerActiveCount.With(labels).Set(countActive)
+	metricRunnerIdleCount.With(labels).Set(countIdle)
+	metricRunnerOfflineCount.With(labels).Set(countOffline)
+}


### PR DESCRIPTION
It would be nice if the controller provides these metrics, as controller already fetches runner information from GitHub periodically via [`ListRunners`](https://github.com/actions-runner-controller/actions-runner-controller/blob/58d2591f09f70bf271c165c755563a19450c30ee/github/github.go#L152) in [reconcile](https://github.com/actions-runner-controller/actions-runner-controller/blob/58d2591f09f70bf271c165c755563a19450c30ee/controllers/runner_controller.go#L353) and for [`PercentageRunnersBusy`](https://github.com/actions-runner-controller/actions-runner-controller/blob/58d2591f09f70bf271c165c755563a19450c30ee/controllers/runner_controller.go#L353) autoscaler, so it's not necessary to set up another system to periodically pull this data from GitHub (e.g. with [tchelovilar/github-org-runner-exporter](https://github.com/tchelovilar/github-org-runner-exporter))