### PR TITLE
Pin go version to the known working version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,8 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.17.7'
+        go-version: '1.17.7'
+        check-latest: false
     - run: go version
     - uses: actions/cache@v3
       with:


### PR DESCRIPTION
Add check-latest to false (for clarity) - default is false now but in case it changes in the future to prevent unexpected behaviours