### PR TITLE
[Doc] Create ARC Overview doc

### DIFF
--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -28,7 +28,7 @@ Self-hosted runners can be physical, virtual, in a container, on-premises, or in
 ARC  is a K8s controller to create self-hosted runners on your K8s cluster. With few commands, you can set up self hosted runners that can scale up and down based on demand. And since these could be ephemeral and based on containers, new instances of the runner can be brought up rapidly and cleanly.
 
 ### Deploying ARC
-We have a quick start guide that demonstrates how to easily deploy ARC into your K8s environment. For more details, see `QuickStart Guide` "[here](*todo - add link*)."
+We have a quick start guide that demonstrates how to easily deploy ARC into your K8s environment. For more details, see "[QuickStart Guide](https://github.com/actions-runner-controller/actions-runner-controller/blob/master/QuickStartGuide.md)."
 
 ## ARC components
 ARC basically consists of a set of custom resources. An ARC deployment is applying these custom resources onto a K8s cluster. Once applied, it creates a set of Pods, with the Github Actions runner running within them. Github is now able to treat these Pods as self hosted runners and allocate jobs to them.
@@ -51,7 +51,7 @@ Once the custom resources are installed, another command deploys ARC into your K
 
 
 The `Deployment and Configure ARC` section in the `Quick Start guide` lists the steps to deploy ARC using a `runnerdeployment.yaml` file. Here, we will explain the details 
-For more information on `Quick Start` guide, see [here] (todo - add link to quick start)
+For more details, see "[QuickStart Guide](https://github.com/actions-runner-controller/actions-runner-controller/blob/master/QuickStartGuide.md)."
 
 ```code
 apiVersion: actions.summerwind.dev/v1alpha1

--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -1,15 +1,15 @@
 ## Introduction
 This document provides a high level overview of Actions Runner Controller (ARC). ARC enables running Github Actions Runners on Kubernetes(K8s) clusters.
 
-This document provides a background of Github Actions, Self-hosted Runners and overview of ARCis also provided. By the end of the doc, the reader is expected to have a good understanding of ARC, setup and try out basic scenarios and set the foundation to review other advanced topics covered outside of the doc
+This document provides a background of Github Actions, Self-hosted Runners and overview of ARCis also provided. By the end of the doc, the reader is expected to have a good understanding of ARC, setup and try out basic scenarios and set the foundation to review other advanced topics covered outside of the doc.
 
 ## GitHub Actions
 GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform to automate your build, test, and deployment pipeline. 
 
-You can create workflows that build and test every pull request to your repository, or deploy merged pull requests to production.Your workflow contains one or more jobs which can run in sequential order or in parallel. Each job will run inside its own runner and has one or more steps that either run a script that you define or run an action, which is a reusable extension that can simplify your workflow.To learn more about about Actions - see [here](https://docs.github.com/en/actions/learn-github-actions)
+You can create workflows that build and test every pull request to your repository, or deploy merged pull requests to production. Your workflow contains one or more jobs which can run in sequential order or in parallel. Each job will run inside its own runner and has one or more steps that either run a script that you define or run an action, which is a reusable extension that can simplify your workflow. To learn more about about Actions - see "[Github Actions](https://docs.github.com/en/actions/learn-github-actions)."
 
 ## Runners
-Runners execute the job that is assigned to them by Github Actions workflow. There are two types of Runners 
+Runners execute the job that is assigned to them by Github Actions workflow. There are two types of Runners.. 
 - Github hosted runners - GitHub provides Linux, Windows, and macOS virtual machines to run your workflows. These virtual machines are hosted in the cloud by Github.
 - Self hosted runners - you can host your own self-hosted runners in your own data center or cloud infrastructure. ARC deploys self hosted runners.
 
@@ -18,9 +18,9 @@ Self-hosted runners offer more control of hardware, operating system, and softwa
 
 ### Types of Self hosted runners
 Self-hosted runners can be physical, virtual, in a container, on-premises, or in a cloud.
-- Traditional Deployment is having a physical machine, with OS and apps on it. The runner runs on this machine and executes any jobs. it comes with the cost of owning and operating the hardware 24/7 even if it isn't in use that entire time. 
+- Traditional Deployment is having a physical machine, with OS and apps on it. The runner runs on this machine and executes any jobs. It comes with the cost of owning and operating the hardware 24/7 even if it isn't in use that entire time. 
 - Virtualized deployments are simpler to manage. Each runner runs on a virtual machine (VM) that runs on a host. There could be multiple such VMs running on the same host. VMs are complete OS’s and might take time to bring up everytime a clean environment is needed to run workflows.
-- Containerized deployments are similar to VMs, but instead of bringing up entire VM’s , a container gets deployed.Kubernetes (K8s) provides a scalable and reproducible environment for containerized workloads. They are lightweight, loosely coupled, highly efficient and can be managed centrally.There are advantages to using Kubernetes (outlined [here](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/)), but it is more complicated and less widely-understood than the other options. A managed provider makes this much simpler to run at scale.
+- Containerized deployments are similar to VMs, but instead of bringing up entire VM’s, a container gets deployed.Kubernetes (K8s) provides a scalable and reproducible environment for containerized workloads. They are lightweight, loosely coupled, highly efficient and can be managed centrally. There are advantages to using Kubernetes (outlined "[here](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/)."), but it is more complicated and less widely-understood than the other options. A managed provider makes this much simpler to run at scale.
 
 *Actions Runner Controller(ARC) makes it simpler to run self hosted runners on K8s managed containers.*
 
@@ -28,15 +28,15 @@ Self-hosted runners can be physical, virtual, in a container, on-premises, or in
 ARC  is a K8s controller to create self-hosted runners on your K8s cluster. With few commands, you can set up self hosted runners that can scale up and down based on demand. And since these could be ephemeral and based on containers, new instances of the runner can be brought up rapidly and cleanly.
 
 ### Deploying ARC
-We have a quick start guide that demonstrates how to easily deploy ARC into your K8s environment. For more details, see `QuickStart Guide` [here](*todo - add link*)
+We have a quick start guide that demonstrates how to easily deploy ARC into your K8s environment. For more details, see `QuickStart Guide` "[here](*todo - add link*)."
 
 ## ARC components
 ARC basically consists of a set of custom resources. An ARC deployment is applying these custom resources onto a K8s cluster. Once applied, it creates a set of Pods, with the Github Actions runner running within them. Github is now able to treat these Pods as self hosted runners and allocate jobs to them.
 
 ### Custom resources 
-ARC consists of several custom resource definitions (Runner,Runner Set, Runner Deployment,Runner Replica Set and Horizontal Runner AutoScaler). For more information on CRDs, refer [here](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+ARC consists of several custom resource definitions (Runner, Runner Set, Runner Deployment, Runner Replica Set and Horizontal Runner AutoScaler). For more information on CRDs, refer "[Kubernetes Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)."
 
-The helm command (in the QuickStart guide) installs the custom resources into the actions-runner-system namespace
+The helm command (in the QuickStart guide) installs the custom resources into the actions-runner-system namespace.
 ```code
 helm install -f custom-values.yaml --wait --namespace actions-runner-system \
   --create-namespace actions-runner-controller \
@@ -44,7 +44,7 @@ helm install -f custom-values.yaml --wait --namespace actions-runner-system \
  ```
 
 ### Runner deployment
-Once the custom resources are installed, another command deploys ARC into your K8s cluster
+Once the custom resources are installed, another command deploys ARC into your K8s cluster.
 
 ![actions-runner-controller architecture](https://user-images.githubusercontent.com/53718047/183928236-ddf72c15-1d11-4304-ad6f-0a0ff251ca55.jpg)
 
@@ -70,21 +70,21 @@ spec:
 - `repository: mumoshu/actions-runner-controller-ci` : is the repository to link to when the pod comes up with the Actions runner (Note, this can configured to link at Enterprise or Organization level also).
 
 When this configuration is applied with `kubectl apply -f runnerdeployment.yaml` , ARC creates one pod `example-runnerdeploy-[**]` with 2 containers `runner` and `docker`.
-`runne` container has the github runner component installed, `docker` container has docker installed.
+`runner` container has the github runner component installed, `docker` container has docker installed.
 
 
 ### The Runner container image
-The GitHub hosted runners include a large amount of pre-installed software packages. For complete list, see [here](https://github.com/actions/virtual-environments/tree/main/images/linux) 
+The GitHub hosted runners include a large amount of pre-installed software packages. For complete list, see "[Runner images](https://github.com/actions/virtual-environments/tree/main/images/linux)."
 
-ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. They contain subset of packages from the GitHub runners: Basic CLI packages,git,docker and build-essentials
+ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. They contain subset of packages from the GitHub runners: Basic CLI packages, git, docker and build-essentials.
 
 The virtual environments from GitHub contain a lot more software packages (different versions of Java, Node.js, Golang, .NET, etc) .Most of these have dedicated setup actions which allow the tools to be installed on-demand in a workflow, for example: `actions/setup-java` or `actions/setup-node`
 
 ## Executing workflows
-Now, all the setup and configuration is done. A workflow can be created in the same repository that could target the self hosted runner created from ARC. The workflow needs to have `runs-on: self-hosted` so it can target the self host pool. For more information on targeting workflows to run on self hosted runners, see [here](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow)
+Now, all the setup and configuration is done. A workflow can be created in the same repository that could target the self hosted runner created from ARC. The workflow needs to have `runs-on: self-hosted` so it can target the self host pool. For more information on targeting workflows to run on self hosted runners, see "[Using Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow)."
 
 ## Scaling runners - statically with replicas count
-With a small tweak to the replicas count (for eg - `replicas: 2`) in the `runnerdeployment.yaml` file, more runners can be created. Depending on the count of replicas, those many sets of pods would be created. As before, Each pod contains the two containers 
+With a small tweak to the replicas count (for eg - `replicas: 2`) in the `runnerdeployment.yaml` file, more runners can be created. Depending on the count of replicas, those many sets of pods would be created. As before, Each pod contains the two containers.
 
 
 ## Scaling runners - dynamically with Pull Driven Scaling
@@ -95,8 +95,8 @@ ARC also allows for scaling the runners dynamically. There are two mechanisms fo
 
 
 You can enable scaling with 3 steps
-1) Enable `HorizontalRunnerAutoscaler` - Create a `deployment.yaml` file of type `HorizontalRunnerAutoscaler`. The schema for this file is defined below
-2) Scaling parameters - `minReplicas` and `maxReplicas` indicates the min and max number of replicas to scale to
+1) Enable `HorizontalRunnerAutoscaler` - Create a `deployment.yaml` file of type `HorizontalRunnerAutoscaler`. The schema for this file is defined below.
+2) Scaling parameters - `minReplicas` and `maxReplicas` indicates the min and max number of replicas to scale to.
 3) Scaling metrics - ARC supports two types of scaling metrics. `TotalNumberOfQueuedAndInProgressWorkflowRuns` and `PercentageRunnersBusy`. These indicate the type of scaling to employ.
 
 The `TotalNumberOfQueuedAndInProgressWorkflowRuns` metric polls GitHub for all pending workflow runs against a given set of repositories. The metric will scale the runner count up to the total number of pending jobs at the sync time up to the `maxReplicas` configuration.
@@ -120,13 +120,13 @@ spec:
   metrics: []
   ```
 
-For examples - please see [here](https://github.com/actions-runner-controller/actions-runner-controller#pull-driven-scaling)
+For examples - please see "[Pull Driven Scaling examples](https://github.com/actions-runner-controller/actions-runner-controller#pull-driven-scaling)."
 
 *The period between polls is defined by the controller's `--sync-period` flag. If this flag isn't provided then the controller defaults to a sync period of `1m`, this can be configured in seconds or minutes.*
 
 ## Other Configurations
-ARC supports several different advanced configuration 
-- support for alternate runners : Setting up runner pods with Docker-In-Docker configuration
+ARC supports several different advanced configuration. 
+- support for alternate runners : Setting up runner pods with Docker-In-Docker configuration.
 - managing runner groups : Managing a set of running with runner groups thus making it easy to manage different groups within enterprise
 - Webhook driven scaling. 
 

--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -1,20 +1,21 @@
 ## Introduction
-This document provides a high level overview of Actions Runner Controller (ARC). ARC enables running Github Actions Runners on Kubernetes(K8s) clusters.
+This document provides a high level overview of Actions Runner Controller (ARC). ARC enables running Github Actions Runners on Kubernetes (K8s) clusters.
 
-This document provides a background of Github Actions, Self-hosted Runners and overview of ARCis also provided. By the end of the doc, the reader is expected to have a good understanding of ARC, setup and try out basic scenarios and set the foundation to review other advanced topics covered outside of the doc.
+This document provides a background of Github Actions, self-hosted runners and ARC overview. By the end of the doc, the reader should have a foundation with basic scenarios and be capable of reviewing other advanced topics.
 
 ## GitHub Actions
-GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform to automate your build, test, and deployment pipeline. 
+[GitHub Actions]](https://github.com/features/actions) is a continuous integration and continuous delivery (CI/CD) platform to automate your build, test, and deployment pipeline. 
 
-You can create workflows that build and test every pull request to your repository, or deploy merged pull requests to production. Your workflow contains one or more jobs which can run in sequential order or in parallel. Each job will run inside its own runner and has one or more steps that either run a script that you define or run an action, which is a reusable extension that can simplify your workflow. To learn more about about Actions - see "[Github Actions](https://docs.github.com/en/actions/learn-github-actions)."
+You can create workflows that build and test every pull request to your repository, or deploy merged pull requests to production. Your workflow contains one or more jobs which can run in sequential order or in parallel. Each job will run inside its own runner and has one or more steps that either run a script that you define or run an action, which is a reusable extension that can simplify your workflow. To learn more about about Actions - see "[Learn Github Actions](https://docs.github.com/en/actions/learn-github-actions)".
 
 ## Runners
-Runners execute the job that is assigned to them by Github Actions workflow. There are two types of Runners.. 
-- Github hosted runners - GitHub provides Linux, Windows, and macOS virtual machines to run your workflows. These virtual machines are hosted in the cloud by Github.
-- Self hosted runners - you can host your own self-hosted runners in your own data center or cloud infrastructure. ARC deploys self hosted runners.
+Runners execute the job that is assigned to them by Github Actions workflow. There are two types of Runners:
+
+- [Github-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) - GitHub provides Linux, Windows, and macOS virtual machines to run your workflows. These virtual machines are hosted in the cloud by Github.
+- [Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) - you can host your own self-hosted runners in your own data center or cloud infrastructure. ARC deploys self-hosted runners.
 
 ## Self hosted runners
-Self-hosted runners offer more control of hardware, operating system, and software tools than GitHub-hosted runners. With self-hosted runners, you can create custom hardware configurations that meet your needs with processing power or memory to run larger jobs, install software available on your local network, and choose an operating system not offered by GitHub-hosted runners. 
+Self-hosted runners offer more control of hardware, operating system, and software tools than GitHub-hosted runners. With self-hosted runners, you can create custom hardware configurations that meet your needs with processing power or memory to run larger jobs, install software available on your local network, and choose an operating system not offered by GitHub-hosted runners.
 
 ### Types of Self hosted runners
 Self-hosted runners can be physical, virtual, in a container, on-premises, or in a cloud.
@@ -37,7 +38,7 @@ ARC basically consists of a set of custom resources. An ARC deployment is applyi
 ARC consists of several custom resource definitions (Runner, Runner Set, Runner Deployment, Runner Replica Set and Horizontal Runner AutoScaler). For more information on CRDs, refer "[Kubernetes Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)."
 
 The helm command (in the QuickStart guide) installs the custom resources into the actions-runner-system namespace.
-```code
+```console
 helm install -f custom-values.yaml --wait --namespace actions-runner-system \
   --create-namespace actions-runner-controller \
   actions-runner-controller/actions-runner-controller
@@ -50,10 +51,10 @@ Once the custom resources are installed, another command deploys ARC into your K
 
 
 
-The `Deployment and Configure ARC` section in the `Quick Start guide` lists the steps to deploy ARC using a `runnerdeployment.yaml` file. Here, we will explain the details 
+The `Deployment and Configure ARC` section in the `Quick Start guide` lists the steps to deploy ARC using a `runnerdeployment.yaml` file. Here, we will explain the details
 For more details, see "[QuickStart Guide](https://github.com/actions-runner-controller/actions-runner-controller/blob/master/QuickStartGuide.md)."
 
-```code
+```yaml
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:
@@ -67,7 +68,7 @@ spec:
 
 - `kind: RunnerDeployment`: indicates its a kind of custom resource RunnerDeployment.
 - `replicas: 1` : will deploy one replica. Multiple replicas can also be deployed ( more on that later).
-- `repository: mumoshu/actions-runner-controller-ci` : is the repository to link to when the pod comes up with the Actions runner (Note, this can configured to link at Enterprise or Organization level also).
+- `repository: mumoshu/actions-runner-controller-ci` : is the repository to link to when the pod comes up with the Actions runner (Note, this can be configured to link at the Enterprise or Organization level also).
 
 When this configuration is applied with `kubectl apply -f runnerdeployment.yaml` , ARC creates one pod `example-runnerdeploy-[**]` with 2 containers `runner` and `docker`.
 `runner` container has the github runner component installed, `docker` container has docker installed.
@@ -76,7 +77,7 @@ When this configuration is applied with `kubectl apply -f runnerdeployment.yaml`
 ### The Runner container image
 The GitHub hosted runners include a large amount of pre-installed software packages. For complete list, see "[Runner images](https://github.com/actions/virtual-environments/tree/main/images/linux)."
 
-ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. They contain subset of packages from the GitHub runners: Basic CLI packages, git, docker and build-essentials. To install additional software, it is recommended to use the corresponding setup actions. For instance, `actions/setup-java` for Java or `actions/setup-node` for Node.
+ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version. These images do not contain all of the software installed on the GitHub runners. They contain subset of packages from the GitHub runners: Basic CLI packages, git, docker and build-essentials. To install additional software, it is recommended to use the corresponding setup actions. For instance, `actions/setup-java` for Java or `actions/setup-node` for Node.
 
 ## Executing workflows
 Now, all the setup and configuration is done. A workflow can be created in the same repository that could target the self hosted runner created from ARC. The workflow needs to have `runs-on: self-hosted` so it can target the self host pool. For more information on targeting workflows to run on self hosted runners, see "[Using Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow)."
@@ -98,7 +99,7 @@ You can enable scaling with 3 steps
 3) Scaling metrics - ARC currently supports `PercentageRunnersBusy` as a metric type. The `PercentageRunnersBusy` will poll GitHub for the number of runners in the `busy` state in the RunnerDeployment's namespace, it will then scale depending on how you have configured the scale factors.
 
 ### Pull Driven Scaling Schema
-```code
+```yaml
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: HorizontalRunnerAutoscaler
 metadata:
@@ -106,9 +107,8 @@ metadata:
 spec:
   scaleTargetRef:
     # Your RunnerDeployment Here
-    name: example-runner-deployment
-    # Uncomment the below in case the target is not RunnerDeployment but RunnerSet
-    #kind: RunnerSet
+    name: example-runnerdeploy
+    kind: RunnerDeployment
   minReplicas: 1
   maxReplicas: 5
   # Your chosen scaling metrics here
@@ -123,6 +123,6 @@ For examples - please see "[Pull Driven Scaling examples](https://github.com/act
 ARC supports several different advanced configuration. 
 - support for alternate runners : Setting up runner pods with Docker-In-Docker configuration.
 - managing runner groups : Managing a set of running with runner groups thus making it easy to manage different groups within enterprise
-- Webhook driven scaling. 
+- Webhook driven scaling.
 
 Please refer to the documentation in this repo for further details.

--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -111,8 +111,12 @@ spec:
     kind: RunnerDeployment
   minReplicas: 1
   maxReplicas: 5
-  # Your chosen scaling metrics here
-  metrics: []
+  metrics:
+  - type: PercentageRunnersBusy
+    scaleUpThreshold: '0.75'
+    scaleDownThreshold: '0.25'
+    scaleUpFactor: '2'
+    scaleDownFactor: '0.5'
   ```
 
 For examples - please see "[Pull Driven Scaling examples](https://github.com/actions-runner-controller/actions-runner-controller#pull-driven-scaling)."

--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -119,7 +119,7 @@ spec:
     scaleDownFactor: '0.5'
   ```
 
-For examples - please see "[Pull Driven Scaling examples](https://github.com/actions-runner-controller/actions-runner-controller#pull-driven-scaling)."
+For more details - please see "[Pull Driven Scaling](https://github.com/actions-runner-controller/actions-runner-controller#pull-driven-scaling)."
 
 *The period between polls is defined by the controller's `--sync-period` flag. If this flag isn't provided then the controller defaults to a sync period of `1m`, this can be configured in seconds or minutes.*
 

--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -76,9 +76,7 @@ When this configuration is applied with `kubectl apply -f runnerdeployment.yaml`
 ### The Runner container image
 The GitHub hosted runners include a large amount of pre-installed software packages. For complete list, see "[Runner images](https://github.com/actions/virtual-environments/tree/main/images/linux)."
 
-ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. They contain subset of packages from the GitHub runners: Basic CLI packages, git, docker and build-essentials.
-
-The virtual environments from GitHub contain a lot more software packages (different versions of Java, Node.js, Golang, .NET, etc) .Most of these have dedicated setup actions which allow the tools to be installed on-demand in a workflow, for example: `actions/setup-java` or `actions/setup-node`
+ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. They contain subset of packages from the GitHub runners: Basic CLI packages, git, docker and build-essentials. To install additional software, it is recommended to use the corresponding setup actions. For instance, `actions/setup-java` for Java or `actions/setup-node` for Node.
 
 ## Executing workflows
 Now, all the setup and configuration is done. A workflow can be created in the same repository that could target the self hosted runner created from ARC. The workflow needs to have `runs-on: self-hosted` so it can target the self host pool. For more information on targeting workflows to run on self hosted runners, see "[Using Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow)."
@@ -97,10 +95,7 @@ ARC also allows for scaling the runners dynamically. There are two mechanisms fo
 You can enable scaling with 3 steps
 1) Enable `HorizontalRunnerAutoscaler` - Create a `deployment.yaml` file of type `HorizontalRunnerAutoscaler`. The schema for this file is defined below.
 2) Scaling parameters - `minReplicas` and `maxReplicas` indicates the min and max number of replicas to scale to.
-3) Scaling metrics - ARC supports two types of scaling metrics. `TotalNumberOfQueuedAndInProgressWorkflowRuns` and `PercentageRunnersBusy`. These indicate the type of scaling to employ.
-
-The `TotalNumberOfQueuedAndInProgressWorkflowRuns` metric polls GitHub for all pending workflow runs against a given set of repositories. The metric will scale the runner count up to the total number of pending jobs at the sync time up to the `maxReplicas` configuration.
-The `PercentageRunnersBusy` will poll GitHub for the number of runners in the `busy` state which live in the RunnerDeployment's namespace, it will then scale depending on how you have configured the scale factors.
+3) Scaling metrics - ARC currently supports `PercentageRunnersBusy` as a metric type. The `PercentageRunnersBusy` will poll GitHub for the number of runners in the `busy` state in the RunnerDeployment's namespace, it will then scale depending on how you have configured the scale factors.
 
 ### Pull Driven Scaling Schema
 ```code

--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -1,42 +1,42 @@
 ## Introduction
-This document provides a high level overview of Actions Runner Controller (ARC). 
+This document provides a high level overview of Actions Runner Controller (ARC). ARC enables running Github Actions Runners on Kubernetes(K8s) clusters.
 
-ARC enables running Github Actions Runners on Kubernetes(K8s) clusters. A background of Github Actions, Runners is also provided.By the end of the doc, the reader is expected to have a good understanding of ARC, setup and try out basic scenarios and set the foundation to review other advanced topics covered outside of the doc
+This document provides a background of Github Actions, Self-hosted Runners and overview of ARCis also provided. By the end of the doc, the reader is expected to have a good understanding of ARC, setup and try out basic scenarios and set the foundation to review other advanced topics covered outside of the doc
 
 ## GitHub Actions
-GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform that allows you to automate your build, test, and deployment pipeline. 
+GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform to automate your build, test, and deployment pipeline. 
 
-You can create workflows that build and test every pull request to your repository, or deploy merged pull requests to production.Your workflow contains one or more jobs which can run in sequential order or in parallel. Each job will run inside its own runner and has one or more steps that either run a script that you define or run an action, which is a reusable extension that can simplify your workflow.To learn more about about Actions - see here
+You can create workflows that build and test every pull request to your repository, or deploy merged pull requests to production.Your workflow contains one or more jobs which can run in sequential order or in parallel. Each job will run inside its own runner and has one or more steps that either run a script that you define or run an action, which is a reusable extension that can simplify your workflow.To learn more about about Actions - see [here](https://docs.github.com/en/actions/learn-github-actions)
 
 ## Runners
 Runners execute the job that is assigned to them by Github Actions workflow. There are two types of Runners 
-- Github managed runners - GitHub provides Linux, Windows, and macOS virtual machines to run your workflows. These virtual machines are hosted in the cloud by Github.
-- Self hosted runners - you can host your own self-hosted runners in your own data center or cloud infrastructure.ARC deploys self hosted runners.
+- Github hosted runners - GitHub provides Linux, Windows, and macOS virtual machines to run your workflows. These virtual machines are hosted in the cloud by Github.
+- Self hosted runners - you can host your own self-hosted runners in your own data center or cloud infrastructure. ARC deploys self hosted runners.
 
 ## Self hosted runners
 Self-hosted runners offer more control of hardware, operating system, and software tools than GitHub-hosted runners. With self-hosted runners, you can create custom hardware configurations that meet your needs with processing power or memory to run larger jobs, install software available on your local network, and choose an operating system not offered by GitHub-hosted runners. 
 
 ### Types of Self hosted runners
 Self-hosted runners can be physical, virtual, in a container, on-premises, or in a cloud.
-- Traditional Deployment is having a physical machine, with OS and apps on it. The runner runs on this machine and executes any jobs from GHActions. it comes with the cost of owning and operating the hardware 24/7 even if it isn't in use that entire time. 
-- Virtualized deployments are simpler to manage. Each runner runs on a virtual machine that runs on a host. There could be multiple such VMs running on the same host. Virtual machines are complete OS’s and might take time to bring up everytime a clean environment is needed to run workflows.
-- Containerized deployments are similar to VMs, but instead of bringing up entire VM’s , a container gets deployed.Kubernetes (K8s) provides a scalable and reproducible environment for containerized workloads. They are lightweight, loosely coupled, highly efficient and can be managed centrally.There are advantages to using Kubernetes (outlined here), but it is more complicated and less widely-understood than the other options. A managed provider makes this much simpler to run at scale.
+- Traditional Deployment is having a physical machine, with OS and apps on it. The runner runs on this machine and executes any jobs. it comes with the cost of owning and operating the hardware 24/7 even if it isn't in use that entire time. 
+- Virtualized deployments are simpler to manage. Each runner runs on a virtual machine (VM) that runs on a host. There could be multiple such VMs running on the same host. VMs are complete OS’s and might take time to bring up everytime a clean environment is needed to run workflows.
+- Containerized deployments are similar to VMs, but instead of bringing up entire VM’s , a container gets deployed.Kubernetes (K8s) provides a scalable and reproducible environment for containerized workloads. They are lightweight, loosely coupled, highly efficient and can be managed centrally.There are advantages to using Kubernetes (outlined [here](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/)), but it is more complicated and less widely-understood than the other options. A managed provider makes this much simpler to run at scale.
 
 *Actions Runner Controller(ARC) makes it simpler to run self hosted runners on K8s managed containers.*
 
 ## Actions Runner Controller (ARC)
-ARC  is a Kubernetes controller to create self-hosted runners on your K8s cluster. With few commands, you can set up self hosted runners that can scale up and down based on demand. And since these could be ephemeral and based on containers, new instances of the runner can be brought up rapidly and cleanly.
+ARC  is a K8s controller to create self-hosted runners on your K8s cluster. With few commands, you can set up self hosted runners that can scale up and down based on demand. And since these could be ephemeral and based on containers, new instances of the runner can be brought up rapidly and cleanly.
 
 ### Deploying ARC
-We have a quick start guide that demonstrates how to easily deploy ARC into your K8s environment. For more details, see here *todo - add link*
+We have a quick start guide that demonstrates how to easily deploy ARC into your K8s environment. For more details, see `QuickStart Guide` [here](*todo - add link*)
 
 ## ARC components
 ARC basically consists of a set of custom resources. An ARC deployment is applying these custom resources onto a K8s cluster. Once applied, it creates a set of Pods, with the Github Actions runner running within them. Github is now able to treat these Pods as self hosted runners and allocate jobs to them.
 
 ### Custom resources 
-ARC consists of the following custom resource definitions (Runner,Runner Set, Runner Deployment,Runner Replica Set and Horizontal Runner AutoScaler). For more information on CRDS, refer [here](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+ARC consists of several custom resource definitions (Runner,Runner Set, Runner Deployment,Runner Replica Set and Horizontal Runner AutoScaler). For more information on CRDs, refer [here](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
-The Helm command (in the QuickStart guide) installs the custom resources into the actions-runner-system namespace
+The helm command (in the QuickStart guide) installs the custom resources into the actions-runner-system namespace
 ```code
 helm install -f custom-values.yaml --wait --namespace actions-runner-system \
   --create-namespace actions-runner-controller \
@@ -50,7 +50,7 @@ Once the custom resources are installed, another command deploys ARC into your K
 
 
 
-The `Deployment and Configure ARC` section in the `Quick Start guide` lists the step to deploy ARC using a `runnerdeployment.yaml` file. Here, we will explain the details 
+The `Deployment and Configure ARC` section in the `Quick Start guide` lists the steps to deploy ARC using a `runnerdeployment.yaml` file. Here, we will explain the details 
 For more information on `Quick Start` guide, see [here] (todo - add link to quick start)
 
 ```code
@@ -65,18 +65,18 @@ spec:
       repository: mumoshu/actions-runner-controller-ci
 ```
 
-- `kind: RunnerDeployment`: indicates its a kind of custom resource RunnerDeployment**
-- `replicas: 1` : will deploy one replica. Multiple replicas can also be deployed ( more on that later)**
-- `repository: mumoshu/actions-runner-controller-ci` : is the repository to link to when the pod comes up with the Actions runner (Note, this can configured to link at Enterprise or Organization level also)**
+- `kind: RunnerDeployment`: indicates its a kind of custom resource RunnerDeployment.
+- `replicas: 1` : will deploy one replica. Multiple replicas can also be deployed ( more on that later).
+- `repository: mumoshu/actions-runner-controller-ci` : is the repository to link to when the pod comes up with the Actions runner (Note, this can configured to link at Enterprise or Organization level also).
 
-When this configuration is applied with `kubectl apply -f runnerdeployment.yaml` , ARC creates one pod `example-runnerdeploy-[**]` with 2 containers 'runner' and 'docker'.
-'runner' container has the github runner component installed 'docker' container has docker installed.
+When this configuration is applied with `kubectl apply -f runnerdeployment.yaml` , ARC creates one pod `example-runnerdeploy-[**]` with 2 containers `runner` and `docker`.
+`runne` container has the github runner component installed, `docker` container has docker installed.
 
 
 ### The Runner container image
 The GitHub hosted runners include a large amount of pre-installed software packages. For complete list, see [here](https://github.com/actions/virtual-environments/tree/main/images/linux) 
 
-ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. The images contain subset of packages from the GitHub runners: Basic CLI packages,git,docker and build-essentials
+ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. They contain subset of packages from the GitHub runners: Basic CLI packages,git,docker and build-essentials
 
 The virtual environments from GitHub contain a lot more software packages (different versions of Java, Node.js, Golang, .NET, etc) .Most of these have dedicated setup actions which allow the tools to be installed on-demand in a workflow, for example: `actions/setup-java` or `actions/setup-node`
 
@@ -84,7 +84,7 @@ The virtual environments from GitHub contain a lot more software packages (diffe
 Now, all the setup and configuration is done. A workflow can be created in the same repository that could target the self hosted runner created from ARC. The workflow needs to have `runs-on: self-hosted` so it can target the self host pool. For more information on targeting workflows to run on self hosted runners, see [here](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow)
 
 ## Scaling runners - statically with replicas count
-With a small tweak to the replicas count (for eg - `replicas: 2`) in the runnerdeployment.yaml file, more runners can be created. Depending on the count of replicas, those many sets of pods would be created. As before, Each pod contains the two containers 
+With a small tweak to the replicas count (for eg - `replicas: 2`) in the `runnerdeployment.yaml` file, more runners can be created. Depending on the count of replicas, those many sets of pods would be created. As before, Each pod contains the two containers 
 
 
 ## Scaling runners - dynamically with Pull Driven Scaling
@@ -95,7 +95,7 @@ ARC also allows for scaling the runners dynamically. There are two mechanisms fo
 
 
 You can enable scaling with 3 steps
-1) Enable `HorizontalRunnerAutoscaler` - Create a deployment.yaml file of type `HorizontalRunnerAutoscaler`. 
+1) Enable `HorizontalRunnerAutoscaler` - Create a `deployment.yaml` file of type `HorizontalRunnerAutoscaler`. The schema for this file is defined below
 2) Scaling parameters - `minReplicas` and `maxReplicas` indicates the min and max number of replicas to scale to
 3) Scaling metrics - ARC supports two types of scaling metrics. `TotalNumberOfQueuedAndInProgressWorkflowRuns` and `PercentageRunnersBusy`. These indicate the type of scaling to employ.
 

--- a/Actions-Runner-Controller-Overview.md
+++ b/Actions-Runner-Controller-Overview.md
@@ -1,0 +1,133 @@
+## Introduction
+This document provides a high level overview of Actions Runner Controller (ARC). 
+
+ARC enables running Github Actions Runners on Kubernetes(K8s) clusters. A background of Github Actions, Runners is also provided.By the end of the doc, the reader is expected to have a good understanding of ARC, setup and try out basic scenarios and set the foundation to review other advanced topics covered outside of the doc
+
+## GitHub Actions
+GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform that allows you to automate your build, test, and deployment pipeline. 
+
+You can create workflows that build and test every pull request to your repository, or deploy merged pull requests to production.Your workflow contains one or more jobs which can run in sequential order or in parallel. Each job will run inside its own runner and has one or more steps that either run a script that you define or run an action, which is a reusable extension that can simplify your workflow.To learn more about about Actions - see here
+
+## Runners
+Runners execute the job that is assigned to them by Github Actions workflow. There are two types of Runners 
+- Github managed runners - GitHub provides Linux, Windows, and macOS virtual machines to run your workflows. These virtual machines are hosted in the cloud by Github.
+- Self hosted runners - you can host your own self-hosted runners in your own data center or cloud infrastructure.ARC deploys self hosted runners.
+
+## Self hosted runners
+Self-hosted runners offer more control of hardware, operating system, and software tools than GitHub-hosted runners. With self-hosted runners, you can create custom hardware configurations that meet your needs with processing power or memory to run larger jobs, install software available on your local network, and choose an operating system not offered by GitHub-hosted runners. 
+
+### Types of Self hosted runners
+Self-hosted runners can be physical, virtual, in a container, on-premises, or in a cloud.
+- Traditional Deployment is having a physical machine, with OS and apps on it. The runner runs on this machine and executes any jobs from GHActions. it comes with the cost of owning and operating the hardware 24/7 even if it isn't in use that entire time. 
+- Virtualized deployments are simpler to manage. Each runner runs on a virtual machine that runs on a host. There could be multiple such VMs running on the same host. Virtual machines are complete OS’s and might take time to bring up everytime a clean environment is needed to run workflows.
+- Containerized deployments are similar to VMs, but instead of bringing up entire VM’s , a container gets deployed.Kubernetes (K8s) provides a scalable and reproducible environment for containerized workloads. They are lightweight, loosely coupled, highly efficient and can be managed centrally.There are advantages to using Kubernetes (outlined here), but it is more complicated and less widely-understood than the other options. A managed provider makes this much simpler to run at scale.
+
+*Actions Runner Controller(ARC) makes it simpler to run self hosted runners on K8s managed containers.*
+
+## Actions Runner Controller (ARC)
+ARC  is a Kubernetes controller to create self-hosted runners on your K8s cluster. With few commands, you can set up self hosted runners that can scale up and down based on demand. And since these could be ephemeral and based on containers, new instances of the runner can be brought up rapidly and cleanly.
+
+### Deploying ARC
+We have a quick start guide that demonstrates how to easily deploy ARC into your K8s environment. For more details, see here *todo - add link*
+
+## ARC components
+ARC basically consists of a set of custom resources. An ARC deployment is applying these custom resources onto a K8s cluster. Once applied, it creates a set of Pods, with the Github Actions runner running within them. Github is now able to treat these Pods as self hosted runners and allocate jobs to them.
+
+### Custom resources 
+ARC consists of the following custom resource definitions (Runner,Runner Set, Runner Deployment,Runner Replica Set and Horizontal Runner AutoScaler). For more information on CRDS, refer [here](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+
+The Helm command (in the QuickStart guide) installs the custom resources into the actions-runner-system namespace
+```code
+helm install -f custom-values.yaml --wait --namespace actions-runner-system \
+  --create-namespace actions-runner-controller \
+  actions-runner-controller/actions-runner-controller
+ ```
+
+### Runner deployment
+Once the custom resources are installed, another command deploys ARC into your K8s cluster
+
+![actions-runner-controller architecture](https://user-images.githubusercontent.com/53718047/183928236-ddf72c15-1d11-4304-ad6f-0a0ff251ca55.jpg)
+
+
+
+The `Deployment and Configure ARC` section in the `Quick Start guide` lists the step to deploy ARC using a `runnerdeployment.yaml` file. Here, we will explain the details 
+For more information on `Quick Start` guide, see [here] (todo - add link to quick start)
+
+```code
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: example-runnerdeploy
+spec:
+  replicas: 1
+  template:
+    spec:
+      repository: mumoshu/actions-runner-controller-ci
+```
+
+- `kind: RunnerDeployment`: indicates its a kind of custom resource RunnerDeployment**
+- `replicas: 1` : will deploy one replica. Multiple replicas can also be deployed ( more on that later)**
+- `repository: mumoshu/actions-runner-controller-ci` : is the repository to link to when the pod comes up with the Actions runner (Note, this can configured to link at Enterprise or Organization level also)**
+
+When this configuration is applied with `kubectl apply -f runnerdeployment.yaml` , ARC creates one pod `example-runnerdeploy-[**]` with 2 containers 'runner' and 'docker'.
+'runner' container has the github runner component installed 'docker' container has docker installed.
+
+
+### The Runner container image
+The GitHub hosted runners include a large amount of pre-installed software packages. For complete list, see [here](https://github.com/actions/virtual-environments/tree/main/images/linux) 
+
+ARC maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. The images contain subset of packages from the GitHub runners: Basic CLI packages,git,docker and build-essentials
+
+The virtual environments from GitHub contain a lot more software packages (different versions of Java, Node.js, Golang, .NET, etc) .Most of these have dedicated setup actions which allow the tools to be installed on-demand in a workflow, for example: `actions/setup-java` or `actions/setup-node`
+
+## Executing workflows
+Now, all the setup and configuration is done. A workflow can be created in the same repository that could target the self hosted runner created from ARC. The workflow needs to have `runs-on: self-hosted` so it can target the self host pool. For more information on targeting workflows to run on self hosted runners, see [here](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow)
+
+## Scaling runners - statically with replicas count
+With a small tweak to the replicas count (for eg - `replicas: 2`) in the runnerdeployment.yaml file, more runners can be created. Depending on the count of replicas, those many sets of pods would be created. As before, Each pod contains the two containers 
+
+
+## Scaling runners - dynamically with Pull Driven Scaling
+ARC also allows for scaling the runners dynamically. There are two mechanisms for dynamically scaling - (1) Webhook driven scaling and (2) Pull Driven scaling, This document describes the Pull Driven scaling model.
+
+![actions-runner-controller architecture_2](https://user-images.githubusercontent.com/53718047/183928429-7000329d-38eb-4054-9879-41ae44e1ff85.jpg)
+
+
+
+You can enable scaling with 3 steps
+1) Enable `HorizontalRunnerAutoscaler` - Create a deployment.yaml file of type `HorizontalRunnerAutoscaler`. 
+2) Scaling parameters - `minReplicas` and `maxReplicas` indicates the min and max number of replicas to scale to
+3) Scaling metrics - ARC supports two types of scaling metrics. `TotalNumberOfQueuedAndInProgressWorkflowRuns` and `PercentageRunnersBusy`. These indicate the type of scaling to employ.
+
+The `TotalNumberOfQueuedAndInProgressWorkflowRuns` metric polls GitHub for all pending workflow runs against a given set of repositories. The metric will scale the runner count up to the total number of pending jobs at the sync time up to the `maxReplicas` configuration.
+The `PercentageRunnersBusy` will poll GitHub for the number of runners in the `busy` state which live in the RunnerDeployment's namespace, it will then scale depending on how you have configured the scale factors.
+
+### Pull Driven Scaling Schema
+```code
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: example-runner-deployment-autoscaler
+spec:
+  scaleTargetRef:
+    # Your RunnerDeployment Here
+    name: example-runner-deployment
+    # Uncomment the below in case the target is not RunnerDeployment but RunnerSet
+    #kind: RunnerSet
+  minReplicas: 1
+  maxReplicas: 5
+  # Your chosen scaling metrics here
+  metrics: []
+  ```
+
+For examples - please see [here](https://github.com/actions-runner-controller/actions-runner-controller#pull-driven-scaling)
+
+*The period between polls is defined by the controller's `--sync-period` flag. If this flag isn't provided then the controller defaults to a sync period of `1m`, this can be configured in seconds or minutes.*
+
+## Other Configurations
+ARC supports several different advanced configuration 
+- support for alternate runners : Setting up runner pods with Docker-In-Docker configuration
+- managing runner groups : Managing a set of running with runner groups thus making it easy to manage different groups within enterprise
+- Webhook driven scaling. 
+
+Please refer to the documentation in this repo for further details.


### PR DESCRIPTION
The purpose of this doc is a starting point overview to ARC, with links to Quick start guide within. Users can use this doc to get a high level understanding of ARC with a bit more details than the `QuickStart` guide. Note - links to `QuickStart` guide will be updated once that PR gets merged.

README.md will be updated( in a separate PR) with links to this doc post merge.