### PR TITLE
Disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,4 @@
-# Blank issues are mainly for maintainers who are known to write complete issue descriptions without need to following a form
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
 - name: Sponsor ARC Maintainers
   about: If your business relies on the continued maintainance of actions-runner-controller, please consider sponsoring the project and the maintainers.


### PR DESCRIPTION
Even though we have a bug report form, we've seen many issues being written in freestyle and I think every occurrence of it resulted in needing multiple hops for us to gather the information necessary for diagnosing the issue. I hope every bug report is more actionable. Let's disable blank issues so that the reporter is likely to choose the bug report form or Discussions depending on their situation.