### PR TITLE
Remove the default `githubEvent: {}` requiring a event to be defined

### DIFF
--- a/controllers/horizontal_runner_autoscaler_webhook_test.go
+++ b/controllers/horizontal_runner_autoscaler_webhook_test.go
@@ -138,6 +138,13 @@ func TestWebhookWorkflowJob(t *testing.T) {
 				ScaleTargetRef: actionsv1alpha1.ScaleTargetRef{
 					Name: "test-name",
 				},
+				ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
+					{
+						GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+							WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+						},
+					},
+				},
 			},
 		}
 
@@ -176,6 +183,13 @@ func TestWebhookWorkflowJob(t *testing.T) {
 			Spec: actionsv1alpha1.HorizontalRunnerAutoscalerSpec{
 				ScaleTargetRef: actionsv1alpha1.ScaleTargetRef{
 					Name: "test-name",
+				},
+				ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
+					{
+						GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+							WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+						},
+					},
 				},
 			},
 		}
@@ -216,6 +230,13 @@ func TestWebhookWorkflowJob(t *testing.T) {
 			Spec: actionsv1alpha1.HorizontalRunnerAutoscalerSpec{
 				ScaleTargetRef: actionsv1alpha1.ScaleTargetRef{
 					Name: "test-name",
+				},
+				ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
+					{
+						GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+							WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+						},
+					},
 				},
 			},
 		}
@@ -277,6 +298,13 @@ func TestWebhookWorkflowJobWithSelfHostedLabel(t *testing.T) {
 				ScaleTargetRef: actionsv1alpha1.ScaleTargetRef{
 					Name: "test-name",
 				},
+				ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
+					{
+						GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+							WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+						},
+					},
+				},
 			},
 		}
 
@@ -315,6 +343,13 @@ func TestWebhookWorkflowJobWithSelfHostedLabel(t *testing.T) {
 			Spec: actionsv1alpha1.HorizontalRunnerAutoscalerSpec{
 				ScaleTargetRef: actionsv1alpha1.ScaleTargetRef{
 					Name: "test-name",
+				},
+				ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
+					{
+						GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+							WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+						},
+					},
 				},
 			},
 		}
@@ -355,6 +390,13 @@ func TestWebhookWorkflowJobWithSelfHostedLabel(t *testing.T) {
 			Spec: actionsv1alpha1.HorizontalRunnerAutoscalerSpec{
 				ScaleTargetRef: actionsv1alpha1.ScaleTargetRef{
 					Name: "test-name",
+				},
+				ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
+					{
+						GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+							WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+						},
+					},
 				},
 			},
 		}

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -1228,9 +1228,11 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 						ScaleDownDelaySecondsAfterScaleUp: intPtr(1),
 						ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
 							{
-								GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{},
-								Amount:      1,
-								Duration:    metav1.Duration{Duration: time.Minute},
+								GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+									WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+								},
+								Amount:   1,
+								Duration: metav1.Duration{Duration: time.Minute},
 							},
 						},
 					},
@@ -1310,9 +1312,11 @@ var _ = Context("INTEGRATION: Inside of a new namespace", func() {
 						ScaleDownDelaySecondsAfterScaleUp: intPtr(1),
 						ScaleUpTriggers: []actionsv1alpha1.ScaleUpTrigger{
 							{
-								GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{},
-								Amount:      1,
-								Duration:    metav1.Duration{Duration: time.Minute},
+								GitHubEvent: &actionsv1alpha1.GitHubEventScaleUpTriggerSpec{
+									WorkflowJob: &actionsv1alpha1.WorkflowJobSpec{},
+								},
+								Amount:   1,
+								Duration: metav1.Duration{Duration: time.Minute},
 							},
 						},
 					},


### PR DESCRIPTION
#922 enahnced the API to accept `workflowJob: {}` under the githubEvent field. But we had not enhanced the autoscaler code to actually read it to toggle the workflow-job-based scaling. This adds that.

Ref #1358

See also #1361