### PR TITLE
Let it be a bug only when it's reproducible with official runner image

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     options:
     - label: I've already read https://github.com/actions-runner-controller/actions-runner-controller/blob/master/TROUBLESHOOTING.md and I'm sure my issue is not covered in the troubleshooting guide.
       required: true
-    - label: I'm not using a custom runner image
+    - label: I'm not using a custom entrypoint in my runner image
       required: true
 - type: input
   id: controller-version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,9 +7,11 @@ body:
   id: read-troubleshooting-guide
   attributes:
     label: Checks
-    description: Please check the boxes below before submitting
+    description: Please check all the boxes below before submitting
     options:
     - label: I've already read https://github.com/actions-runner-controller/actions-runner-controller/blob/master/TROUBLESHOOTING.md and I'm sure my issue is not covered in the troubleshooting guide.
+      required: true
+    - label: I'm not using a custom runner image
       required: true
 - type: input
   id: controller-version
@@ -58,7 +60,7 @@ body:
   id: checks
   attributes:
     label: Checks
-    description: Please check the boxes below before submitting
+    description: Please check all the boxes below before submitting
     options:
     - label: This isn't a question or user support case (For Q&A and community support, go to [Discussions](https://github.com/actions-runner-controller/actions-runner-controller/discussions). It might also be a good idea to contract with any of contributors and maintainers if your business is so critical and therefore you need priority support
       required: true


### PR DESCRIPTION
A custom runner image can break runners and ARC in interesting ways. Probably it's better to clearly state that ARC is not guaranteed to work with every custom runner image in the wild.