### PR TITLE
Enhance the acceptance runnerset yaml template for manual E2E

### DIFF
--- a/acceptance/testdata/runnerset.envsubst.yaml
+++ b/acceptance/testdata/runnerset.envsubst.yaml
@@ -122,8 +122,10 @@ spec:
           value: "/home/runner/.cache/go-mod"
         # PV-backed runner work dir
         volumeMounts:
-        - name: work
-          mountPath: /runner/_work
+        # Comment out the ephemeral work volume if you're going to test the kubernetes container mode
+        # The volume and mount with the same names will be created by workVolumeClaimTemplate and the kubernetes container mode support.
+        # - name: work
+        #   mountPath: /runner/_work
         # Cache docker image layers, in case dockerdWithinRunnerContainer=true
         - name: var-lib-docker
           mountPath: /var/lib/docker
@@ -163,17 +165,18 @@ spec:
         # For buildx cache
         - name: cache
           mountPath: "/home/runner/.cache"
-      volumes:
-      - name: work
-        ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-              - ReadWriteOnce
-              storageClassName: "${NAME}-runner-work-dir"
-              resources:
-                requests:
-                  storage: 10Gi
+        # Comment out the ephemeral work volume if you're going to test the kubernetes container mode
+      # volumes:
+      # - name: work
+      #   ephemeral:
+      #     volumeClaimTemplate:
+      #       spec:
+      #         accessModes:
+      #         - ReadWriteOnce
+      #         storageClassName: "${NAME}-runner-work-dir"
+      #         resources:
+      #           requests:
+      #             storage: 10Gi
   volumeClaimTemplates:
   - metadata:
       name: vol1
@@ -251,3 +254,10 @@ spec:
   minReplicas: ${RUNNER_MIN_REPLICAS}
   maxReplicas: 10
   scaleDownDelaySecondsAfterScaleOut: ${RUNNER_SCALE_DOWN_DELAY_SECONDS_AFTER_SCALE_OUT}
+  # Comment out the whole metrics if you'd like to solely test webhook-based scaling
+  metrics:
+  - type: PercentageRunnersBusy
+    scaleUpThreshold: '0.75'
+    scaleDownThreshold: '0.25'
+    scaleUpFactor: '2'
+    scaleDownFactor: '0.5'


### PR DESCRIPTION
The primary goal of this change is to let the tester know about the config difference between the explicitly configured ephemeral work volume vs the automatically configured work volume with workVolumeClaimTemplate+containerMode=kubernetes.