### PR TITLE
Fix runner pod to be cleaned up earlier regardless of the sync period

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -181,6 +181,9 @@ func (rs *RunnerSpec) ValidateRepository() error {
 
 // RunnerStatus defines the observed state of Runner
 type RunnerStatus struct {
+	// Turns true only if the runner pod is ready.
+	// +optional
+	Ready bool `json:"ready"`
 	// +optional
 	Registration RunnerStatusRegistration `json:"registration"`
 	// +optional

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -5126,6 +5126,9 @@ spec:
                   type: string
                 phase:
                   type: string
+                ready:
+                  description: Turns true only if the runner pod is ready.
+                  type: boolean
                 reason:
                   type: string
                 registration:

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -5126,6 +5126,9 @@ spec:
                   type: string
                 phase:
                   type: string
+                ready:
+                  description: Turns true only if the runner pod is ready.
+                  type: boolean
                 reason:
                   type: string
                 registration:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,13 +37,23 @@ var (
 		},
 		{
 			Dockerfile: "../../runner/Dockerfile",
-			Args:       []testing.BuildArg{},
-			Image:      runnerImage,
+			Args: []testing.BuildArg{
+				{
+					Name:  "RUNNER_VERSION",
+					Value: "2.289.2",
+				},
+			},
+			Image: runnerImage,
 		},
 		{
 			Dockerfile: "../../runner/Dockerfile.dindrunner",
-			Args:       []testing.BuildArg{},
-			Image:      runnerDindImage,
+			Args: []testing.BuildArg{
+				{
+					Name:  "RUNNER_VERSION",
+					Value: "2.289.2",
+				},
+			},
+			Image: runnerDindImage,
 		},
 	}
 
@@ -58,7 +68,7 @@ var (
 	}
 
 	commonScriptEnv = []string{
-		"SYNC_PERIOD=" + "10s",
+		"SYNC_PERIOD=" + "30m",
 		"NAME=" + controllerImageRepo,
 		"VERSION=" + controllerImageTag,
 		"RUNNER_TAG=" + runnerImageTag,


### PR DESCRIPTION
This is intended to be the minimum addition to the runner status to help the runner replicaset controller to notice that the runner pod is NotReady(due to whatever reasons like the runner container that is running an ephemeral runner completely successfully).

The runner replicaset controller is already able to terminate a NotReady runner and create a new runner as a replacement (if needed). That behavior, in combination with this fix, seems to fix the issue reported in #1291 for me.

Ref #1291