### PR TITLE
Fix a regression in webhook-based autoscaler

### DIFF
--- a/controllers/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/horizontal_runner_autoscaler_webhook.go
@@ -524,6 +524,7 @@ func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) getScaleUpTargetWithF
 	if autoscaler.GitHubClient != nil {
 		simu := &simulator.Simulator{
 			Client: autoscaler.GitHubClient,
+			Log:    log,
 		}
 		// Get available organization runner groups and enterprise runner groups for a repository
 		// These are the sum of runner groups with repository access = All repositories and runner groups

--- a/github/github.go
+++ b/github/github.go
@@ -273,8 +273,17 @@ func (c *Client) ListOrganizationRunnerGroupsForRepository(ctx context.Context, 
 	var runnerGroups []*github.RunnerGroup
 
 	var opts github.ListOrgRunnerGroupOptions
+
 	opts.PerPage = 100
-	opts.VisibleToRepository = repo
+
+	repoName := repo
+	parts := strings.Split(repo, "/")
+	if len(parts) == 2 {
+		repoName = parts[1]
+	}
+	// This must be the repo name without the owner part, so in case the repo is "myorg/myrepo" the repo name
+	// passed to visible_to_repository must be "myrepo".
+	opts.VisibleToRepository = repoName
 
 	for {
 		list, res, err := c.Actions.ListOrganizationRunnerGroups(ctx, org, &opts)

--- a/simulator/runnergroup_visibility.go
+++ b/simulator/runnergroup_visibility.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 
 	"github.com/actions-runner-controller/actions-runner-controller/github"
+	"github.com/go-logr/logr"
 )
 
 type Simulator struct {
 	Client *github.Client
+	Log    logr.Logger
 }
 
 func (c *Simulator) GetRunnerGroupsVisibleToRepository(ctx context.Context, org, repo string, managed *VisibleRunnerGroups) (*VisibleRunnerGroups, error) {
@@ -22,6 +24,10 @@ func (c *Simulator) GetRunnerGroupsVisibleToRepository(ctx context.Context, org,
 		runnerGroups, err := c.Client.ListOrganizationRunnerGroupsForRepository(ctx, org, repo)
 		if err != nil {
 			return visible, err
+		}
+
+		if c.Log.V(3).Enabled() {
+			c.Log.V(3).Info("ListOrganizationRunnerGroupsForRepository succeeded", "runerGroups", runnerGroups)
 		}
 
 		for _, runnerGroup := range runnerGroups {


### PR DESCRIPTION
The regression resulted in the webhook-based autoscaler be unable to find visible runner groups and therefore unable to scale up and down the target RunnerDeployment/RunnerSet at all when the webhook-based autoscaler was provided GitHub API credentials to enable the runner groups support. This fixes that.

The regression was introduced via #1578 which is not released yet. Users of existing ARC releases are therefore not affected.