### PR TITLE
refactor: remove legacy controller Docker build

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,8 @@
     },
     {
       "fileMatch": [
-        "runner/Makefile"
+        "runner/Makefile",
+        "Makefile"
       ],
       "matchStrings": ["RUNNER_VERSION \\?= +(?<currentValue>.*?)\\n"],
       "depNameTemplate": "actions/runner",

--- a/.github/workflows/runners.yml
+++ b/.github/workflows/runners.yml
@@ -11,6 +11,7 @@ on:
       - 'master'
     paths:
       - 'runner/**'
+      - '!runner/Makefile'
       - .github/workflows/runners.yml
       - '!**.md'
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ else
 endif
 DOCKER_USER ?= $(shell echo ${NAME} | cut -d / -f1)
 VERSION ?= latest
+RUNNER_VERSION ?= 2.290.1
 TARGETPLATFORM ?= $(shell arch)
 RUNNER_NAME ?= ${DOCKER_USER}/actions-runner
 RUNNER_TAG  ?= ${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -109,13 +109,9 @@ vet:
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
-# Build the docker image
-docker-build:
-	docker build -t ${NAME}:${VERSION} .
-	docker build -t ${RUNNER_NAME}:${RUNNER_TAG} --build-arg TARGETPLATFORM=${TARGETPLATFORM} runner
-
 docker-buildx:
-	export DOCKER_CLI_EXPERIMENTAL=enabled
+	export DOCKER_CLI_EXPERIMENTAL=enabled ;\
+    export DOCKER_BUILDKIT=1
 	@if ! docker buildx ls | grep -q container-builder; then\
 		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ generate: controller-gen
 
 docker-buildx:
 	export DOCKER_CLI_EXPERIMENTAL=enabled ;\
-    export DOCKER_BUILDKIT=1
+	export DOCKER_BUILDKIT=1
 	@if ! docker buildx ls | grep -q container-builder; then\
 		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
 	fi

--- a/runner/Makefile
+++ b/runner/Makefile
@@ -33,7 +33,8 @@ docker-push-ubuntu:
 	docker push ${DIND_RUNNER_NAME}:${TAG}
 
 docker-buildx-ubuntu:
-	export DOCKER_CLI_EXPERIMENTAL=enabled
+	export DOCKER_CLI_EXPERIMENTAL=enabled ;\
+    export DOCKER_BUILDKIT=1
 	@if ! docker buildx ls | grep -q container-builder; then\
 		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
 	fi


### PR DESCRIPTION
Ref https://github.com/actions-runner-controller/actions-runner-controller/issues/1357

Changes: 
1. Removed the non-buildx target
2. I also enabled buildkit in the Makefile as I don't see a reason not to use it? It's off by default https://github.com/moby/moby/issues/40379
3. Added the RUNNER_VERSION the same as the runner Makefile for consistency and added it to Renovate