### PR TITLE
Add workflow job metrics to Github webhook server

### DIFF
--- a/cmd/githubwebhookserver/metrics/metrics.go
+++ b/cmd/githubwebhookserver/metrics/metrics.go
@@ -1,0 +1,126 @@
+// Package metrics provides monitoring of the GitHub related metrics.
+//
+// This depends on the metrics exporter of kubebuilder.
+// See https://book.kubebuilder.io/reference/metrics.html for details.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		githubWorkflowJobQueueDurationSeconds,
+		githubWorkflowJobRunDurationSeconds,
+		githubWorkflowJobConclusionsTotal,
+		githubWorkflowJobsQueuedTotal,
+		githubWorkflowJobsStartedTotal,
+		githubWorkflowJobsCompletedTotal,
+		githubWorkflowJobFailuresTotal,
+	)
+}
+
+var (
+	runtimeBuckets []float64 = []float64{
+		0.01,
+		0.05,
+		0.1,
+		0.5,
+		1,
+		2,
+		3,
+		4,
+		5,
+		6,
+		7,
+		8,
+		9,
+		10,
+		12,
+		15,
+		18,
+		20,
+		25,
+		30,
+		40,
+		50,
+		60,
+		70,
+		80,
+		90,
+		100,
+		110,
+		120,
+		150,
+		180,
+		210,
+		240,
+		300,
+		360,
+		420,
+		480,
+		540,
+		600,
+		900,
+		1200,
+		1800,
+		2400,
+		3000,
+		3600,
+	}
+)
+
+var (
+	githubWorkflowJobQueueDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "github_workflow_job_queue_duration_seconds",
+			Help:    "Queue times for workflow jobs in seconds",
+			Buckets: runtimeBuckets,
+		},
+		[]string{"runs_on", "job_name"},
+	)
+	githubWorkflowJobRunDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "github_workflow_job_run_duration_seconds",
+			Help:    "Run times for workflow jobs in seconds",
+			Buckets: runtimeBuckets,
+		},
+		[]string{"runs_on", "job_name", "job_conclusion"},
+	)
+	githubWorkflowJobConclusionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "github_workflow_job_conclusions_total",
+			Help: "Conclusions for tracked workflow jobs",
+		},
+		[]string{"runs_on", "job_name", "job_conclusion"},
+	)
+	githubWorkflowJobsQueuedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "github_workflow_jobs_queued_total",
+			Help: "Total count of workflow jobs queued (events where job_status=queued)",
+		},
+		[]string{"runs_on", "job_name"},
+	)
+	githubWorkflowJobsStartedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "github_workflow_jobs_started_total",
+			Help: "Total count of workflow jobs started (events where job_status=in_progress)",
+		},
+		[]string{"runs_on", "job_name"},
+	)
+	githubWorkflowJobsCompletedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "github_workflow_jobs_completed_total",
+			Help: "Total count of workflow jobs completed (events where job_status=completed)",
+		},
+		[]string{"runs_on", "job_name"},
+	)
+	githubWorkflowJobFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "github_workflow_job_failures_total",
+			Help: "Conclusions for tracked workflow runs",
+		},
+		[]string{"runs_on", "job_name", "failed_step", "exit_code"},
+	)
+)

--- a/cmd/githubwebhookserver/metrics/workflow_job_metrics_event_reader.go
+++ b/cmd/githubwebhookserver/metrics/workflow_job_metrics_event_reader.go
@@ -108,10 +108,25 @@ func (reader *WorkflowJobMetricsEventReader) ProcessWorkflowJobEvent(ctx context
 		}
 
 		if *e.WorkflowJob.Conclusion == "failure" {
-			failedStep := "?"
+			failedStep := "null"
 			for i, step := range e.WorkflowJob.Steps {
-				if *step.Conclusion != "success" {
+
+				// *step.Conclusion ~
+				// "success",
+				// "failure",
+				// "neutral",
+				// "cancelled",
+				// "skipped",
+				// "timed_out",
+				// "action_required",
+				// null
+				if *step.Conclusion == "failure" {
 					failedStep = fmt.Sprint(i)
+					break
+				}
+				if *step.Conclusion == "timed_out" {
+					failedStep = fmt.Sprint(i)
+					parseResult.ExitCode = "timed_out"
 					break
 				}
 			}
@@ -158,7 +173,7 @@ func (reader *WorkflowJobMetricsEventReader) fetchAndParseWorkflowJobLogs(ctx co
 		return nil, err
 	}
 
-	exitCode := "0"
+	exitCode := "null"
 
 	var (
 		queuedTime    time.Time

--- a/cmd/githubwebhookserver/metrics/workflow_job_metrics_event_reader.go
+++ b/cmd/githubwebhookserver/metrics/workflow_job_metrics_event_reader.go
@@ -1,0 +1,212 @@
+package metrics
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	gogithub "github.com/google/go-github/v47/github"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/actions-runner-controller/actions-runner-controller/github"
+)
+
+type WorkflowJobMetricsEventReader struct {
+	Log logr.Logger
+
+	// GitHub Client to fetch information about job failures
+	GitHubClient *github.Client
+
+	// Event queue
+	Events chan interface{}
+}
+
+// HandleWorkflowJobEvent send event to reader channel for processing
+//
+// forcing the events through a channel ensures they are processed in sequentially,
+// and prevents any race conditions with githubWorkflowJobStatus
+func (reader *WorkflowJobMetricsEventReader) HandleWorkflowJobEvent(event interface{}) {
+	reader.Events <- event
+}
+
+// ProcessWorkflowJobEvents pop events in a loop for processing
+//
+// Should be called asynchronously with `go`
+func (reader *WorkflowJobMetricsEventReader) ProcessWorkflowJobEvents(ctx context.Context) {
+	for {
+		select {
+		case event := <-reader.Events:
+			reader.ProcessWorkflowJobEvent(ctx, event)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// ProcessWorkflowJobEvent processes a single event
+//
+// Events should be processed in the same order that Github emits them
+func (reader *WorkflowJobMetricsEventReader) ProcessWorkflowJobEvent(ctx context.Context, event interface{}) {
+
+	e, ok := event.(*gogithub.WorkflowJobEvent)
+	if !ok {
+		return
+	}
+
+	// collect labels
+	labels := make(prometheus.Labels)
+
+	runsOn := strings.Join(e.WorkflowJob.Labels, `,`)
+	labels["runs_on"] = runsOn
+	labels["job_name"] = *e.WorkflowJob.Name
+
+	// switch on job status
+	switch action := e.GetAction(); action {
+	case "queued":
+		githubWorkflowJobsQueuedTotal.With(labels).Inc()
+
+	case "in_progress":
+		githubWorkflowJobsStartedTotal.With(labels).Inc()
+
+		if reader.GitHubClient == nil {
+			return
+		}
+
+		parseResult, err := reader.fetchAndParseWorkflowJobLogs(ctx, e)
+		if err != nil {
+			reader.Log.Error(err, "reading workflow job log")
+			return
+		} else {
+			reader.Log.Info("reading workflow_job logs",
+				"job_name", *e.WorkflowJob.Name,
+				"job_id", fmt.Sprint(*e.WorkflowJob.ID),
+			)
+		}
+
+		githubWorkflowJobQueueDurationSeconds.With(labels).Observe(parseResult.QueueTime.Seconds())
+
+	case "completed":
+		githubWorkflowJobsCompletedTotal.With(labels).Inc()
+
+		// job_conclusion -> (neutral, success, skipped, cancelled, timed_out, action_required, failure)
+		githubWorkflowJobConclusionsTotal.With(extraLabel("job_conclusion", *e.WorkflowJob.Conclusion, labels)).Inc()
+
+		parseResult, err := reader.fetchAndParseWorkflowJobLogs(ctx, e)
+		if err != nil {
+			reader.Log.Error(err, "reading workflow job log")
+			return
+		} else {
+			reader.Log.Info("reading workflow_job logs",
+				"job_name", *e.WorkflowJob.Name,
+				"job_id", fmt.Sprint(*e.WorkflowJob.ID),
+			)
+		}
+
+		if *e.WorkflowJob.Conclusion == "failure" {
+			failedStep := "?"
+			for i, step := range e.WorkflowJob.Steps {
+				if *step.Conclusion != "success" {
+					failedStep = fmt.Sprint(i)
+					break
+				}
+			}
+			githubWorkflowJobFailuresTotal.With(
+				extraLabel("failed_step", failedStep,
+					extraLabel("exit_code", parseResult.ExitCode, labels),
+				),
+			).Inc()
+		}
+
+		githubWorkflowJobRunDurationSeconds.With(extraLabel("job_conclusion", *e.WorkflowJob.Conclusion, labels)).Observe(parseResult.RunTime.Seconds())
+	}
+}
+
+func extraLabel(key string, value string, labels prometheus.Labels) prometheus.Labels {
+	fixedLabels := make(prometheus.Labels)
+	for k, v := range labels {
+		fixedLabels[k] = v
+	}
+	fixedLabels[key] = value
+	return fixedLabels
+}
+
+type ParseResult struct {
+	ExitCode  string
+	QueueTime time.Duration
+	RunTime   time.Duration
+}
+
+var logLine = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7}Z)\s(.+)$`)
+var exitCodeLine = regexp.MustCompile(`##\[error\]Process completed with exit code (\d)\.`)
+
+func (reader *WorkflowJobMetricsEventReader) fetchAndParseWorkflowJobLogs(ctx context.Context, e *gogithub.WorkflowJobEvent) (*ParseResult, error) {
+
+	owner := *e.Repo.Owner.Login
+	repo := *e.Repo.Name
+	id := *e.WorkflowJob.ID
+	url, _, err := reader.GitHubClient.Actions.GetWorkflowJobLogs(ctx, owner, repo, id, true)
+	if err != nil {
+		return nil, err
+	}
+	jobLogs, err := http.DefaultClient.Get(url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	exitCode := "0"
+
+	var (
+		queuedTime    time.Time
+		startedTime   time.Time
+		completedTime time.Time
+	)
+
+	func() {
+		// Read jobLogs.Body line by line
+
+		defer jobLogs.Body.Close()
+		lines := bufio.NewScanner(jobLogs.Body)
+
+		for lines.Scan() {
+			matches := logLine.FindStringSubmatch(lines.Text())
+			if matches == nil {
+				continue
+			}
+			timestamp := matches[1]
+			line := matches[2]
+
+			if strings.HasPrefix(line, "##[error]") {
+				// Get exit code
+				exitCodeMatch := exitCodeLine.FindStringSubmatch(line)
+				if exitCodeMatch != nil {
+					exitCode = exitCodeMatch[1]
+				}
+				continue
+			}
+
+			if strings.HasPrefix(line, "Waiting for a runner to pick up this job...") {
+				queuedTime, _ = time.Parse(time.RFC3339, timestamp)
+				continue
+			}
+
+			if strings.HasPrefix(line, "Job is about to start running on the runner:") {
+				startedTime, _ = time.Parse(time.RFC3339, timestamp)
+				continue
+			}
+
+			// Last line in the log will count as the completed time
+			completedTime, _ = time.Parse(time.RFC3339, timestamp)
+		}
+	}()
+
+	return &ParseResult{
+		ExitCode:  exitCode,
+		QueueTime: startedTime.Sub(queuedTime),
+		RunTime:   completedTime.Sub(startedTime),
+	}, nil
+}


### PR DESCRIPTION
Relates to issue https://github.com/actions-runner-controller/actions-runner-controller/issues/1551

This PR adds these metrics:
```
github_workflow_job_queue_duration_seconds
github_workflow_job_run_duration_seconds
github_workflow_job_conclusions_total
github_workflow_jobs_queued_total
github_workflow_jobs_started_total
github_workflow_jobs_completed_total
github_workflow_job_failures_total
```
