### PR TITLE
refactor(runner/entrypoint): check for externalstmp

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -151,9 +151,11 @@ cat .runner
 #     https://api.github.com/repos/USER/REPO/actions/runners/171
 
 if [ -z "${UNITTEST:-}" ]; then
-  mkdir ./externals
+  mkdir -p ./externals
   # Hack due to the DinD volumes
-  mv ./externalstmp/* ./externals/
+  if [ -d ./externalstmp ]; then
+    mv ./externalstmp/* ./externals/
+  fi
 fi
 
 args=()

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -153,9 +153,7 @@ cat .runner
 if [ -z "${UNITTEST:-}" ]; then
   mkdir -p ./externals
   # Hack due to the DinD volumes
-  if [ -d ./externalstmp ]; then
-    mv ./externalstmp/* ./externals/
-  fi
+  mv ./externalstmp/* ./externals/
 fi
 
 args=()


### PR DESCRIPTION
This fixes these annoying messages in the runner logs:
```
# Authentication
√ Connected to GitHub
# Runner Registration
√ Runner successfully added
√ Runner connection is good
# Runner settings
√ Settings Saved.
Runner successfully configured.
﻿{
  "agentId": 123,
  "agentName": "runner-deployment-123",
  "poolId": 1,
  "poolName": "Default",
  "ephemeral": true,
  "serverUrl": "https://pipelines.actions.githubusercontent.com/123",
  "gitHubUrl": "https://github.com/123",
  "workFolder": "/runner/_work"
mkdir: cannot create directory './externals': File exists
mv: cannot stat './externalstmp/*': No such file or directory
}
√ Connected to GitHub

Current runner version: '2.289.1'
2022-03-27 11:04:41Z: Listening for Jobs
```

Emphasis:

```
mkdir: cannot create directory './externals': File exists
mv: cannot stat './externalstmp/*': No such file or directory
```
