### PR TITLE
Adds way to allow additional environment variables from secretKeyRef

### DIFF
--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -118,10 +118,6 @@ spec:
               name: {{ include "actions-runner-controller.secretName" . }}
               optional: true
         {{- end }}
-        {{- range $key, $val := .Values.env }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-        {{- end }}
         {{- if kindIs "slice" .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
         {{- else }}

--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -122,6 +122,9 @@ spec:
         - name: {{ $key }}
           value: {{ $val | quote }}
         {{- end }}
+        { { - if .Values.additionalFullEnv } }
+          { { - toYaml .Values.additionalFullEnv | nindent 8 } }
+        { { - end } }
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (cat "v" .Chart.AppVersion | replace " " "") }}"
         name: manager
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -122,9 +122,14 @@ spec:
         - name: {{ $key }}
           value: {{ $val | quote }}
         {{- end }}
-        { { - if .Values.additionalFullEnv } }
-          { { - toYaml .Values.additionalFullEnv | nindent 8 } }
-        { { - end } }
+        {{- if kindIs "slice" .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- else }}
+        {{- range $key, $val := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+        {{- end }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (cat "v" .Chart.AppVersion | replace " " "") }}"
         name: manager
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -143,9 +143,20 @@ priorityClassName: ""
 
 env:
   {}
+  # specify additional environment variables for the controller pod.
+  # It's possible to specify either key vale pairs e.g.:
   # http_proxy: "proxy.com:8080"
   # https_proxy: "proxy.com:8080"
   # no_proxy: ""
+
+  # or a list of complete environment variable definitions e.g.:
+  # - name: GITHUB_APP_INSTALLATION_ID
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: some_key_in_the_secret
+  #       name: some-secret-name
+  #       optional: true
+
 
 ## specify additional volumes to mount in the manager container, this can be used
 ## to specify additional storage of material or to inject files from ConfigMaps


### PR DESCRIPTION
First-off: Thanks for the great work here! 

### Problem
We are using a CSI-provder to sync secrets between AWS and EKS. The way that secrets are bound into the controller deployment doesn't really fit our workflow, so I'd be happy to specify my own environment variables from secrets, kind of the same way as I can specify additional volumes and mounts. 

This PR would allow something like this: 
```yaml
env:
  - name: GITHUB_APP_ID
    valueFrom:
      secretKeyRef:
        key: PROD_GHA-CONTROLLER_APP-ID
        name: prod-gha-controller-app-id
        optional: true
  - name: GITHUB_APP_INSTALLATION_ID
    valueFrom:
      secretKeyRef:
        key: PROD_GHA-CONTROLLER_APP-INSTALLATION-ID
        name: prod-gha-controller-app-installation-id
        optional: true
  - name: GITHUB_APP_PRIVATE_KEY
    valueFrom:
      secretKeyRef:
        key: PROD_GHA-CONTROLLER_APP-PRIVATE-KEY
        name: prod-gha-controller-app-private-key
        optional: true
```

Since i didn't want to break the existing `env` prop I've added a new one. The name is not perfect, maybe there're other suggestions :)   