### PR TITLE
Reduce number of http superfluous messages

### DIFF
--- a/controllers/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/horizontal_runner_autoscaler_webhook.go
@@ -98,6 +98,7 @@ func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) Handle(w http.Respons
 
 	// respond ok to GET / e.g. for health check
 	if r.Method == http.MethodGet {
+		ok = true
 		fmt.Fprintln(w, "webhook server is running")
 		return
 	}


### PR DESCRIPTION
write to http.ResponseWriter create HTTP OK response, so set *ok* to true will disable calling error code in defered function