### PR TITLE
fix(chart): allow to use basic auth when authSecret.create is false

### DIFF
--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -104,8 +104,10 @@ spec:
               key: github_app_private_key
               name: {{ include "actions-runner-controller.secretName" . }}
               optional: true
+        {{- if .Values.authSecret.github_basicauth_username }}
         - name: GITHUB_BASICAUTH_USERNAME
           value: {{ .Values.authSecret.github_basicauth_username }}
+        {{- end }}
         - name: GITHUB_BASICAUTH_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -104,17 +104,14 @@ spec:
               key: github_app_private_key
               name: {{ include "actions-runner-controller.secretName" . }}
               optional: true
-        {{- if .Values.authSecret.github_basicauth_username  }}
         - name: GITHUB_BASICAUTH_USERNAME
           value: {{ .Values.authSecret.github_basicauth_username }}
-        {{- end }}
-        {{- if .Values.authSecret.github_basicauth_password }}
         - name: GITHUB_BASICAUTH_PASSWORD
           valueFrom:
             secretKeyRef:
               key: github_basicauth_password
               name: {{ include "actions-runner-controller.secretName" . }}
-        {{- end }}
+              optional: true
         {{- end }}
         {{- range $key, $val := .Values.env }}
         - name: {{ $key }}

--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -94,17 +94,14 @@ spec:
               key: github_app_private_key
               name: {{ include "actions-runner-controller.githubWebhookServerSecretName" . }}
               optional: true
-        {{- if .Values.authSecret.github_basicauth_username  }}
         - name: GITHUB_BASICAUTH_USERNAME
           value: {{ .Values.authSecret.github_basicauth_username }}
-        {{- end }}
-        {{- if .Values.authSecret.github_basicauth_password }}
         - name: GITHUB_BASICAUTH_PASSWORD
           valueFrom:
             secretKeyRef:
               key: github_basicauth_password
               name: {{ include "actions-runner-controller.secretName" . }}
-        {{- end }}
+              optional: true
         {{- end }}
         {{- range $key, $val := .Values.githubWebhookServer.env }}
         - name: {{ $key }}

--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -94,8 +94,10 @@ spec:
               key: github_app_private_key
               name: {{ include "actions-runner-controller.githubWebhookServerSecretName" . }}
               optional: true
+        {{- if .Values.authSecret.github_basicauth_username }}
         - name: GITHUB_BASICAUTH_USERNAME
           value: {{ .Values.authSecret.github_basicauth_username }}
+        {{- end }}
         - name: GITHUB_BASICAUTH_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
When secret is created outside of the ARC chart using authSecret.create=false and basicAuth, the controller fails as we're not including the basic password as environment variable as the password value won't be inside the helm values.

This PR includes both environment variables for consistent regardless if those are set or not similar as the rest of the other auth options (e.g app_id, private  key, etc)