### PR TITLE
Fix RunnerDeployment to be able to finish rollout

### DIFF
--- a/controllers/runner_pod_owner.go
+++ b/controllers/runner_pod_owner.go
@@ -434,7 +434,6 @@ func syncRunnerPodsOwners(ctx context.Context, c client.Client, log logr.Logger,
 					log.V(2).Info("BUG: Redundant object was already annotated")
 				}
 			}
-			return nil, err
 		} else if retained > newDesiredReplicas {
 			log.V(2).Info("Waiting sync before scale down", "retained", retained, "newDesiredReplicas", newDesiredReplicas)
 


### PR DESCRIPTION
I found that #1179 was unable to finish rollout of an RunnerDeployment update(like runner env update). It was able to create a new RunnerReplicaSet with the desired spec, but unable to tear down the older ones. This fixes that.