### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+##  Sponsoring the project
+
+This project is maintained by a small team of two and therefore lacks the resource to provide security fixes in a timely manner.
+
+If you have important business(es) that relis on this project, please consider sponsoring the project so that manitainer(s) can commit to provide such service.
+
+Please refer to https://github.com/sponsors/actions-runner-controller for available tiers.
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.23.0  | :white_check_mark: |
+| < 0.23.0| :x:                |
+
+## Reporting a Vulnerability
+
+To report a security issue, please email ykuoka+arcsecurity(at)gmail.com with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+A maintainer will try to respond within 5 working days. If the issue is confirmed as a vulnerability, a Security Advisory will be opened. This project tries to follow a 90 day disclosure timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 This project is maintained by a small team of two and therefore lacks the resource to provide security fixes in a timely manner.
 
-If you have important business(es) that relis on this project, please consider sponsoring the project so that manitainer(s) can commit to provide such service.
+If you have important business(es) that relies on this project, please consider sponsoring the project so that the maintainer(s) can commit to providing such service.
 
 Please refer to https://github.com/sponsors/actions-runner-controller for available tiers.
 


### PR DESCRIPTION
According to https://github.com/ossf/scorecard/blob/5758364c82f7fc72b256f9a8cfc89dc550d7dd66/docs/checks.md#security-policy

![CleanShot 2022-05-10 at 20 50 41@2x](https://user-images.githubusercontent.com/22009/167621971-6cc7367b-b314-4bb1-92d4-75ef762c05eb.png)

The policy is based on https://github.com/ossf/oss-vulnerability-guide/blob/main/templates/security_policies/github_security_policy.md, altered to make it more maintainer-friendly for sustainability.

Ref #1298