### PR TITLE
Ensure the runner status update hooks work with the Kubernetes container mode

### DIFF
--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -54,6 +54,7 @@ if [ "${tool}" == "helm" ]; then
     --set imagePullSecrets[0].name=${IMAGE_PULL_SECRET} \
     --set image.actionsRunnerImagePullSecrets[0].name=${IMAGE_PULL_SECRET} \
     --set githubWebhookServer.imagePullSecrets[0].name=${IMAGE_PULL_SECRET} \
+    --set image.imagePullPolicy=${IMAGE_PULL_POLICY} \
     -f ${VALUES_FILE}
   set +v
   # To prevent `CustomResourceDefinition.apiextensions.k8s.io "runners.actions.summerwind.dev" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`

--- a/acceptance/testdata/kubernetes_container_mode.envsubst.yaml
+++ b/acceptance/testdata/kubernetes_container_mode.envsubst.yaml
@@ -1,0 +1,82 @@
+# USAGE:
+#   cat acceptance/testdata/kubernetes_container_mode.envsubst.yaml  | NAMESPACE=default envsubst  | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-mode-runner
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "create", "delete"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get", "list", "watch",]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "create", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: runner-status-updater
+rules:
+- apiGroups: ["actions.summerwind.dev"]
+  resources: ["runners/status"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: runner
+  namespace: ${NAMESPACE}
+---
+# To verify it's working, try:
+#   kubectl auth can-i --as system:serviceaccount:default:runner get pod
+# If incomplete, workflows and jobs would fail with an error message like:
+#   Error: Error: The Service account needs the following permissions [{"group":"","verbs":["get","list","create","delete"],"resource":"pods","subresource":""},{"group":"","verbs":["get","create"],"resource":"pods","subresource":"exec"},{"group":"","verbs":["get","list","watch"],"resource":"pods","subresource":"log"},{"group":"batch","verbs":["get","list","create","delete"],"resource":"jobs","subresource":""},{"group":"","verbs":["create","delete","get","list"],"resource":"secrets","subresource":""}] on the pod resource in the 'default' namespace. Please contact your self hosted runner administrator.
+#   Error: Process completed with exit code 1.
+apiVersion: rbac.authorization.k8s.io/v1
+# This role binding allows "jane" to read pods in the "default" namespace.
+# You need to already have a Role named "pod-reader" in that namespace.
+kind: RoleBinding
+metadata:
+  name: runner-k8s-mode-runner
+  namespace: ${NAMESPACE}
+subjects:
+- kind: ServiceAccount
+  name: runner
+  namespace: ${NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: k8s-mode-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: runner-runner-stat-supdater
+  namespace: ${NAMESPACE}
+subjects:
+- kind: ServiceAccount
+  name: runner
+  namespace: ${NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: runner-status-updater
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: org-runnerdeploy-runner-work-dir
+  labels:
+    content: org-runnerdeploy-runner-work-dir
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/acceptance/testdata/runnerdeploy.envsubst.yaml
+++ b/acceptance/testdata/runnerdeploy.envsubst.yaml
@@ -43,6 +43,17 @@ spec:
       # Non-standard working directory
       #
       # workDir: "/"
+
+      # # Uncomment the below to enable the kubernetes container mode
+      # # See https://github.com/actions-runner-controller/actions-runner-controller#runner-with-k8s-jobs
+      containerMode: kubernetes
+      workVolumeClaimTemplate:
+        accessModes:
+        - ReadWriteOnce
+        storageClassName: "${NAME}-runner-work-dir"
+        resources:
+          requests:
+            storage: 10Gi
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: HorizontalRunnerAutoscaler

--- a/acceptance/values.yaml
+++ b/acceptance/values.yaml
@@ -5,6 +5,11 @@ imagePullSecrets:
 image:
   actionsRunnerImagePullSecrets:
   - name:
+runner:
+  statusUpdateHook:
+    enabled: true
+rbac:
+  allowGrantingKubernetesContainerModePermissions: true
 githubWebhookServer:
   imagePullSecrets:
   - name:

--- a/charts/actions-runner-controller/templates/manager_role.yaml
+++ b/charts/actions-runner-controller/templates/manager_role.yaml
@@ -284,3 +284,27 @@ rules:
   - delete
   - get
 {{- end }}
+{{- if .Values.rbac.allowGrantingKubernetesContainerModePermissions }}
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+{{- end }}

--- a/charts/actions-runner-controller/templates/manager_role.yaml
+++ b/charts/actions-runner-controller/templates/manager_role.yaml
@@ -285,6 +285,8 @@ rules:
   - get
 {{- end }}
 {{- if .Values.rbac.allowGrantingKubernetesContainerModePermissions }}
+{{/* These permissions are required by ARC to create RBAC resources for the runner pod to use the kubernetes container mode. */}}
+{{/* See https://github.com/actions-runner-controller/actions-runner-controller/pull/1268/files#r917331632 */}}
 - apiGroups:
   - ""
   resources:
@@ -300,6 +302,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - create
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -72,6 +72,7 @@ runner:
     enabled: false
 
 rbac:
+  {}
   # # This allows ARC to dynamically create a ServiceAccount and a Role for each Runner pod that uses "kubernetes" container mode,
   # # by extending ARC's manager role to have the same permissions required by the pod runs the runner agent in "kubernetes" container mode.
   # # Without this, Kubernetes blocks ARC to create the role to prevent a priviledge escalation.

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -71,6 +71,13 @@ runner:
   statusUpdateHook:
     enabled: false
 
+rbac:
+  # # This allows ARC to dynamically create a ServiceAccount and a Role for each Runner pod that uses "kubernetes" container mode,
+  # # by extending ARC's manager role to have the same permissions required by the pod runs the runner agent in "kubernetes" container mode.
+  # # Without this, Kubernetes blocks ARC to create the role to prevent a priviledge escalation.
+  # # See https://github.com/actions-runner-controller/actions-runner-controller/pull/1268/files#r917327010
+  # allowGrantingKubernetesContainerModePermissions: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -305,6 +305,11 @@ func (r *RunnerReconciler) processRunnerCreation(ctx context.Context, runner v1a
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
+					APIGroups: []string{"batch"},
+					Resources: []string{"jobs"},
+					Verbs:     []string{"get", "list", "create", "delete"},
+				},
+				{
 					APIGroups: []string{""},
 					Resources: []string{"secrets"},
 					Verbs:     []string{"get", "list", "create", "delete"},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -254,6 +254,7 @@ type env struct {
 	dockerdWithinRunnerContainer                bool
 	remoteKubeconfig                            string
 	imagePullSecretName                         string
+	imagePullPolicy                             string
 
 	vars          vars
 	VerifyTimeout time.Duration
@@ -367,6 +368,12 @@ func initTestEnv(t *testing.T, k8sMinorVer string, vars vars) *env {
 	e.imagePullSecretName = testing.Getenv(t, "ARC_E2E_IMAGE_PULL_SECRET_NAME", "")
 	e.vars = vars
 
+	if e.remoteKubeconfig != "" {
+		e.imagePullPolicy = "Always"
+	} else {
+		e.imagePullPolicy = "IfNotPresent"
+	}
+
 	if e.remoteKubeconfig == "" {
 		e.Kind = testing.StartKind(t, k8sMinorVer, testing.Preload(images...))
 		e.Env.Kubeconfig = e.Kind.Kubeconfig()
@@ -457,6 +464,7 @@ func (e *env) installActionsRunnerController(t *testing.T, repo, tag, testID str
 		"NAME=" + repo,
 		"VERSION=" + tag,
 		"IMAGE_PULL_SECRET=" + e.imagePullSecretName,
+		"IMAGE_PULL_POLICY=" + e.imagePullPolicy,
 	}
 
 	if e.useApp {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -105,6 +105,10 @@ func TestE2E(t *testing.T) {
 	}
 
 	t.Run("RunnerSets", func(t *testing.T) {
+		if os.Getenv("ARC_E2E_SKIP_RUNNERSETS") != "" {
+			t.Skip("RunnerSets test has been skipped due to ARC_E2E_SKIP_RUNNERSETS")
+		}
+
 		var (
 			testID string
 		)


### PR DESCRIPTION
This is a follow-up PR that contains three commits to address the remaining issues mentioned and unmentioned in https://github.com/actions-runner-controller/actions-runner-controller/pull/1268#pullrequestreview-1033594072, except the below one:

> If the runner controller's resync period passed and hence it reconciled the runner resource immediately after the hook update the runner status to Idle, the runner status might be "corrected" to Running(=pod status phase). So it can look a bit flappy if you watched the runner status phase transitions continuously (by e.g. running kubectl get runner -w and triggering a bunch of workflow runs). It might not be a big deal, but might be worth a fix.

