### PR TITLE
ci: fix permisions

### DIFF
--- a/.github/actions/setup-docker-environment/action.yaml
+++ b/.github/actions/setup-docker-environment/action.yaml
@@ -37,7 +37,6 @@ runs:
         version: latest
 
     - name: Login to DockerHub
-      if: ${{ github.ref == 'master' && github.event.pull_request.merged == true }}
       uses: docker/login-action@v2
       with:
         username: ${{ inputs.username }}
@@ -45,7 +44,6 @@ runs:
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
-      if: ${{ github.ref == 'master' && github.event.pull_request.merged == true }}
       with:
         registry: ghcr.io
         username: ${{ inputs.ghcr_username }}

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -19,8 +19,10 @@ on:
       - 'LICENSE'
       - 'Makefile'
 
+# https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
 permissions:
   contents: read
+  actions: write
 
 jobs:
   canary-build:

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -22,7 +22,7 @@ on:
 # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
 permissions:
   contents: read
-  actions: write
+  packages: write  
 
 jobs:
   canary-build:

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -32,4 +32,3 @@ func Test_filterLabels(t *testing.T) {
 		})
 	}
 }
-

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -32,3 +32,4 @@ func Test_filterLabels(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
The canary pipeline currently fails with `error: failed to solve: server message: insufficient_scope: authorization failed`. I think we need additional permissions. It's not clear which permission relates to caching but this looked like the most likely one.

EDIT Added the write permission for packages seen as we require a login to GitHub Packages as part of the composite action, we are planning on publish all images to GitHub Packages in addition to Dockerhub so it's needed for a subsequent PR anyway. We also weren't logging in due to conditionals on the composite action. This action is now used ot set-up Docker everywhere and so are now a problem.