### PR TITLE
ci: runners trigger on push

### DIFF
--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -13,8 +13,8 @@ on:
       - '!runner/Makefile'
       - '.github/workflows/runners.yaml'
       - '!**.md'
-  # We must do a release from a push trigger instead of a close pul requset (a merge) so 
-  # GitHub Secrets are available to the workflow run
+  # We must do a trigger on a push: instead of a types: closed so GitHub Secrets 
+  # are available to the workflow run
   push:
     branches:
       - 'master'

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -13,6 +13,8 @@ on:
       - '!runner/Makefile'
       - '.github/workflows/runners.yaml'
       - '!**.md'
+  # We must do a release from a push trigger instead of a close pul requset (a merge) so 
+  # GitHub Secrets are available to the workflow run
   push:
     branches:
       - 'master'

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -6,7 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - closed
     branches:
       - 'master'
     paths:
@@ -14,6 +13,9 @@ on:
       - '!runner/Makefile'
       - '.github/workflows/runners.yaml'
       - '!**.md'
+  push:
+    branches:
+      - 'master'
 
 env:
   RUNNER_VERSION: 2.293.0


### PR DESCRIPTION
GitHub secrets are not available in a pipeline run when the run is triggered by a pull request has been triggered from someone outside the organisation. 

GitHub secrets are available from a push trigger. 

Updating our runner CI when releasing a new runner to trigger from a push rather than a closed pull request (i.e. a merged pull request). This will allow us to do releases of the runners without the need for someone in the organisation to also make a change.