### PR TITLE
chore: bump chart to latest

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.2
+version: 0.17.3
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.22.2
+appVersion: 0.22.3
 
 home: https://github.com/actions-runner-controller/actions-runner-controller
 


### PR DESCRIPTION
Bumps the chart version along with the controller version.
We bump the patch number for the chart as the release for the controller is a patch release.
That's the same handling as we've done in the previous version https://github.com/actions-runner-controller/actions-runner-controller/commit/ecc8b4472abbc14f5695607eff6528c3b5165d6e and #1300

As always, be sure to upgrade CRDs before updating the controller version!
Otherwise it can break in interesting ways.