### PR TITLE
Use --ephemeral by default

### DIFF
--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -50,10 +50,12 @@ const (
 	// This is an annotation internal to actions-runner-controller and can change in backward-incompatible ways
 	annotationKeyRegistrationOnly = "actions-runner-controller/registration-only"
 
-	EnvVarOrg        = "RUNNER_ORG"
-	EnvVarRepo       = "RUNNER_REPO"
-	EnvVarEnterprise = "RUNNER_ENTERPRISE"
-	EnvVarEphemeral  = "RUNNER_EPHEMERAL"
+	EnvVarOrg                        = "RUNNER_ORG"
+	EnvVarRepo                       = "RUNNER_REPO"
+	EnvVarEnterprise                 = "RUNNER_ENTERPRISE"
+	EnvVarEphemeral                  = "RUNNER_EPHEMERAL"
+	EnvVarRunnerFeatureFlagEphemeral = "RUNNER_FEATURE_FLAG_EPHEMERAL"
+	EnvVarTrue                       = "true"
 )
 
 // RunnerReconciler reconciles a Runner object
@@ -810,6 +812,12 @@ func newRunnerPod(runnerName string, template corev1.Pod, runnerSpec v1alpha1.Ru
 		} else {
 			pod.Spec.Containers[dockerdContainerIndex] = *dockerdContainer
 		}
+	}
+
+	// TODO Remove this once we remove RUNNER_FEATURE_FLAG_EPHEMERAL from runner's entrypoint.sh
+	// and make --ephemeral the default option.
+	if getRunnerEnv(pod, EnvVarRunnerFeatureFlagEphemeral) == "" {
+		setRunnerEnv(pod, EnvVarRunnerFeatureFlagEphemeral, EnvVarTrue)
 	}
 
 	return *pod, nil

--- a/controllers/runner_graceful_stop.go
+++ b/controllers/runner_graceful_stop.go
@@ -283,6 +283,21 @@ func getRunnerEnv(pod *corev1.Pod, key string) string {
 	return ""
 }
 
+func setRunnerEnv(pod *corev1.Pod, key, value string) {
+	for i := range pod.Spec.Containers {
+		c := pod.Spec.Containers[i]
+		if c.Name == containerName {
+			for j, env := range c.Env {
+				if env.Name == key {
+					pod.Spec.Containers[i].Env[j].Value = value
+					return
+				}
+			}
+			pod.Spec.Containers[i].Env = append(c.Env, corev1.EnvVar{Name: key, Value: value})
+		}
+	}
+}
+
 // unregisterRunner unregisters the runner from GitHub Actions by name.
 //
 // This function returns:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -220,7 +220,7 @@ func initTestEnv(t *testing.T) *env {
 	e.testOrgRepo = testing.Getenv(t, "TEST_ORG_REPO", "")
 	e.testEnterprise = testing.Getenv(t, "TEST_ENTERPRISE")
 	e.testJobs = createTestJobs(id, testResultCMNamePrefix, 100)
-	ephemeral, _ := strconv.ParseBool(testing.Getenv(t, "TEST_FEATURE_FLAG_EPHEMERAL"))
+	ephemeral, _ := strconv.ParseBool(testing.Getenv(t, "TEST_FEATURE_FLAG_EPHEMERAL", ""))
 	e.featureFlagEphemeral = ephemeral
 	e.scaleDownDelaySecondsAfterScaleOut, _ = strconv.ParseInt(testing.Getenv(t, "TEST_RUNNER_SCALE_DOWN_DELAY_SECONDS_AFTER_SCALE_OUT", "10"), 10, 32)
 	e.minReplicas, _ = strconv.ParseInt(testing.Getenv(t, "TEST_RUNNER_MIN_REPLICAS", "1"), 10, 32)


### PR DESCRIPTION
Every runner is now `--ephemeral` by default.

Note that this works by ARC setting the `RUNNER_FEATURE_FLAG_EPHEMERAL` envvar to `true` by default. Previously you had to explicitly set it to `true` otherwise the runner was passed `--once` which is known to various race conditions.

It's worth noting that the very confusing and related configuration, `ephemeral: true`, which creates `--once` runners instead of static(or persistent) runners had been the default since many months ago. So, this should be the only change needed to make every runner ephemeral without any explicit configuration.

You can still fall back to static(persistent) runners by setting `ephemeral: false`, and to `--once` runners by setting `RUNNER_FEATURE_FLAG_EPHEMERAL` to `"false"`. But I don't think there're many reasons to do so.

Ref https://github.com/actions-runner-controller/actions-runner-controller/issues/1189