### PR TITLE
ci: separate ubuntu versions out in ci

### DIFF
--- a/.github/actions/setup-docker-environment/action.yaml
+++ b/.github/actions/setup-docker-environment/action.yaml
@@ -1,0 +1,31 @@
+name: "Setup Docker"
+
+inputs:
+  username:
+    description: "Username"
+    required: true
+  password:
+    description: "Password"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Short SHA
+      id: vars
+      run: echo ::set-output name=sha_short::${GITHUB_SHA::7}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+      with:
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,10 @@
   "regexManagers": [
     {
       // use https://github.com/actions/runner/releases
-      "fileMatch": [".github/workflows/build-and-release-runners.yml"],
+      "fileMatch": [
+        ".github/workflows/ubuntu-18-04-runners.yml",
+        ".github/workflows/ubuntu-20-04-runners.yml"
+        ],
       "matchStrings": ["RUNNER_VERSION: +(?<currentValue>.*?)\\n"],
       "depNameTemplate": "actions/runner",
       "datasourceTemplate": "github-releases"

--- a/.github/workflows/ubuntu-18-04-runners.yml
+++ b/.github/workflows/ubuntu-18-04-runners.yml
@@ -1,0 +1,76 @@
+name: Ubuntu 18.04 Runners
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - 'runner/**'
+      - .github/workflows/build-and-release-runners.yml
+      - '!**.md'
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'runner/**'
+      - .github/workflows/build-and-release-runners.yml
+      - '!**.md'
+
+env:
+  RUNNER_VERSION: 2.284.0
+  DOCKER_VERSION: 20.10.8
+  DOCKERHUB_USERNAME: summerwind
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build ${{ matrix.name }}-ubuntu-${{ matrix.os-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: actions-runner
+            os-version: 18.04
+            dockerfile: Dockerfile.ubuntu.1804
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Docker Environment
+        uses: ./.github/actions/setup-docker-environment
+        with: 
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build and Push Versioned Tags
+        uses: docker/build-push-action@v2
+        with:
+          context: ./runner
+          file: ./runner/${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
+            DOCKER_VERSION=${{ env.DOCKER_VERSION }}
+          tags: |
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-ubuntu-${{ matrix.os-version }}
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-ubuntu-${{ matrix.os-version }}-${{ steps.vars.outputs.sha_short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and Push Latest Tag
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ./runner
+          file: ./runner/${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
+            DOCKER_VERSION=${{ env.DOCKER_VERSION }}
+          tags: |
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ubuntu-20-04-runners.yml
+++ b/.github/workflows/ubuntu-20-04-runners.yml
@@ -1,22 +1,18 @@
-name: Build and Release Runners
+name: Ubuntu 20.04 Runners
 
 on:
   pull_request:
     branches:
-      - '**'
+      - 'master'
     paths:
       - 'runner/**'
       - .github/workflows/build-and-release-runners.yml
       - '!**.md'
   push:
     branches:
-      - master
+      - 'master'
     paths:
-      - runner/patched/*
-      - runner/Dockerfile
-      - runner/Dockerfile.ubuntu.1804
-      - runner/Dockerfile.dindrunner
-      - runner/entrypoint.sh
+      - 'runner/**'
       - .github/workflows/build-and-release-runners.yml
       - '!**.md'
 
@@ -30,38 +26,23 @@ jobs:
     runs-on: ubuntu-latest
     name: Build ${{ matrix.name }}-ubuntu-${{ matrix.os-version }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: actions-runner
             os-version: 20.04
             dockerfile: Dockerfile
-          - name: actions-runner
-            os-version: 18.04
-            dockerfile: Dockerfile.ubuntu.1804
           - name: actions-runner-dind
             os-version: 20.04
             dockerfile: Dockerfile.dindrunner
 
     steps:
-      - name: Set outputs
-        id: vars
-        run: echo ::set-output name=sha_short::${GITHUB_SHA::7}
-
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
-        with:
+      - name: Setup Docker Environment
+        uses: ./.github/actions/setup-docker-environment
+        with: 
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
@@ -78,38 +59,11 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-ubuntu-${{ matrix.os-version }}
             ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-ubuntu-${{ matrix.os-version }}-${{ steps.vars.outputs.sha_short }}
-
-  latest-tags:
-    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
-    runs-on: ubuntu-latest
-    name: Build ${{ matrix.name }}-latest
-    strategy:
-      matrix:
-        include:
-          - name: actions-runner
-            dockerfile: Dockerfile
-          - name: actions-runner-dind
-            dockerfile: Dockerfile.dindrunner
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and Push Latest Tag
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/build-push-action@v2
         with:
           context: ./runner
@@ -121,3 +75,5 @@ jobs:
             DOCKER_VERSION=${{ env.DOCKER_VERSION }}
           tags: |
             ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Ubuntu 18.04 builds are failing and it's not immediately obvious why.

Changes:
- Seperating the ci out between versions so problems in 18.04 don't block 20.04, if there are problems it's likely to be in that version group rather in the OS family
- Might as well make use of the repository cache for layers
- Might as well use use composite actions if we're making changes to the flows
- Update Renovate to point at both pipelien files