### PR TITLE
doc: Removed the default `githubEvent: {}` requiring a event to be defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,8 @@ spec:
     # Uncomment the below in case the target is not RunnerDeployment but RunnerSet
     #kind: RunnerSet
   scaleUpTriggers:
-  - githubEvent: {}
+  - githubEvent:
+      workflowJob: {}
     duration: "30m"
 ```
 


### PR DESCRIPTION
Fixes #1358 