### PR TITLE
Bump E2E runner version to 2.294.0

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -41,7 +41,7 @@ var (
 			Args: []testing.BuildArg{
 				{
 					Name:  "RUNNER_VERSION",
-					Value: "2.291.1",
+					Value: "2.294.0",
 				},
 			},
 			Image:        runnerImage,
@@ -52,7 +52,7 @@ var (
 			Args: []testing.BuildArg{
 				{
 					Name:  "RUNNER_VERSION",
-					Value: "2.291.1",
+					Value: "2.294.0",
 				},
 			},
 			Image:        runnerDindImage,


### PR DESCRIPTION
so that every runner does not result in auto-updating itself on startup in E2E, which makes E2E take longer to complete.