### PR TITLE
ci: include sha in canary version

### DIFF
--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
-          build-args: VERSION=canary
+          build-args: VERSION=canary-${{ github.sha }}
           push: true
           tags: |
             ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:canary


### PR DESCRIPTION
Given the canary tag is mutable it might be handy to include the SHA in the version so it's easier to be sure what canary code you're running.