### PR TITLE
docs: add default label considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1592,7 +1592,7 @@ jobs:
 When using labels there are a few things to be aware of:
 
 1. `self-hosted` is implict with every runner as this is an automatic label GitHub apply to any self-hosted runner. As a result ARC can treat all runners as having this label without having it explicitly defined in a runner's manifest. You do not need to explicitly define this label in your runner manifests (you can if you want though).
-2. In addition to the `self-hosted` label, GitHub also applies a few other [default](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow#using-default-labels-to-route-jobs) labels to any self-hosted runner. These other default labels relate to the architecture of the runner and so can't be implicitly assumed by ARC as ARC doesn't know if your runner is `linux` or `windows`, `x64` or `ARM64`. If you wish to use these labels in your workflows you must add them to your runner manifests or ARC will ignore them.
+2. In addition to the `self-hosted` label, GitHub also applies a few other [default](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow#using-default-labels-to-route-jobs) labels to any self-hosted runner. The other default labels relate to the architecture of the runner and so can't be implicitly applied by ARC as ARC doesn't know if the runner is `linux` or `windows`, `x64` or `ARM64` etc. If you wish to use these labels in your workflows and have ARC scale runners accurately you must also add them to your runner manifests.
 
 ### Runner Groups
 

--- a/README.md
+++ b/README.md
@@ -1591,7 +1591,7 @@ jobs:
 
 When using labels there are a few things to be aware of:
 
-1. `self-hosted` is implict with every runner as this is an automatic label GitHub apply to any self-hosted runner. As a result ARC can treat all runners as having this label without physically having it a runner's manifest. You do not need to explicitly define this label in your runner manifests (you can if you want though).
+1. `self-hosted` is implict with every runner as this is an automatic label GitHub apply to any self-hosted runner. As a result ARC can treat all runners as having this label without having it explicitly defined in a runner's manifest. You do not need to explicitly define this label in your runner manifests (you can if you want though).
 2. In addition to the `self-hosted` label, GitHub also applies a few other [default](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow#using-default-labels-to-route-jobs) labels to any self-hosted runner. These other default labels relate to the architecture of the runner and so can't be implicitly assumed by ARC as ARC doesn't know if your runner is `linux` or `windows`, `x64` or `ARM64`. If you wish to use these labels in your workflows you must add them to your runner manifests or ARC will ignore them.
 
 ### Runner Groups

--- a/README.md
+++ b/README.md
@@ -1589,7 +1589,10 @@ jobs:
     runs-on: custom-runner
 ```
 
-Note that if you specify `self-hosted` in your workflow, then this will run your job on _any_ self-hosted runner, regardless of the labels that they have.
+When using labels there are a few things to be aware of:
+
+1. `self-hosted` is implict with every runner as this is an automatic label GitHub apply to any self-hosted runner. As a result ARC can treat all runners as having this label without physically having it a runner's manifest. You do not need to explicitly define this label in your runner manifests (you can if you want though).
+2. In addition to the `self-hosted` label, GitHub also applies a few other [default](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow#using-default-labels-to-route-jobs) labels to any self-hosted runner. These other default labels relate to the architecture of the runner and so can't be implicitly assumed by ARC as ARC doesn't know if your runner is `linux` or `windows`, `x64` or `ARM64`. If you wish to use these labels in your workflows you must add them to your runner manifests or ARC will ignore them.
 
 ### Runner Groups
 

--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,6 @@ jobs:
 When you have multiple kinds of self-hosted runners, you can distinguish between them using labels. In order to do so, you can specify one or more labels in your `Runner` or `RunnerDeployment` spec.
 
 ```yaml
-# runnerdeployment.yaml
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:
@@ -1601,7 +1600,6 @@ Runner groups can be used to limit which repositories are able to use the GitHub
 To add the runner to the group `NewGroup`, specify the group in your `Runner` or `RunnerDeployment` spec.
 
 ```yaml
-# runnerdeployment.yaml
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:


### PR DESCRIPTION
+ removed the commented out file names as we don't talk about applying the manifests like we do early in the docs meaning the hyperthetical file names are pointless