### PR TITLE
chore: Change log ts format to RFC3339

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	zaplib "go.uber.org/zap"
@@ -48,6 +49,7 @@ func NewLogger(logLevel string) logr.Logger {
 			atomicLevel := zaplib.NewAtomicLevelAt(level)
 			o.Level = &atomicLevel
 		}
+		o.TimeEncoder = zapcore.TimeEncoderOfLayout(time.RFC3339)
 	})
 
 	return log


### PR DESCRIPTION
The TimeEncoder for zap seems to have been set to EpochTimeEncoder which is the default and it was not very readable. Changing it to a TimeEncoderOfLayout(time.RFC3339) for readability.
Another benefit of doing this is the ts format is now consistent with various timestamps ARC put into pod and other custom resource annotations.

BEFORE:

```
{"level":"debug","ts":1646530339.3554308,"logger":"actions-runner-controller.horizontalrunnerautoscaler","msg":"Calculated desired replicas of 10","horizontalrunnerautoscaler":"default/org-runnerdeploy","suggested":2,"reserved":20,"min":2,"cached":2,"max":10}
```

AFTER:

```
{"level":"debug","ts":"2022-03-08T01:30:46Z","logger":"actions-runner-controller.horizontalrunnerautoscaler","msg":"Calculated desired replicas of 2","horizontalrunnerautoscaler":"default/enterprisegroup-runnerdeploy","suggested":2,"reserved":0,"min":2,"max":10,"cached":2}
```