### PR TITLE
Encourage folks to write up a proper title for a bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-title: "Bug"
+title: ""
 labels: ["bug"]
 body:
 - type: checkboxes


### PR DESCRIPTION
Honestly, I'm a bit tired of seeing issues filed with the default title "Bug" that are seemingly not related to real bugs!
I'm emptying it so that the reporter is more encouraged to write up a sentence to describe the problem and they hopefully notice along the way that there are places to diagnose before considering it as a bug.