### PR TITLE
Add rootless DinD runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ToC:
     - [Scheduled Overrides](#scheduled-overrides)
   - [Alternative Runners](#alternative-runners)
     - [Runner with DinD](#runner-with-dind)
+    - [Runner with rootless DinD](#runner-with-rootless-dind)
     - [Runner with k8s jobs](#runner-with-k8s-jobs)
   - [Additional Tweaks](#additional-tweaks)
   - [Custom Volume mounts](#custom-volume-mounts)

--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,10 @@ spec:
       env: []
 ```
 
+#### Runner with rootless DinD
+
+When using the DinD runner, it assumes that the main runner is rootful, which can be problematic in a regulated or more security-conscious environment, such as co-tenanting across enterprise projects.  The `actions-runner-dind-rootless` image runs rootless Docker inside the container as `runner` user.  Note that this user does not have sudo access, so anything requiring admin privileges must be built into the runner's base image (like running `apt` to install additional software).
+
 #### Runner with K8s Jobs
 
 When using the default runner, jobs that use a container will run in docker. This necessitates privileged mode, either on the runner pod or the sidecar container

--- a/runner/actions-runner-dind-rootless.dockerfile
+++ b/runner/actions-runner-dind-rootless.dockerfile
@@ -1,0 +1,139 @@
+FROM ubuntu:20.04
+
+# Target architecture
+ARG TARGETPLATFORM=linux/amd64
+
+# GitHub runner arguments
+ARG RUNNER_VERSION=2.294.0
+
+# Docker and Docker Compose arguments
+ENV CHANNEL=stable
+ARG COMPOSE_VERSION=v2.6.0
+
+# Dumb-init version
+ARG DUMB_INIT_VERSION=1.2.5
+
+# Other arguments
+ARG DEBUG=false
+
+# Set environment variables needed at build
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    ca-certificates \
+    dnsutils \
+    ftp \
+    fuse-overlayfs \
+    git \
+    iproute2 \
+    iputils-ping \
+    iptables \
+    jq \
+    libunwind8 \
+    locales \
+    netcat \
+    net-tools \
+    openssh-client \
+    parallel \
+    python3-pip \
+    rsync \
+    shellcheck \
+    supervisor \
+    software-properties-common \
+    sudo \
+    telnet \
+    time \
+    tzdata \
+    uidmap \
+    unzip \
+    upx \
+    wget \
+    zip \
+    zstd \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Runner user
+RUN adduser --disabled-password --gecos "" --uid 1000 runner
+
+RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)
+
+# Setup subuid and subgid so that "--userns-remap=default" works
+RUN set -eux; \
+    addgroup --system dockremap; \
+    adduser --system --ingroup dockremap dockremap; \
+    echo 'dockremap:165536:65536' >> /etc/subuid; \
+    echo 'dockremap:165536:65536' >> /etc/subgid
+
+ENV RUNNER_ASSETS_DIR=/runnertmp
+
+# Runner download supports amd64 as x64
+RUN ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && export ARCH \
+    && if [ "$ARCH" = "amd64" ]; then export ARCH=x64 ; fi \
+    && mkdir -p "$RUNNER_ASSETS_DIR" \
+    && cd "$RUNNER_ASSETS_DIR" \
+    && curl -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh \
+    && apt-get install -y libyaml-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache > /runner.env \
+    && mkdir /opt/hostedtoolcache \
+    && chgrp runner /opt/hostedtoolcache \
+    && chmod g+rwx /opt/hostedtoolcache
+
+# Configure hooks folder structure.
+COPY hooks /etc/arc/hooks/
+
+# arch command on OS X reports "i386" for Intel CPUs regardless of bitness
+RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && curl -f -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
+    && chmod +x /usr/local/bin/dumb-init
+
+COPY entrypoint.sh logger.bash rootless-startup.sh update-status /usr/bin/
+
+RUN chmod +x /usr/bin/rootless-startup.sh /usr/bin/entrypoint.sh
+
+# Make the rootless runner directory executable
+RUN mkdir /run/user/1000 \
+    && chown runner:runner /run/user/1000 \
+    && chmod a+x /run/user/1000
+
+# Add the Python "User Script Directory" to the PATH
+ENV PATH="${PATH}:${HOME}/.local/bin:/home/runner/bin"
+ENV ImageOS=ubuntu20
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+ENV XDG_RUNTIME_DIR=/run/user/1000
+
+RUN echo "PATH=${PATH}" > /etc/environment \
+    && echo "ImageOS=${ImageOS}" >> /etc/environment \
+    && echo "DOCKER_HOST=${DOCKER_HOST}" >> /etc/environment \
+    && echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> /etc/environment
+
+ENV HOME=/home/runner
+
+# No group definition, as that makes it harder to run docker.
+USER runner
+
+# Docker installation
+ENV SKIP_IPTABLES=1
+RUN curl -fsSL https://get.docker.com/rootless | sh
+
+# Docker-compose installation
+RUN curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-Linux-x86_64" -o /home/runner/bin/docker-compose ; \
+    chmod +x /home/runner/bin/docker-compose
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+CMD ["rootless-startup.sh"]

--- a/runner/rootless-startup.sh
+++ b/runner/rootless-startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+source logger.bash
+
+log.notice "Writing out Docker config file"
+/bin/bash <<SCRIPT
+mkdir -p /home/runner/.config/docker/
+
+if [ ! -f /home/runner/.config/docker/daemon.json ]; then
+  echo "{}" > /home/runner/.config/docker/daemon.json
+fi
+
+if [ -n "${MTU}" ]; then
+jq ".\"mtu\" = ${MTU}" /home/runner/.config/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /home/runner/.config/docker/daemon.json
+# See https://docs.docker.com/engine/security/rootless/
+echo "environment=DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=${MTU}" >> /etc/supervisor/conf.d/dockerd.conf
+fi
+
+if [ -n "${DOCKER_REGISTRY_MIRROR}" ]; then
+jq ".\"registry-mirrors\"[0] = \"${DOCKER_REGISTRY_MIRROR}\"" /home/runner/.config/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /home/runner/.config/docker/daemon.json
+fi
+SCRIPT
+
+log.notice "Starting Docker (rootless)"
+/home/runner/bin/dockerd-rootless.sh --config-file /home/runner/.config/docker/daemon.json >> /dev/null 2>&1 &
+
+# Wait processes to be running
+entrypoint.sh


### PR DESCRIPTION
Addresses, possibly closes #1288 

Docker-in-Docker is great!  While I was an enterprise admin, I just wanted GitHub Actions to work the way it does in .com for my users in GHES.  However, rootful DinD raises some eyebrows to say the least.  This PR adds a rootless DinD runner that does not allow `sudo` access.

This mitigates _some_ security concerns around nested virtualization, especially in a co-tenanted or enterprise-wide environment.  However, it also means the administrator who builds these images on-premises needs to be responsible for every configuration that'd require sudo, such as installing new software with `apt-get`.  On the other hand, this is much more "it just works" experience for users to build Docker images and otherwise use GitHub Actions on-premises. ❤️ 

---

I wasn't sure how to add additional runner tests for this, but ran some tests manually on my own demo cluster and everything seems to work as anticipated so far. 😅 

Running a docker build job, rootlessly:
<img width="1446" alt="Screen Shot 2022-07-13 at 9 05 39 AM" src="https://user-images.githubusercontent.com/9995618/178774153-aeb35e7e-a4a6-4021-ac69-952411208157.png">

Here's an example test [workflow run](https://github.com/some-natalie/kubernoodles/runs/7348527196?check_suite_focus=true) in my own demo repo.  I tested the following

1. Docker daemon is up and running rootlessly.
2. Container Actions work as the `runner` user.
3. Docker building containers works as the `runner` user.
4. `sudo` fails

There's also a decent amount of debug info in that test as well.