### PR TITLE
Add toubleshooting for cert-manager ca error

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -67,7 +67,7 @@ var (
 		},
 	}
 
-	certManagerVersion = "v1.1.1"
+	certManagerVersion = "v1.8.2"
 
 	images = []testing.ContainerImage{
 		testing.Img("docker", "dind"),


### PR DESCRIPTION
I encountered this once while E2E testing ARC with K8s 1.22 and cert-manager 1.1.1. The K8s version is too high / The cert-manager is too low so you generally need to fix either. In a standard scenario, it should be more feasible and meaningful to upgrade cert-manager to a recent enough version that supports the new Kubernetes version.