### PR TITLE
Set UserAgent to `actions-runner-controller`  for all Http Client.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -46,7 +46,6 @@ type BasicAuthTransport struct {
 
 func (p BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.SetBasicAuth(p.Username, p.Password)
-	req.Header.Set("User-Agent", "actions-runner-controller")
 	return http.DefaultTransport.RoundTrip(req)
 }
 
@@ -127,6 +126,8 @@ func (c *Config) NewClient() (*Client, error) {
 			}
 		}
 	}
+
+	client.UserAgent = "actions-runner-controller"
 
 	return &Client{
 		Client:        client,

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -152,3 +152,10 @@ func TestCleanup(t *testing.T) {
 		t.Errorf("expired token still exists")
 	}
 }
+
+func TestUserAgent(t *testing.T) {
+	client := newTestClient()
+	if client.UserAgent != "actions-runner-controller" {
+		t.Errorf("UserAgent should be set to actions-runner-controller")
+	}
+}


### PR DESCRIPTION
I can't find any requests made by user agent `actions-runner-controller` in GitHub.com's telemetry in the past 7 days.

Turns out we only set user agent `actions-runner-controller` if we are configured to use BasicAuth which is not the case for most customers I think.

I update the code a little bit to make sure it always set `actions-runner-controller` as UserAgent for the GitHub HttpClient in ARC.

A further step would be somehow baking the ARC release version into the UserAgent as well. 😄 