### PR TITLE
Fix startup.sh of runner from exiting `Bad file descriptor` error

### DIFF
--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -27,7 +27,7 @@ if [[ $MTU ]]; then
   # session.
   if [[ $MTU =~ ^[1-9][0-9]*$ ]]; then
     # See https://docs.docker.com/engine/security/rootless/
-    sudo tee -a $dockerd_supervisor_config_path 1>&- <<<"environment=DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=$MTU"
+    sudo tee -a $dockerd_supervisor_config_path 1>/dev/null <<<"environment=DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=$MTU"
     dockerd_config=$(jq -S ".mtu = $MTU" <<<"$dockerd_config")
   else
     # shellcheck source=runner/logger.bash
@@ -42,7 +42,7 @@ if [[ ${DOCKER_REGISTRY_MIRROR:-} != '' ]]; then
 fi
 
 sudo mkdir -p ${dockerd_config_path%/*}
-sudo tee $dockerd_config_path 1>&- <<<"$dockerd_config"
+sudo tee $dockerd_config_path 1>/dev/null <<<"$dockerd_config"
 
 for config in $dockerd_config_path $dockerd_supervisor_config_path; do
   (


### PR DESCRIPTION
This may fix https://github.com/actions-runner-controller/actions-runner-controller/issues/1557.

The original line `sudo tee $dockerd_config_path 1>&- <<<"$dockerd_config" may intent to write string `"$dockerd_config"` to `$dockerd_config_path` without echoing to terminal (`1>&-`).
But it doesn't work in the runner pod's bash (`bash 5.0.17(1)`) because of `Bad file descriptor` error for the part of command: `1>&-`.

The `1>&-` is a special use of bash's redirection that closes 1 (stdout) and I thought it causes the error.
ref: https://www.gnu.org/software/bash/manual/html_node/Redirections.html

To fix the error, I rewrite it to `1>/dev/null`.
