### PR TITLE
fix: update volumes and volumes mounts indent

### DIFF
--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
           name: cert
           readOnly: true
         {{- if .Values.additionalVolumeMounts }}
-          {{- toYaml .Values.additionalVolumeMounts | nindent 10 }} 
+          {{- toYaml .Values.additionalVolumeMounts | nindent 8 }} 
         {{- end }}
       {{- if .Values.metrics.proxy.enabled }}
       - args:
@@ -146,7 +146,7 @@ spec:
       - name: tmp
         emptyDir: {}
       {{- if .Values.additionalVolumes }}
-        {{- toYaml .Values.additionalVolumes | nindent 8}}
+        {{- toYaml .Values.additionalVolumes | nindent 6}}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
I was getting `YAML parse error on actions-runner-controller/templates/deployment.yaml` and when I investigated it seems the indent by values were off by 2. 

These are the values I was testing with:

```
additionalVolumeMounts:
- mountPath: /etc/ssl/certs
  name: ghe-cert
  readOnly: true
additionalVolumes:
- name: ghe-cert
  secret:
    secretName: ghecert
```

Signed-off-by: Gregory Schofield <gscho@github.com>