### PR TITLE
Fix picking up wrong scale target when webhook labels are empty (such as for cloud running jobs)

### DIFF
--- a/controllers/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/horizontal_runner_autoscaler_webhook.go
@@ -650,6 +650,11 @@ func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) getManagedRunnerGroup
 }
 
 func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) getJobScaleTarget(ctx context.Context, name string, labels []string) (*ScaleTarget, error) {
+	if len(labels) == 0 {
+		// No labels, can't be self-hosted runner
+		autoscaler.Log.V(1).Info(fmt.Sprintf("Skipping finding scale target for %s, because no labels", name))
+		return nil, nil
+	}
 	hras, err := autoscaler.findHRAsByKey(ctx, name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We are seeing scale down events due to some other jobs which are running in the github cloud. These events do not have labels so the first scale set is picked up. (I observed this while debugging other issue https://github.com/actions-runner-controller/actions-runner-controller/issues/911#issuecomment-1047523629)

What do you think could this work? I tested this in our own environment and it seems to work as expected, although I'm not sure if there is some unwanted side effects for some other scenarios?