### PR TITLE
Correct test to append docker container

### DIFF
--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -619,7 +619,7 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 			Resources:       runner.Spec.Resources,
 		})
 
-		if runner.Spec.DockerdWithinRunnerContainer == nil || !*runner.Spec.DockerdWithinRunnerContainer {
+		if (runner.Spec.DockerEnabled == nil || *runner.Spec.DockerEnabled) && (runner.Spec.DockerdWithinRunnerContainer == nil || !*runner.Spec.DockerdWithinRunnerContainer) {
 			template.Spec.Containers = append(template.Spec.Containers, corev1.Container{
 				Name:         "docker",
 				VolumeMounts: runner.Spec.DockerVolumeMounts,


### PR DESCRIPTION
This updates the do-we-append-a-docker-container decision to more like elsewhere, e.g. https://github.com/actions-runner-controller/actions-runner-controller/blob/24602ff3ee05303e019b395b5d6805f2ebedaa14/controllers/runner_controller.go#L1040

This appears to fix #835