### PR TITLE
Fail with detailed message on envvar parse error

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,8 @@ func main() {
 	var c github.Config
 	err = envconfig.Process("github", &c)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error: Environment variable read failed.")
+		fmt.Fprintf(os.Stderr, "Error: processing environment variables: %v\n", err)
+		os.Exit(1)
 	}
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
Currently, it's hard for users to notice envvar parse error(s). This fixes that, by adding a more detailed message on such error and existing with status 1 instead of just continuing the application startup process with possibly broken configuration.

Ref #829