### PR TITLE
Update the helm chart app version

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.2
+version: 0.15.3
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.20.3
+appVersion: 0.20.4
 
 home: https://github.com/actions-runner-controller/actions-runner-controller
 


### PR DESCRIPTION
The Helm chart isn't using the latest app version `0.20.4` which was released a while back
Bumping it up