### PR TITLE
Removed --once flag in favor of --ephemeral

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ spec:
           tolerationSeconds: 10
       # true (default) = The runner restarts after running jobs, to ensure a clean and reproducible build environment
       # false = The runner is persistent across jobs and doesn't automatically restart
-      # This directly controls the behaviour of `--once` flag provided to the github runner
+      # This directly controls the behaviour of `--ephemeral` flag provided to the github runner
       ephemeral: false
       # true (default) = A privileged docker sidecar container is included in the runner pod.
       # false = A docker sidecar container is not included in the runner pod and you can't use docker.
@@ -1166,44 +1166,7 @@ We envision that `RunnerSet` will eventually replace `RunnerDeployment`, as `Run
 
 Both `RunnerDeployment` and `RunnerSet` has ability to configure `ephemeral: true` in the spec.
 
-When it is configured, it passes a `--once` flag to every runner.
-
-`--once` is an experimental `actions/runner` feature that instructs the runner to stop after the first job run. But it is a known race issue that may fetch a job even when it's being terminated. If a runner fetched a job while terminating, the job is very likely to fail because the terminating runner doesn't wait for the job to complete. This is tracked in #466.
-
-> The below feature depends on an unreleased GitHub feature
-
-GitHub seems to be adding an another flag called `--ephemeral` that is race-free. The pull request to add it to `actions/runner` can be found at https://github.com/actions/runner/pull/660.
-
-`actions-runner-controller` has a feature flag backend by an environment variable to enable using `--ephemeral` instead of `--once`. The environment variable is `RUNNER_FEATURE_FLAG_EPHEMERAL`. You can se it to `true` on runner containers in your runner pods to enable the feature.
-
-> At the time of writing this, you need to wait until GitHub rolls out the server-side feature for `--ephemeral`, AND you need to include your own `actions/runner` binary built from https://github.com/actions/runner/pull/660 into the runner container image to test this feature.
->
-> Please see comments in [`runner/Dockerfile`](/runner/Dockerfile) for more information about how to build a custom image using your own `actions/runner` binary.
-
-For example, a `RunnerSet` config with the flag enabled looks like:
-
-```yaml
-kind: RunnerSet
-metadata:
-  name: example-runnerset
-spec:
-  # ...
-  template:
-    metadata:
-      labels:
-        app: example-runnerset
-    spec:
-      containers:
-      - name: runner
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: RUNNER_FEATURE_FLAG_EPHEMERAL
-          value: "true"
-```
-
-Note that once https://github.com/actions/runner/pull/660 becomes generally available on GitHub, you no longer need to build a custom runner image to use this feature. Just set `RUNNER_FEATURE_FLAG_EPHEMERAL` and it should use `--ephemeral`.
-
-In the future, `--once` might get removed in `actions/runner`. `actions-runner-controller` will make `--ephemeral` the default option for `ephemeral: true` runners until the legacy flag is removed.
+When it is configured, it passes the `--ephemeral` flag to every runner when configuring it. This will instruct the runner to stop running (and it won't accept new jobs) after it has processed a single job.
 
 ### Software Installed in the Runner Image
 

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -79,7 +79,7 @@ cd ${RUNNER_HOME}
 # past that point, it's all relative pathes from /runner
 
 config_args=()
-if [ "${RUNNER_FEATURE_FLAG_EPHEMERAL:-}" == "true" -a "${RUNNER_EPHEMERAL}" != "false" ]; then
+if [ "${RUNNER_EPHEMERAL}" != "false" ]; then
   config_args+=(--ephemeral)
   echo "Passing --ephemeral to config.sh to enable the ephemeral runner."
 fi
@@ -150,11 +150,5 @@ if [ -z "${UNITTEST:-}" ]; then
   done
 fi
 
-args=()
-if [ "${RUNNER_FEATURE_FLAG_EPHEMERAL:-}" != "true" -a "${RUNNER_EPHEMERAL}" != "false" ]; then
-  args+=(--once)
-  echo "Passing --once to runsvc.sh to enable the legacy ephemeral runner."
-fi
-
 unset RUNNER_NAME RUNNER_REPO RUNNER_TOKEN
-exec ./bin/runsvc.sh "${args[@]}"
+exec ./bin/runsvc.sh


### PR DESCRIPTION
Edit: probably a duplicate of #831 

Since the `--ephemeral` flag is now generally available, it is best to remove the `--once` flag altogether - it is undocumented and could be removed at any time. So, it would be best to switch over.

According to [the official docs for autoscaling](https://docs.github.com/en/actions/hosting-your-own-runners/autoscaling-with-self-hosted-runners#using-ephemeral-runners-for-autoscaling) this flag is the preferred way to implementing webhook-based autoscaling.

# Testing

I tested this on the latest runner image `v2.284.0` and it works without issues, no customizations required.
Since this update to the `entrypoint.sh` will only be included in newer images, there is no real need to keep
the old flag supported.

I only tested this with a single RunnerDeployment inside a local cluster. The pod logs the following output:

```
√ Connected to GitHub

Current runner version: '2.284.0'
2021-11-09 20:38:33Z: Listening for Jobs
2021-11-09 20:44:56Z: Running job: test
2021-11-09 20:45:02Z: Job test completed with result: Succeeded
√ Removed .credentials
√ Removed .runner
Runner listener exited with error code 0
Runner listener exit with 0 return code, stop the service, no retry needed.

```

As expected, it exits right after the job was finished, after which a new pod is started.

If you feel this requires additional testing then please let me know.

# Documentation

I basically cut out the entire part from the README.md documenting the experimental nature of the `--ephemeral`
flag. It now contains only a section decribing that the flag exists and not much more
