### PR TITLE
docs: various changes in preparation for 0.22.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,7 +1278,7 @@ spec:
         # Configure runner with --ephemeral instead of --once flag
         # WARNING | THIS ENV VAR IS DEPRECATED AND WILL BE REMOVED
         # IN A FUTURE VERSION OF ARC. IN 0.22.0 ARC SETS --ephemeral VIA 
-        # THIS THE CONTROLLER SETTING THIS ENV VAR ON POD CREATION.
+        # THE CONTROLLER SETTING THIS ENV VAR ON POD CREATION.
         # THIS ENV VAR WILL BE REMOVED, SEE ISSUE #1196 FOR DETAILS
         - name: RUNNER_FEATURE_FLAG_EPHEMERAL
           value: "true"

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Subsequent to this, install the custom resource definitions and actions-runner-c
 **Kubectl Deployment:**
 
 ```shell
-# REPLACE "v0.20.2" with the version you wish to deploy
-kubectl apply -f https://github.com/actions-runner-controller/actions-runner-controller/releases/download/v0.20.2/actions-runner-controller.yaml
+# REPLACE "v0.21.1" with the version you wish to deploy
+kubectl apply -f https://github.com/actions-runner-controller/actions-runner-controller/releases/download/v0.21.1/actions-runner-controller.yaml
 ```
 
 **Helm Deployment:**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ToC:
   - [Organization Runners](#organization-runners)
   - [Enterprise Runners](#enterprise-runners)
   - [RunnerDeployments](#runnerdeployments)
-  - [Stateful Runners](#stateful-runners)
+  - [RunnerSets](#runnersets)
   - [Autoscaling](#autoscaling)
     - [Anti-Flapping Configuration](#anti-flapping-configuration)
     - [Pull Driven Scaling](#pull-driven-scaling)
@@ -361,11 +361,11 @@ example-runnerdeploy2475h595fr   mumoshu/actions-runner-controller-ci   Running
 example-runnerdeploy2475ht2qbr   mumoshu/actions-runner-controller-ci   Running
 ```
 
-  ### Stateful Runners
+  ### RunnerSets
 
 > This feature requires controller version => [v0.20.0](https://github.com/actions-runner-controller/actions-runner-controller/releases/tag/v0.20.0)
 
-For scenarios where you require the advantages of a StatefulSet, for example persistent storage, ARC implements a runner based on Kubernete's StaefulSets, the RunnerSet.
+For scenarios where you require the advantages of a `StatefulSet`, for example persistent storage, ARC implements a runner based on Kubernete's StatefulSets, the RunnerSet.
 
 A basic `RunnerSet` would look like this:
 

--- a/charts/actions-runner-controller/docs/UPGRADING.md
+++ b/charts/actions-runner-controller/docs/UPGRADING.md
@@ -22,11 +22,11 @@ Due to the above you can't just do a `helm upgrade` to release the latest versio
 
 ```shell
  # REMEMBER TO UPDATE THE CHART_VERSION TO RELEVANT CHART VERISON!!!!
-CHART_VERSION=0.14.0
+CHART_VERSION=0.16.1
 
 curl -L https://github.com/actions-runner-controller/actions-runner-controller/releases/download/actions-runner-controller-${CHART_VERSION}/actions-runner-controller-${CHART_VERSION}.tgz | tar zxv --strip 1 actions-runner-controller/crds
 
-kubectl apply -f crds/
+kubectl replace -f crds/
 ```
 
 2. Upgrade the Helm release

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -165,7 +165,8 @@ fi
 args=()
 if [ "${RUNNER_FEATURE_FLAG_EPHEMERAL:-}" != "true" -a "${RUNNER_EPHEMERAL}" != "false" ]; then
   args+=(--once)
-  echo "Passing --once to runsvc.sh to enable the legacy ephemeral runner."
+  echo "[WARNING] Passing --once is deprecated and will be removed as an option from the image and ARC at the release of 0.24.0."
+  echo "[WARNING] Upgrade to GHES => 3.3 to continue using actions-runner-controller. If you are using github.com ignore this warning."
 fi
 
 unset RUNNER_NAME RUNNER_REPO RUNNER_TOKEN


### PR DESCRIPTION
- Move RunnerSets to a more predominant location in the docs
- Clean up  a few bits
- Highlight the deprecation and removal timeline for the `--once` flag
- Renamed ephemeral runners section to something more logical (persistent runners). Static runners were an option however the word static is awkward as it's sort of tied up with autoscaling and the `Runner` kind so Persistent was chosen instead.
- Update upgrade docs to use `replace` instead of `apply`