### PR TITLE
Pin GitHub Actions workflow dependencies by hash and restrict permissions

### DIFF
--- a/.github/workflows/on-push-lint-charts.yml
+++ b/.github/workflows/on-push-lint-charts.yml
@@ -12,18 +12,21 @@ env:
   KUBE_SCORE_VERSION: 1.10.0
   HELM_VERSION: v3.8.0
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     name: Lint Chart
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v2.1
+        uses: azure/setup-helm@217bf70cbd2e930ba2e81ba7e1de2f7faecc42ba
         with:
           version: ${{ env.HELM_VERSION }}
 
@@ -44,12 +47,12 @@ jobs:
               --enable-optional-test container-security-context-readonlyrootfilesystem
 
       # python is a requirement for the chart-testing action below (supports yamllint among other tests)
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
+        uses: helm/chart-testing-action@62a185010be4cb08459f7acb19f37927235d5cf3
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -63,7 +66,7 @@ jobs:
         run: ct lint --config charts/.ci/ct-config.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478
         if: steps.list-changed.outputs.changed == 'true'
 
       # We need cert-manager already installed in the cluster because we assume the CRDs exist

--- a/.github/workflows/on-push-master-publish-chart.yml
+++ b/.github/workflows/on-push-master-publish-chart.yml
@@ -15,6 +15,9 @@ env:
   KUBE_SCORE_VERSION: 1.10.0
   HELM_VERSION: v3.8.0
 
+permissions:
+  contents: read
+
 jobs:
   lint-chart:
     runs-on: ubuntu-latest
@@ -23,12 +26,12 @@ jobs:
       publish-chart: ${{ steps.publish-chart-step.outputs.publish }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v2.1
+        uses: azure/setup-helm@217bf70cbd2e930ba2e81ba7e1de2f7faecc42ba
         with:
           version: ${{ env.HELM_VERSION }}
 
@@ -49,12 +52,12 @@ jobs:
               --enable-optional-test container-security-context-readonlyrootfilesystem
 
       # python is a requirement for the chart-testing action below (supports yamllint among other tests)
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
+        uses: helm/chart-testing-action@62a185010be4cb08459f7acb19f37927235d5cf3
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -68,7 +71,7 @@ jobs:
         run: ct lint --config charts/.ci/ct-config.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478
         if: steps.list-changed.outputs.changed == 'true'
 
       # We need cert-manager already installed in the cluster because we assume the CRDs exist
@@ -97,6 +100,8 @@ jobs:
           fi
 
   publish-chart:
+    permissions:
+      contents: write  # for helm/chart-releaser-action to push chart release and create a release
     if: needs.lint-chart.outputs.publish-chart == 'true'
     needs: lint-chart
     runs-on: ubuntu-latest
@@ -104,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
         with:
           fetch-depth: 0
 
@@ -114,7 +119,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@fc23f249f75decd5edf254c6b4401532cef093c3
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
         run: echo ::set-output name=sha_short::${GITHUB_SHA::7}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab
         with:
           go-version: '1.17.7'
 
@@ -42,22 +42,22 @@ jobs:
         run: make github-release
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
         with:
           version: latest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/runners.yml
+++ b/.github/workflows/runners.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Setup Docker Environment
         id: vars
@@ -54,7 +54,7 @@ jobs:
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Versioned Tags
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: ./runner
           file: ./runner/${{ matrix.dockerfile }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,11 +4,17 @@ on:
     # 01:30 every day
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@428b0ed64d74596742200dc98805bb90f39ef9f0
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           # turn off stale for both issues and PRs

--- a/.github/workflows/test-entrypoint.yaml
+++ b/.github/workflows/test-entrypoint.yaml
@@ -9,13 +9,16 @@ on:
       - 'test/entrypoint/**'
       - '!**.md'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Test entrypoint
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
     - name: Run unit tests for entrypoint.sh
       run: |
         make acceptance/runner/entrypoint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,19 +15,22 @@ on:
       - '**.md'
       - '.gitignore'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Test
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+      uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+    - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab
       with:
         go-version: '1.17.7'
         check-latest: false
     - run: go version
-    - uses: actions/cache@v3
+    - uses: actions/cache@730dc31003a72af3c3b4bf51268c167ad4c67ad6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -14,6 +14,9 @@ on:
       - "**.md"
       - ".gitignore"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,19 +25,19 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
         with:
           version: latest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -42,7 +45,7 @@ jobs:
       # Considered unstable builds
       # See Issue #285, PR #286, and PR #323 for more information
       - name: Build and Push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
as recommended in https://github.com/ossf/scorecard/blob/5758364c82f7fc72b256f9a8cfc89dc550d7dd66/docs/checks.md#pinned-dependencies and https://github.com/ossf/scorecard/blob/5758364c82f7fc72b256f9a8cfc89dc550d7dd66/docs/checks.md#token-permissions

The permission changes should be fine as it only makes the ones that had quite restricted default permissions to explicitly have contents:read permission only.

Regarding the version pinning, I suppose renovate would handle updates for deps pinned with commit IDs. If it turned out to not work, I'll explore ways to deal with it, like updating renovate config somehow or even consider migrating to dependabot.

Ref #1298