### PR TITLE
Add terraform deployment method to contrib/examples

### DIFF
--- a/contrib/examples/terraform/actions-runner-controller.tf
+++ b/contrib/examples/terraform/actions-runner-controller.tf
@@ -1,0 +1,60 @@
+### Deploying with exposed github token
+
+resource "kubernetes_namespace" "arc" {
+ metadata {
+   name = "actions-runner-system"
+ }
+}
+
+resource "helm_release" "actions-runner-controller" {
+ count            = var.actions_runner_controller
+ name             = "actions-runner-controller"
+ namespace        = kubernetes_namespace.arc.metadata[0].name
+ create_namespace = true
+ chart            = "actions-runner-controller"
+ repository       = "https://actions-runner-controller.github.io/actions-runner-controller"
+ version          = "v0.19.1"
+ values = [<<EOF
+   authSecret:
+     github_token: hdjasyd7das7d7asd78as87dasdas
+     create: true
+ EOF
+ ]
+ depends_on = [resource.helm_release.cm]
+}
+
+#============================================================================================================================================
+### Deploying with secret manager like AWS's
+# make sure the name of the secret is the same as secret_id
+
+data "aws_secretsmanager_secret_version" "creds" {
+  secret_id = "github/access_token"
+}
+locals {
+  github_creds = jsondecode(
+    data.aws_secretsmanager_secret_version.creds.secret_string
+  )
+}
+
+resource "kubernetes_namespace" "arc" {
+  metadata {
+    name = "actions-runner-system"
+  }
+}
+
+resource "helm_release" "actions-runner-controller" {
+  count            = var.actions_runner_controller
+  name             = "actions-runner-controller"
+  namespace        = kubernetes_namespace.arc.metadata[0].name
+  create_namespace = true
+  chart            = "actions-runner-controller"
+  repository       = "https://actions-runner-controller.github.io/actions-runner-controller"
+  version          = "v0.19.1"
+  values = [<<EOF
+    authSecret:
+      github_token: ${local.github_creds.github_token}
+      create: true
+  EOF
+  ]
+  depends_on = [resource.helm_release.cm]
+}

--- a/contrib/examples/terraform/cert-manager.tf
+++ b/contrib/examples/terraform/cert-manager.tf
@@ -1,0 +1,27 @@
+# cert-manager must be deployed or included via the deployment process
+
+resource "kubernetes_namespace" "cm" {
+  metadata {
+    name = "cert-manager"
+  }
+}
+
+resource "helm_release" "cm" {
+  count            = var.actions_runner_controller
+  name             = "cm"
+  namespace        = kubernetes_namespace.cm.metadata[0].name
+  create_namespace = true
+  chart            = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  version          = "v1.8.0"
+  values = [<<EOF
+    global:
+      podSecurityPolicy:
+        enabled: true
+        useAppArmor: true
+    prometheus:
+      enabled: false
+    installCRDs: true
+  EOF
+  ]
+}


### PR DESCRIPTION
# Context

As the chart is a controller it should always be in the cluster if you are planning to use self-host runners, regardless if there are any running atm. It will save cluster's state with it deployed successfully once, avoiding issues in the future. uninstalling is also as simple as removing those files from your terraform modules and applying again.