### PR TITLE
chore: suggest gist first

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -133,6 +133,8 @@ body:
     description: "NEVER EVER OMIT THIS! Include logs from `actions-runner-controller`'s controller-manager pod"
     render: shell
     placeholder: |
+      PROVIDE THE LOGS VIA A GIST LINK (https://gist.github.com/), NOT DIRECTLY IN THIS TEXT AREA
+      
       To grab controller logs:
 
       # Set NS according to your setup
@@ -142,8 +144,6 @@ body:
       kubectl -n $NS get po
 
       kubectl -n $NS logs $POD_NAME > arc.log
-
-      Upload it to e.g. https://gist.github.com/ and paste the link to it here.
   validations:
     required: true
 - type: textarea
@@ -153,6 +153,8 @@ body:
     description: "Include logs from runner pod(s)"
     render: shell
     placeholder: |
+      PROVIDE THE LOGS VIA A GIST LINK (https://gist.github.com/), NOT DIRECTLY IN THIS TEXT AREA
+      
       To grab the runner pod logs:
 
       # Set NS according to your setup. It should match your RunnerDeployment's metadata.namespace.
@@ -163,8 +165,6 @@ body:
 
       kubectl -n $NS logs $POD_NAME -c runner > runnerpod_runner.log
       kubectl -n $NS logs $POD_NAME -c docker > runnerpod_docker.log
-
-      Upload it to e.g. https://gist.github.com/ and paste the link to it here.
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Ref https://github.com/actions-runner-controller/actions-runner-controller/issues/1533

<img width="880" alt="image" src="https://user-images.githubusercontent.com/15716903/173794257-f2e1d5a3-4502-4d3b-be00-d4c3efaba270.png">

The default text area cuts off the existing instructions to provide the logs via a Gist. Moved this to the top so people see it making them more likely to provide them via a gist and not have issues when creating bugs by hitting the max issue length