### PR TITLE
Add Additional Autoscaling Metrics to Prometheus

### DIFF
--- a/controllers/autoscaling.go
+++ b/controllers/autoscaling.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/actions-runner-controller/actions-runner-controller/api/v1alpha1"
+	prometheus_metrics "github.com/actions-runner-controller/actions-runner-controller/controllers/metrics"
 	arcgithub "github.com/actions-runner-controller/actions-runner-controller/github"
 	"github.com/google/go-github/v45/github"
 	corev1 "k8s.io/api/core/v1"
@@ -211,6 +212,20 @@ func (r *HorizontalRunnerAutoscalerReconciler) suggestReplicasByQueuedAndInProgr
 
 	necessaryReplicas := queued + inProgress
 
+	prometheus_metrics.SetHorizontalRunnerAutoscalerQueuedAndInProgressWorkflowRuns(
+		hra.ObjectMeta,
+		st.enterprise,
+		st.org,
+		st.repo,
+		st.kind,
+		st.st,
+		necessaryReplicas,
+		completed,
+		inProgress,
+		queued,
+		unknown,
+	)
+
 	r.Log.V(1).Info(
 		fmt.Sprintf("Suggested desired replicas of %d by TotalNumberOfQueuedAndInProgressWorkflowRuns", necessaryReplicas),
 		"workflow_runs_completed", completed,
@@ -382,6 +397,20 @@ func (r *HorizontalRunnerAutoscalerReconciler) suggestReplicasByPercentageRunner
 	//
 	// - num_runners can be as twice as large as replicas_desired_before while
 	//   the runnerdeployment controller is replacing RunnerReplicaSet for runner update.
+	prometheus_metrics.SetHorizontalRunnerAutoscalerPercentageRunnersBusy(
+		hra.ObjectMeta,
+		st.enterprise,
+		st.org,
+		st.repo,
+		st.kind,
+		st.st,
+		desiredReplicasBefore,
+		desiredReplicas,
+		numRunners,
+		numRunnersRegistered,
+		numRunnersBusy,
+		numTerminatingBusy,
+	)
 
 	r.Log.V(1).Info(
 		fmt.Sprintf("Suggested desired replicas of %d by PercentageRunnersBusy", desiredReplicas),

--- a/controllers/metrics/horizontalrunnerautoscaler.go
+++ b/controllers/metrics/horizontalrunnerautoscaler.go
@@ -7,8 +7,13 @@ import (
 )
 
 const (
-	hraName      = "horizontalrunnerautoscaler"
-	hraNamespace = "namespace"
+	hraName        = "horizontalrunnerautoscaler"
+	hraNamespace   = "namespace"
+	stEnterprise   = "enterprise"
+	stOrganization = "organization"
+	stRepository   = "repository"
+	stKind         = "kind"
+	stName         = "name"
 )
 
 var (
@@ -16,6 +21,17 @@ var (
 		horizontalRunnerAutoscalerMinReplicas,
 		horizontalRunnerAutoscalerMaxReplicas,
 		horizontalRunnerAutoscalerDesiredReplicas,
+		horizontalRunnerAutoscalerReplicasDesiredBefore,
+		horizontalRunnerAutoscalerReplicasDesired,
+		horizontalRunnerAutoscalerNumRunners,
+		horizontalRunnerAutoscalerNumRunnersRegistered,
+		horizontalRunnerAutoscalerNumRunnersBusy,
+		horizontalRunnerAutoscalerNumTerminatingBusy,
+		horizontalRunnerAutoscalerNecessaryReplicas,
+		horizontalRunnerAutoscalerWorkflowRunsCompleted,
+		horizontalRunnerAutoscalerWorkflowRunsInProgress,
+		horizontalRunnerAutoscalerWorkflowRunsQueued,
+		horizontalRunnerAutoscalerWorkflowRunsUnknown,
 	}
 )
 
@@ -41,6 +57,85 @@ var (
 		},
 		[]string{hraName, hraNamespace},
 	)
+	// PercentageRunnersBusy
+	horizontalRunnerAutoscalerReplicasDesiredBefore = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_replicas_desired_before",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerReplicasDesired = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_replicas_desired",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerNumRunners = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_num_runners",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerNumRunnersRegistered = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_num_runners_registered",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerNumRunnersBusy = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_num_runners_busy",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerNumTerminatingBusy = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_num_terminating_busy",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	// QueuedAndInProgressWorkflowRuns
+	horizontalRunnerAutoscalerNecessaryReplicas = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_necessary_replicas",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerWorkflowRunsCompleted = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_workflow_runs_completed",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerWorkflowRunsInProgress = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_workflow_runs_in_progress",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerWorkflowRunsQueued = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_workflow_runs_queued",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
+	horizontalRunnerAutoscalerWorkflowRunsUnknown = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "horizontalrunnerautoscaler_workflow_runs_unknown",
+			Help: "", // TODO: Update this
+		},
+		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
+	)
 )
 
 func SetHorizontalRunnerAutoscalerSpec(o metav1.ObjectMeta, spec v1alpha1.HorizontalRunnerAutoscalerSpec) {
@@ -64,4 +159,64 @@ func SetHorizontalRunnerAutoscalerStatus(o metav1.ObjectMeta, status v1alpha1.Ho
 	if status.DesiredReplicas != nil {
 		horizontalRunnerAutoscalerDesiredReplicas.With(labels).Set(float64(*status.DesiredReplicas))
 	}
+}
+
+func SetHorizontalRunnerAutoscalerPercentageRunnersBusy(
+	o metav1.ObjectMeta,
+	enterprise string,
+	organization string,
+	repository string,
+	kind string,
+	name string,
+	desiredReplicasBefore int,
+	desiredReplicas int,
+	numRunners int,
+	numRunnersRegistered int,
+	numRunnersBusy int,
+	numTerminatingBusy int,
+) {
+	labels := prometheus.Labels{
+		hraName:        o.Name,
+		hraNamespace:   o.Namespace,
+		stEnterprise:   enterprise,
+		stOrganization: organization,
+		stRepository:   repository,
+		stKind:         kind,
+		stName:         name,
+	}
+	horizontalRunnerAutoscalerReplicasDesiredBefore.With(labels).Set(float64(desiredReplicasBefore))
+	horizontalRunnerAutoscalerReplicasDesired.With(labels).Set(float64(desiredReplicas))
+	horizontalRunnerAutoscalerNumRunners.With(labels).Set(float64(numRunners))
+	horizontalRunnerAutoscalerNumRunnersRegistered.With(labels).Set(float64(numRunnersRegistered))
+	horizontalRunnerAutoscalerNumRunnersBusy.With(labels).Set(float64(numRunnersBusy))
+	horizontalRunnerAutoscalerNumTerminatingBusy.With(labels).Set(float64(numTerminatingBusy))
+}
+
+func SetHorizontalRunnerAutoscalerQueuedAndInProgressWorkflowRuns(
+	o metav1.ObjectMeta,
+	enterprise string,
+	organization string,
+	repository string,
+	kind string,
+	name string,
+	necessaryReplicas int,
+	workflowRunsCompleted int,
+	workflowRunsInProgress int,
+	workflowRunsQueued int,
+	workflowRunsUnknown int,
+) {
+	labels := prometheus.Labels{
+		hraName:        o.Name,
+		hraNamespace:   o.Namespace,
+		stEnterprise:   enterprise,
+		stOrganization: organization,
+		stRepository:   repository,
+		stKind:         kind,
+		stName:         name,
+	}
+	horizontalRunnerAutoscalerNecessaryReplicas.With(labels).Set(float64(necessaryReplicas))
+	horizontalRunnerAutoscalerWorkflowRunsCompleted.With(labels).Set(float64(workflowRunsCompleted))
+	horizontalRunnerAutoscalerWorkflowRunsInProgress.With(labels).Set(float64(workflowRunsInProgress))
+	horizontalRunnerAutoscalerWorkflowRunsQueued.With(labels).Set(float64(workflowRunsQueued))
+	horizontalRunnerAutoscalerWorkflowRunsUnknown.With(labels).Set(float64(workflowRunsUnknown))
 }

--- a/controllers/metrics/horizontalrunnerautoscaler.go
+++ b/controllers/metrics/horizontalrunnerautoscaler.go
@@ -61,42 +61,42 @@ var (
 	horizontalRunnerAutoscalerReplicasDesiredBefore = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_replicas_desired_before",
-			Help: "", // TODO: Update this
+			Help: "replicas_desired_before of PercentageRunnersBusy",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerReplicasDesired = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_replicas_desired",
-			Help: "", // TODO: Update this
+			Help: "replicas_desired of PercentageRunnersBusy",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerNumRunners = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_num_runners",
-			Help: "", // TODO: Update this
+			Help: "num_runners of PercentageRunnersBusy",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerNumRunnersRegistered = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_num_runners_registered",
-			Help: "", // TODO: Update this
+			Help: "num_runners_registered of PercentageRunnersBusy",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerNumRunnersBusy = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_num_runners_busy",
-			Help: "", // TODO: Update this
+			Help: "num_runners_busy of PercentageRunnersBusy",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerNumTerminatingBusy = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_num_terminating_busy",
-			Help: "", // TODO: Update this
+			Help: "num_terminating_busy of PercentageRunnersBusy",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
@@ -104,35 +104,35 @@ var (
 	horizontalRunnerAutoscalerNecessaryReplicas = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_necessary_replicas",
-			Help: "", // TODO: Update this
+			Help: "necessary_replicas of QueuedAndInProgressWorkflowRuns",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerWorkflowRunsCompleted = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_workflow_runs_completed",
-			Help: "", // TODO: Update this
+			Help: "workflow_runs_completed oQueuedAndInProgressWorkflowRunsf ",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerWorkflowRunsInProgress = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_workflow_runs_in_progress",
-			Help: "", // TODO: Update this
+			Help: "workflow_runs_in_progressQueuedAndInProgressWorkflowRuns of ",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerWorkflowRunsQueued = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_workflow_runs_queued",
-			Help: "", // TODO: Update this
+			Help: "workflow_runs_queued of QueuedAndInProgressWorkflowRuns",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)
 	horizontalRunnerAutoscalerWorkflowRunsUnknown = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "horizontalrunnerautoscaler_workflow_runs_unknown",
-			Help: "", // TODO: Update this
+			Help: "workflow_runs_unknown of QueuedAndInProgressWorkflowRuns",
 		},
 		[]string{hraName, hraNamespace, stEnterprise, stOrganization, stRepository, stKind, stName},
 	)


### PR DESCRIPTION
For https://github.com/actions-runner-controller/actions-runner-controller/issues/1717

Added following metrics to Prometheus

For `PercentageRunnersBusy` metric
- `horizontalrunnerautoscaler_replicas_desired_before`
- `horizontalrunnerautoscaler_replicas_desired`
- `horizontalrunnerautoscaler_num_runners`
- `horizontalrunnerautoscaler_num_runners_registered`
- `horizontalrunnerautoscaler_num_runners_busy`
- `horizontalrunnerautoscaler_num_terminating_busy`

For `QueuedAndInProgressWorkflowRuns` metric
- `horizontalrunnerautoscaler_necessary_replicas`
- `horizontalrunnerautoscaler_workflow_runs_completed`
- `horizontalrunnerautoscaler_workflow_runs_in_progress`
- `horizontalrunnerautoscaler_workflow_runs_queued`
- `horizontalrunnerautoscaler_workflow_runs_unknown`