### PR TITLE
e2e: Fix inability to install the stable version of ARC before the edge / Validate GH tokenn on start

### DIFF
--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -41,15 +41,23 @@ TEST_ID=${TEST_ID:-default}
 
 if [ "${tool}" == "helm" ]; then
   set -v
+
+  CHART=${CHART:-charts/actions-runner-controller}
+
   flags=()
   if [ "${IMAGE_PULL_SECRET}" != "" ]; then
     flags+=( --set imagePullSecrets[0].name=${IMAGE_PULL_SECRET})
     flags+=( --set image.actionsRunnerImagePullSecrets[0].name=${IMAGE_PULL_SECRET})
     flags+=( --set githubWebhookServer.imagePullSecrets[0].name=${IMAGE_PULL_SECRET})
   fi
+  if [ "${CHART_VERSION}" != "" ]; then
+    flags+=( --version ${CHART_VERSION})
+  fi
+
   set -vx
+
   helm upgrade --install actions-runner-controller \
-    charts/actions-runner-controller \
+    ${CHART} \
     -n actions-runner-system \
     --create-namespace \
     --set syncPeriod=${SYNC_PERIOD} \


### PR DESCRIPTION
Let me improve two things for what I had found while I was E2E-testing ARC for the upcoming 0.26.0 release.