### PR TITLE
Bump chart version to fix outdated CRDs

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.15.2
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.20.3
+appVersion: 0.20.4
 
 home: https://github.com/actions-runner-controller/actions-runner-controller
 


### PR DESCRIPTION
Changes happened to the CRDs since the last time that the Helm chart was bumped, so there are Helm users out there (like myself) who are running recent controllers with old CRDs. I am for example missing the new `dockerEnv` feature in the runnerdeployment resource.

I have bumped the chart version to pull the latest CRDs into a new point release. I've also nudged the appVersion up to match the latest release.

It'll be important to bump the chart version any time a change is made that results in different YAML rendering behavior to avoid future recurrence of the breakage.