### PR TITLE
Runner Entrypoint: fix daemon.json

### DIFF
--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -20,7 +20,7 @@ function wait_for_process () {
 sudo /bin/bash <<SCRIPT
 mkdir -p /etc/docker
 
-echo "{}" > /etc/docker/daemon.json
+[ ! -f /etc/docker/daemon.json ] && echo "{}" > /etc/docker/daemon.json
 
 if [ -n "${MTU}" ]; then
 jq ".\"mtu\" = ${MTU}" /etc/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /etc/docker/daemon.json

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -20,7 +20,9 @@ function wait_for_process () {
 sudo /bin/bash <<SCRIPT
 mkdir -p /etc/docker
 
-[ ! -f /etc/docker/daemon.json ] && echo "{}" > /etc/docker/daemon.json
+if [ ! -f /etc/docker/daemon.json ]; then
+  echo "{}" > /etc/docker/daemon.json
+fi
 
 if [ -n "${MTU}" ]; then
 jq ".\"mtu\" = ${MTU}" /etc/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /etc/docker/daemon.json


### PR DESCRIPTION
Do not overwrite daemon.json if it already exists.
Usage: custom images, which are using a public image as source.