### PR TITLE
chart: Remove support for extensions/v1beta1 and networking.k8s.io/v1beta1

### DIFF
--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -1,13 +1,7 @@
 {{- if .Values.githubWebhookServer.ingress.enabled -}}
 {{- $fullName := include "actions-runner-controller-github-webhook-server.fullname" . -}}
 {{- $svcPort := (index .Values.githubWebhookServer.service.ports 0).port -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1/Ingress" }}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.ingress.yaml
@@ -36,19 +36,12 @@ spec:
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                name: {{ $fullName }}
                port:
                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
`networking.k8s.io/v1` has been available since v1.19.

As of today, AWS EKS supports v1.19+ and Oracle Cloud supports v1.20+. GKE and AKS supports v1.21+. The upstream Kubernetes project maintains v1.22+.
So it should be safe to remove it now.