### PR TITLE
refactor(runner/entrypoint): don't mv externalstmp if it's not there

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -150,9 +150,9 @@ cat .runner
 #     -H "Authorization: bearer ${GITHUB_TOKEN}"
 #     https://api.github.com/repos/USER/REPO/actions/runners/171
 
-if [ -z "${UNITTEST:-}" ]; then
+# Hack due to the DinD volumes
+if [ -z "${UNITTEST:-}" ] && [ -e ./externalstmp ]; then
   mkdir -p ./externals
-  # Hack due to the DinD volumes
   mv ./externalstmp/* ./externals/
 fi
 


### PR DESCRIPTION
This is a follow-up to #1277, which was edited before landing causing the issue
to not be fixed.

Essentially, we don't want to try moving `./externalstmp` unless it actually
exists, otherwise we get spurious error messages on the `mv` call.

This just adds that check.
