### PR TITLE
fix #1621: add missing COPY statements to dind docker image

### DIFF
--- a/runner/actions-runner-dind.dockerfile
+++ b/runner/actions-runner-dind.dockerfile
@@ -98,7 +98,8 @@ RUN mkdir /opt/hostedtoolcache \
 
 # We place the scripts in `/usr/bin` so that users who extend this image can
 # override them with scripts of the same name placed in `/usr/local/bin`.
-COPY entrypoint.sh logger.bash startup.sh /usr/bin/
+COPY entrypoint.sh logger.bash startup.sh update-status /usr/bin/
+COPY hooks /etc/arc/hooks/
 COPY supervisor/ /etc/supervisor/conf.d/
 RUN chmod +x /usr/bin/startup.sh /usr/bin/entrypoint.sh
 


### PR DESCRIPTION
Fixes #1621 