### PR TITLE
chart: Add extraPaths to Ingress of GitHub Webhook Server

### DIFF
--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -37,7 +37,7 @@ spec:
       http:
         paths:
           {{- if .extraPaths }}
-          {{ toYaml .extraPaths | indent 10 }}
+          {{ toYaml .extraPaths | nindent 10 }}
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}

--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -36,6 +36,9 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+          {{- if .extraPaths }}
+          {{ toYaml .extraPaths | indent 10 }}
+          {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}

--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -37,7 +37,7 @@ spec:
       http:
         paths:
           {{- if .extraPaths }}
-          {{ toYaml .extraPaths | nindent 10 }}
+          {{- toYaml .extraPaths | nindent 10 }}
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -217,6 +217,20 @@ githubWebhookServer:
         paths: []
         #  - path: /*
         #    pathType: ImplementationSpecific
+        # Extra paths that are not automatically connected to the server. This is useful when working with annotation based services.
+        extraPaths: []
+        # - path: /*
+        #   backend:
+        #     serviceName: ssl-redirect
+        #     servicePort: use-annotation
+        ## for Kubernetes >=1.19 (when "networking.k8s.io/v1" is used)
+        # - path: /*
+        #   pathType: Prefix
+        #   backend:
+        #     service:
+        #       name: ssl-redirect
+        #       port:
+        #         name: use-annotation
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
Hi, congratulation that the team released appVersion 0.21.0 and chartVersion 0.16.0.

I want to add some extra paths to the Ingress of the GitHub Webhook Server but every `paths` is automatically connected to the server, so I've add `extraPaths` just like [grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana) or [argo-cd](https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd) charts.

References:

* https://github.com/grafana/helm-charts/blob/afcaf811ae181b64032994e677790266d49049db/charts/grafana/values.yaml#L200-L213
* https://github.com/grafana/helm-charts/blob/afcaf811ae181b64032994e677790266d49049db/charts/grafana/templates/ingress.yaml#L40-L42
* https://github.com/argoproj/argo-helm/blob/591de85984906ad5e98e4bb9785448dc4a78eb8a/charts/argo-cd/values.yaml#L1027-L1040
* https://github.com/argoproj/argo-helm/blob/591de85984906ad5e98e4bb9785448dc4a78eb8a/charts/argo-cd/templates/argocd-server/ingress.yaml#L38-L40