### PR TITLE
docs: remove runner kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ We go into details about the differences between the 2 later, initially lets loo
 To launch a single self-hosted runner, you need to create a manifest file that includes a `RunnerDeployment` resource as follows. This example launches a self-hosted runner with name *example-runnerdeploy* for the *actions-runner-controller/actions-runner-controller* repository.
 
 ```yaml
+# runnerdeployment.yaml
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:
@@ -292,6 +293,21 @@ spec:
   template:
     spec:
       repository: mumoshu/actions-runner-controller-ci
+```
+
+Apply the created manifest file to your Kubernetes.
+
+```shell
+$ kubectl apply -f runnerdeployment.yaml
+runnerdeployment.actions.summerwind.dev/example-runnerdeploy created
+```
+
+You can see that 1 runner have been created as specified by `replicas: 1` attribute:
+
+```shell
+$ kubectl get runners
+NAME                             REPOSITORY                             STATUS
+example-runnerdeploy2475h595fr   mumoshu/actions-runner-controller-ci   Running
 ```
 
 The runner you created has been registered directly to the defined repository, you should be able to see it in the settings of the repository.
@@ -336,7 +352,7 @@ Now you can see the runner on the enterprise level (if you have enterprise acces
 
 ### RunnerDeployments
 
-In our previous examples we were deploying a single runner via the `RunnerDeployment` kind, the amount of runners deployed is controlled statically via the `replicas:` field, we can increase this value to deploy additioanl sets of runners instead:
+In our previous examples we were deploying a single runner via the `RunnerDeployment` kind, the amount of runners deployed can be statically set via the `replicas:` field, we can increase this value to deploy additioanl sets of runners instead:
 
 ```yaml
 # runnerdeployment.yaml

--- a/README.md
+++ b/README.md
@@ -302,12 +302,16 @@ $ kubectl apply -f runnerdeployment.yaml
 runnerdeployment.actions.summerwind.dev/example-runnerdeploy created
 ```
 
-You can see that 1 runner have been created as specified by `replicas: 1` attribute:
+You can see that 1 runner and its underlying pod has been created as specified by `replicas: 1` attribute:
 
 ```shell
 $ kubectl get runners
 NAME                             REPOSITORY                             STATUS
 example-runnerdeploy2475h595fr   mumoshu/actions-runner-controller-ci   Running
+
+$ kubectl get pods
+NAME                           READY   STATUS    RESTARTS   AGE
+example-runnerdeploy2475ht2qbr 2/2     Running   0          1m
 ```
 
 The runner you created has been registered directly to the defined repository, you should be able to see it in the settings of the repository.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Alternatively, you can install each controller stack into a unique namespace (re
 
 Runners can be deployed as 1 of 2 abstractions: 
 
-- A `RunnerDeployment` (based on k8s's `Deployments`)
+- A `RunnerDeployment` (similar to k8s's `Deployments`, based on `Pods`)
 - A `RunnerSet` (based on k8s's `StatefulSets`)
 
 We go into details about the differences between the 2 later, initially lets look at how to deploy a basic `RunnerDeployment` at the 3 possible management hierarchies.

--- a/README.md
+++ b/README.md
@@ -382,9 +382,7 @@ kind: RunnerSet
 metadata:
   name: example
 spec:
-  ephemeral: false
-  # This will deploy 2 runners now
-  replicas: 2
+  replicas: 1
   repository: mumoshu/actions-runner-controller-ci
   # Other mandatory fields from StatefulSet
   selector:
@@ -415,8 +413,7 @@ kind: RunnerSet
 metadata:
   name: example
 spec:
-  ephemeral: false
-  replicas: 2
+  replicas: 1
   repository: mumoshu/actions-runner-controller-ci
   dockerdWithinRunnerContainer: true
   template:


### PR DESCRIPTION
The `Runner` kind is no longer to be used by end the end user and should be considered an internal implementation detail now.