### PR TITLE
chore: bump chart to latest

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.1
+version: 0.17.2
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.22.1
+appVersion: 0.22.2
 
 home: https://github.com/actions-runner-controller/actions-runner-controller
 

--- a/charts/actions-runner-controller/docs/UPGRADING.md
+++ b/charts/actions-runner-controller/docs/UPGRADING.md
@@ -18,7 +18,7 @@ Due to the above you can't just do a `helm upgrade` to release the latest versio
 
 ## Steps
 
-1. Upgrade CRDs
+1. Upgrade CRDs, this isn't optional, the CRDs you are using must be those that correspond with the version of the controller you are installing
 
 ```shell
 # REMEMBER TO UPDATE THE CHART_VERSION TO RELEVANT CHART VERISON!!!!


### PR DESCRIPTION
Bumps the chart version along with the controller version.
We bump the patch number for the chart as the release for the controller is a patch release.
That's the same handling as we've done in the previous version https://github.com/actions-runner-controller/actions-runner-controller/commit/ecc8b4472abbc14f5695607eff6528c3b5165d6e

As always, be sure to upgrade CRDs before updating the controller version!
Otherwise it can break in interesting ways.