### PR TITLE
Fix runner controller to not recreate restarting ephemeral runner

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -73,6 +73,10 @@ type RunnerConfig struct {
 	VolumeStorageMedium *string `json:"volumeStorageMedium,omitempty"`
 }
 
+func (c *RunnerConfig) IsEphemeral() bool {
+	return c.Ephemeral == nil || *c.Ephemeral
+}
+
 // RunnerPodSpec defines the desired pod spec fields of the runner pod
 type RunnerPodSpec struct {
 	// +optional

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -416,7 +416,9 @@ func (r *RunnerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 					"podCreationTimestamp", pod.CreationTimestamp,
 				)
 
-				metav1.SetMetaDataAnnotation(&pod.ObjectMeta, AnnotationKeyFirstRegistrationDate, pod.CreationTimestamp.Format(time.RFC3339))
+				if runner.Spec.IsEphemeral() {
+					metav1.SetMetaDataAnnotation(&pod.ObjectMeta, AnnotationKeyFirstRegistrationDate, pod.CreationTimestamp.Format(time.RFC3339))
+				}
 			}
 
 			updated := runner.DeepCopy()
@@ -814,7 +816,7 @@ func newRunnerPod(template corev1.Pod, runnerSpec v1alpha1.RunnerConfig, default
 		privileged                bool = true
 		dockerdInRunner           bool = runnerSpec.DockerdWithinRunnerContainer != nil && *runnerSpec.DockerdWithinRunnerContainer
 		dockerEnabled             bool = runnerSpec.DockerEnabled == nil || *runnerSpec.DockerEnabled
-		ephemeral                 bool = runnerSpec.Ephemeral == nil || *runnerSpec.Ephemeral
+		ephemeral                 bool = runnerSpec.IsEphemeral()
 		dockerdInRunnerPrivileged bool = dockerdInRunner
 	)
 

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -299,11 +299,9 @@ func (r *RunnerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		registrationTimeout := 10 * time.Minute
 		durationAfterRegistrationTimeout := currentTime.Sub(pod.CreationTimestamp.Add(registrationTimeout))
-		ephemeralRunnerRegisteredOnce := false
 		ephemeralRunnerFirstRegistrationDate := ""
 		if annotations := pod.GetAnnotations(); annotations != nil {
 			if v, ok := annotations[AnnotationKeyFirstRegistrationDate]; ok {
-				ephemeralRunnerRegisteredOnce = true
 				ephemeralRunnerFirstRegistrationDate = v
 			}
 		}
@@ -311,7 +309,7 @@ func (r *RunnerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		if notFound {
 			if registrationDidTimeout {
-				if ephemeralRunnerRegisteredOnce {
+				if ephemeralRunnerFirstRegistrationDate != "" {
 					log.Info(
 						"Ephemeral runner %q was successfully registered once, but is not recognized by GitHub now. "+
 							"This situation is normal and known to happen when ARC called GitHub's List Runners API while "+


### PR DESCRIPTION
This is a potential fix for #911 based on [my interpretation](https://github.com/actions-runner-controller/actions-runner-controller/issues/911#issuecomment-1024846009) of the [problem observed by @jbkc85](https://github.com/actions-runner-controller/actions-runner-controller/issues/911#issuecomment-1024846009).

In case you've seen ARC abruptly terminate an ephemeral runner that just got restarted, this might be the fix.