### PR TITLE
Fix: Match Ingress API Version correctly.

### DIFF
--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.githubWebhookServer.ingress.enabled -}}
 {{- $fullName := include "actions-runner-controller-github-webhook-server.fullname" . -}}
 {{- $svcPort := (index .Values.githubWebhookServer.service.ports 0).port -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
-{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1/Ingress" }}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
@@ -42,11 +42,11 @@ spec:
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                name: {{ $fullName }}
                port:


### PR DESCRIPTION
Using version 1.17 I run into rendering issues. 
```
Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "actions-runner-controller-github-webhook-server" namespace: "github-runners" from "": no matches for kind "Ingress" in version "networking.k8s.io/v1"
  ensure CRDs are installed first
```

The conditional managing this only looks at API versions, which can have several kinds, so the condition would match incorrectly. 

Here is an example of how others have [solved this](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/templates/ingress.yaml#L5-L11) 
