### PR TITLE
🍱 add git-lfs package as standard tool

### DIFF
--- a/runner/actions-runner-dind-rootless.dockerfile
+++ b/runner/actions-runner-dind-rootless.dockerfile
@@ -30,6 +30,7 @@ RUN apt update -y \
     dnsutils \
     ftp \
     git \
+    git-lfs \
     iproute2 \
     iputils-ping \
     iptables \

--- a/runner/actions-runner-dind.dockerfile
+++ b/runner/actions-runner-dind.dockerfile
@@ -20,6 +20,7 @@ RUN apt update -y \
     dnsutils \
     ftp \
     git \
+    git-lfs \
     iproute2 \
     iputils-ping \
     iptables \

--- a/runner/actions-runner.dockerfile
+++ b/runner/actions-runner.dockerfile
@@ -21,6 +21,7 @@ RUN apt update -y \
     dnsutils \
     ftp \
     git \
+    git-lfs \
     iproute2 \
     iputils-ping \
     jq \


### PR DESCRIPTION
As discussed in https://github.com/actions-runner-controller/actions-runner-controller/issues/822#issuecomment-921601219, adding `git-lfs` as standard tool seems to be ✅ , thus creating a PR for all 3 images.

`git-lfs` package [is available from official repository](https://ubuntu.pkgs.org/20.04/ubuntu-universe-amd64/git-lfs_2.9.2-1_amd64.deb.html) on Ubuntu distribution

Related to #822 