### PR TITLE
Make it easier to E2E test on various K8s versions

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -122,11 +122,12 @@ func TestE2E(t *testing.T) {
 		t.Skip("Skipped as -short is set")
 	}
 
+	k8sMinorVer := os.Getenv("ARC_E2E_KUBE_VERSION")
 	skipRunnerCleanUp := os.Getenv("ARC_E2E_SKIP_RUNNER_CLEANUP") != ""
 	retainCluster := os.Getenv("ARC_E2E_RETAIN_CLUSTER") != ""
 	skipTestIDCleanUp := os.Getenv("ARC_E2E_SKIP_TEST_ID_CLEANUP") != ""
 
-	env := initTestEnv(t)
+	env := initTestEnv(t, k8sMinorVer)
 
 	t.Run("build and load images", func(t *testing.T) {
 		env.buildAndLoadImages(t)
@@ -264,10 +265,10 @@ type env struct {
 	dockerdWithinRunnerContainer                bool
 }
 
-func initTestEnv(t *testing.T) *env {
+func initTestEnv(t *testing.T, k8sMinorVer string) *env {
 	t.Helper()
 
-	testingEnv := testing.Start(t, testing.Preload(images...))
+	testingEnv := testing.Start(t, k8sMinorVer, testing.Preload(images...))
 
 	e := &env{Env: testingEnv}
 


### PR DESCRIPTION
According to the Kubernetes version skew policy, all the currently supported Kubernetes versions are 1.22, 1.23, and 1.24.
We ensure ARC works on all those three versions by running the E2E test against those three versions.

This change makes it easy to do so- Just set `ARC_E2E_KUBE_VERSION` to the desired Kubernetes major and minor version numbers before running the E2E test. For example, you can run it against K8s 1.24.x with `ARC_E2E_KUBE_VERSION=1.24 go test -run TestE2E ./...`.