### PR TITLE
Use numeric USER for nonroot:nonroot in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ WORKDIR /
 COPY --from=builder /out/manager .
 COPY --from=builder /out/github-webhook-server .
 
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Hey guys,

While tightening our security posture, I noticed the following error when deploying ARC:

```
  Warning  Failed     10s (x4 over 24s)  kubelet            Error: container has runAsNonRoot and image has non-numeric user
(nonroot), cannot verify user is non-root (pod: "actions-runner-controller-github-webhook-server-c68bcb8c4-
x7qqp_actions-runner-controller(545601de-f9bd-460e-b706-23ffd3f3c7da)", container: github-webhook-server)
```

This PR simply solves the above by updating the Dockerfile to use the numeric UID of the `nonroot` user supplied by the `distroless:nonroot` image :)

Cheers!
D