### PR TITLE
fix: don't base64 decode secret strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Alternatively, you can install each controller stack into a unique namespace (re
 - The organization level
 - The enterprise level
 
-Runners can be deployed as 1 of 2 abstractions: 
+Runners can be deployed as 1 of 2 abstractions:
 
 - A `RunnerDeployment` (similar to k8s's `Deployments`, based on `Pods`)
 - A `RunnerSet` (based on k8s's `StatefulSets`)
@@ -1786,9 +1786,11 @@ kind: RunnerDeployment
 metadata:
   namespace: org1-runners
 spec:
-  githubAPICredentialsFrom:
-    secretRef:
-      name: org1-github-app
+  template:
+    spec:
+      githubAPICredentialsFrom:
+        secretRef:
+          name: org1-github-app
 ---
 kind: HorizontalRunnerAutoscaler
 metadata:

--- a/controllers/multi_githubclient.go
+++ b/controllers/multi_githubclient.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"crypto/sha1"
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -270,17 +269,6 @@ func (c *MultiGitHubClient) derefClient(ns, secretName string, dependent *runner
 	}
 }
 
-func decodeBase64(s []byte) (string, error) {
-	enc := base64.RawStdEncoding
-	dbuf := make([]byte, enc.DecodedLen(len(s)))
-	n, err := enc.Decode(dbuf, []byte(s))
-	if err != nil {
-		return "", err
-	}
-
-	return string(dbuf[:n]), nil
-}
-
 func secretDataToGitHubClientConfig(data map[string][]byte) (*github.Config, error) {
 	var (
 		conf github.Config
@@ -288,55 +276,31 @@ func secretDataToGitHubClientConfig(data map[string][]byte) (*github.Config, err
 		err error
 	)
 
-	conf.URL, err = decodeBase64(data["github_url"])
-	if err != nil {
-		return nil, err
-	}
+	conf.URL = string(data["github_url"])
 
-	conf.UploadURL, err = decodeBase64(data["github_upload_url"])
-	if err != nil {
-		return nil, err
-	}
+	conf.UploadURL = string(data["github_upload_url"])
 
-	conf.EnterpriseURL, err = decodeBase64(data["github_enterprise_url"])
-	if err != nil {
-		return nil, err
-	}
+	conf.EnterpriseURL = string(data["github_enterprise_url"])
 
-	conf.RunnerGitHubURL, err = decodeBase64(data["github_runner_url"])
-	if err != nil {
-		return nil, err
-	}
+	conf.RunnerGitHubURL = string(data["github_runner_url"])
 
-	conf.Token, err = decodeBase64(data["github_token"])
-	if err != nil {
-		return nil, err
-	}
+	conf.Token = string(data["github_token"])
 
-	appID, err := decodeBase64(data["github_app_id"])
-	if err != nil {
-		return nil, err
-	}
+	appID := string(data["github_app_id"])
 
 	conf.AppID, err = strconv.ParseInt(appID, 10, 64)
 	if err != nil {
 		return nil, err
 	}
 
-	instID, err := decodeBase64(data["github_app_installation_id"])
-	if err != nil {
-		return nil, err
-	}
+	instID := string(data["github_app_installation_id"])
 
 	conf.AppInstallationID, err = strconv.ParseInt(instID, 10, 64)
 	if err != nil {
 		return nil, err
 	}
 
-	conf.AppPrivateKey, err = decodeBase64(data["github_app_private_key"])
-	if err != nil {
-		return nil, err
-	}
+	conf.AppPrivateKey = string(data["github_app_private_key"])
 
 	return &conf, nil
 }


### PR DESCRIPTION
I was trying to use the new multi-tenancy functionality in the canary release but was getting an error 
```2022-08-01T22:51:51Z	ERROR	Reconciler error	{"controller": "horizontalrunnerautoscaler-controller", "controllerGroup": "actions.summerwind.dev", "controllerKind": "HorizontalRunnerAutoscaler", "horizontalRunnerAutoscaler": {"name":"xxxxxxx","namespace":"actions-runner-system"}, "namespace": "actions-runner-system", "name": "xxxxxxx", "reconcileID": "2c994235-92be-40f9-bc42-4f0ada10247c", "error": "strconv.ParseInt: parsing \"\\xdbm\\xf8\\xd3\": invalid syntax"}```

The controller is trying to base64 decode the secret values even though they are already being returned unencoded.

I built a docker image from this PR and was able to successfully do multi-tenancy.