### PR TITLE
integration: Reduce error logs to ease debugging

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,12 @@ jobs:
       with:
         go-version: '^1.17.7'
     - run: go version
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Install kubebuilder
       run: |
         curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_linux_amd64.tar.gz

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -108,8 +108,8 @@ func SetupIntegrationTest(ctx2 context.Context) *testEnvironment {
 			RunnerImage:                 "example/runner:test",
 			DockerImage:                 "example/docker:test",
 			Name:                        controllerName("runner"),
-			RegistrationRecheckInterval: time.Millisecond,
-			RegistrationRecheckJitter:   time.Millisecond,
+			RegistrationRecheckInterval: time.Millisecond * 100,
+			RegistrationRecheckJitter:   time.Millisecond * 10,
 			UnregistrationTimeout:       1 * time.Second,
 			UnregistrationRetryDelay:    1 * time.Second,
 		}

--- a/github/fake/fake.go
+++ b/github/fake/fake.go
@@ -162,6 +162,10 @@ func NewServer(opts ...Option) *httptest.Server {
 		},
 
 		// For RemoveRunner
+		"/repos/test/valid/actions/runners/0": &Handler{
+			Status: http.StatusNoContent,
+			Body:   "",
+		},
 		"/repos/test/valid/actions/runners/1": &Handler{
 			Status: http.StatusNoContent,
 			Body:   "",


### PR DESCRIPTION
This will remove a bunch of errors like:

```
.6462984231756542e+09	ERROR	Failed to unregister runner before deleting the pod.	{"runner": "testns-nsc7m/example-runnerdeploy-5rp2h-8gzfs", "error": "failed to remove runner: DELETE http://127.0.0.1:43771/repos/test/valid/actions/runners/0: 404  []"}
github.com/actions-runner-controller/actions-runner-controller/controllers.tickRunnerGracefulStop
	/home/runner/work/actions-runner-controller/actions-runner-controller/controllers/runner_graceful_stop.go:35
github.com/actions-runner-controller/actions-runner-controller/controllers.(*RunnerReconciler).processRunnerDeletion
	/home/runner/work/actions-runner-controller/actions-runner-controller/controllers/runner_controller.go:483
github.com/actions-runner-controller/actions-runner-controller/controllers.(*RunnerReconciler).Reconcile
	/home/runner/work/actions-runner-controller/actions-runner-controller/controllers/runner_controller.go:125
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:227
```

and

```
1.646298422902583e+09	DEBUG	Rechecking the runner registration in 2.082781ms	{"runner": "testns-nsc7m/example-runnerdeploy-5rp2h-ncdw4"}
1.6462984229058487e+09	DEBUG	Runner pod exists but we failed to check if runner is busy. Apparently it still needs more time.	{"runner": "testns-nsc7m/example-runnerdeploy-5rp2h-hcxr6", "runnerName": "example-runnerdeploy-5rp2h-hcxr6"}
```

when an integration test failed, which made debugging harder.