### PR TITLE
Enhance the E2E test to be runnable against remote clusters on e.g. AWS EKS

### DIFF
--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -51,6 +51,9 @@ if [ "${tool}" == "helm" ]; then
     --set image.tag=${VERSION} \
     --set podAnnotations.test-id=${TEST_ID} \
     --set githubWebhookServer.podAnnotations.test-id=${TEST_ID} \
+    --set imagePullSecrets[0].name=${IMAGE_PULL_SECRET} \
+    --set image.actionsRunnerImagePullSecrets[0].name=${IMAGE_PULL_SECRET} \
+    --set githubWebhookServer.imagePullSecrets[0].name=${IMAGE_PULL_SECRET} \
     -f ${VALUES_FILE}
   set +v
   # To prevent `CustomResourceDefinition.apiextensions.k8s.io "runners.actions.summerwind.dev" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`

--- a/acceptance/values.yaml
+++ b/acceptance/values.yaml
@@ -1,6 +1,13 @@
 # Set actions-runner-controller settings for testing
 logLevel: "-4"
+imagePullSecrets:
+- name:
+image:
+  actionsRunnerImagePullSecrets:
+  - name:
 githubWebhookServer:
+  imagePullSecrets:
+  - name:
   logLevel: "-4"
   enabled: true
   labels: {}

--- a/testing/docker.go
+++ b/testing/docker.go
@@ -71,3 +71,18 @@ func (k *Docker) dockerBuildCombinedOutput(ctx context.Context, build DockerBuil
 
 	return k.CombinedOutput(cmd)
 }
+
+func (k *Docker) Push(ctx context.Context, images []ContainerImage) error {
+	for _, img := range images {
+		_, err := k.CombinedOutput(dockerPushCmd(ctx, img.Repo, img.Tag))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func dockerPushCmd(ctx context.Context, repo, tag string) *exec.Cmd {
+	return exec.CommandContext(ctx, "docker", "push", repo+":"+tag)
+}


### PR DESCRIPTION
This contains apparently enough changes to the current E2E test code to make it runnable against remote Kubernetes clusters.

I was actually able to make the test pass against my AWS EKS-based test clusters with these changes. You still need to trigger it manually from a local checkout of the ARC repo today.

But this might be the foundation for automated E2E tests against major cloud providers.