### PR TITLE
Use container name to detect runner container in Pod

### DIFF
--- a/controllers/runner_pod_controller.go
+++ b/controllers/runner_pod_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -64,9 +65,19 @@ func (r *RunnerPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	var envvars []corev1.EnvVar
+	for _, container := range runnerPod.Spec.Containers {
+		if container.Name == "runner" {
+			envvars = container.Env
+		}
+	}
+
+	if len(envvars) == 0 {
+		return ctrl.Result{}, errors.New("Could not determine env vars for runner Pod")
+	}
+
 	var enterprise, org, repo string
 
-	envvars := runnerPod.Spec.Containers[0].Env
 	for _, e := range envvars {
 		switch e.Name {
 		case EnvVarEnterprise:


### PR DESCRIPTION
This switches to instead of using index which is easily breakable if using the sidecar pattern to using the name of "runner" instead ot determine the container inside of the runner Pod.

EDIT by @mumoshu: Note that the issue reproduces only when you use a mutating webhook other than ARC's own to inject arbitrary container at the index 0 of a runner pod.