### PR TITLE
Add MTU propagation docker-shim also to rootless dind runner images

### DIFF
--- a/acceptance/testdata/runnerdeploy.envsubst.yaml
+++ b/acceptance/testdata/runnerdeploy.envsubst.yaml
@@ -52,6 +52,10 @@ spec:
       env:
       - name: ROLLING_UPDATE_PHASE
         value: "${ROLLING_UPDATE_PHASE}"
+      - name: ARC_DOCKER_MTU_PROPAGATION
+        value: "true"
+
+      dockerMTU: 1400
 
       #
       # Non-standard working directory

--- a/runner/actions-runner-dind-rootless.dockerfile
+++ b/runner/actions-runner-dind-rootless.dockerfile
@@ -106,6 +106,10 @@ COPY entrypoint.sh logger.bash rootless-startup.sh update-status /usr/bin/
 
 RUN chmod +x /usr/bin/rootless-startup.sh /usr/bin/entrypoint.sh
 
+# Copy the docker shim which propagates the docker MTU to underlying networks
+# to replace the docker binary in the PATH.
+COPY docker-shim.sh /usr/local/bin/docker
+
 # Make the rootless runner directory executable
 RUN mkdir /run/user/1000 \
     && chown runner:runner /run/user/1000 \

--- a/runner/actions-runner-dind-rootless.dockerfile
+++ b/runner/actions-runner-dind-rootless.dockerfile
@@ -133,6 +133,7 @@ USER runner
 
 # Docker installation
 ENV SKIP_IPTABLES=1
+# This will install docker under $HOME/bin according to the content of the script
 RUN curl -fsSL https://get.docker.com/rootless | sh
 
 # Docker-compose installation

--- a/runner/actions-runner-dind.dockerfile
+++ b/runner/actions-runner-dind.dockerfile
@@ -103,6 +103,10 @@ COPY entrypoint.sh logger.bash startup.sh update-status /usr/bin/
 COPY supervisor/ /etc/supervisor/conf.d/
 RUN chmod +x /usr/bin/startup.sh /usr/bin/entrypoint.sh
 
+# Copy the docker shim which propagates the docker MTU to underlying networks
+# to replace the docker binary in the PATH.
+COPY docker-shim.sh /usr/local/bin/docker
+
 # Configure hooks folder structure.
 COPY hooks /etc/arc/hooks/
 

--- a/runner/docker-shim.sh
+++ b/runner/docker-shim.sh
@@ -2,11 +2,16 @@
 
 set -Eeuo pipefail
 
+DOCKER=/usr/bin/docker
+if [ ! -e $DOCKER ]; then
+  DOCKER=$HOME/bin/docker
+fi
+
 if [[ ${ARC_DOCKER_MTU_PROPAGATION:-false} == true ]] &&
   (($# >= 2)) && [[ $1 == network && $2 == create ]] &&
-  mtu=$(/usr/bin/docker network inspect bridge --format '{{index .Options "com.docker.network.driver.mtu"}}' 2>/dev/null); then
+  mtu=$($DOCKER network inspect bridge --format '{{index .Options "com.docker.network.driver.mtu"}}' 2>/dev/null); then
   shift 2
   set -- network create --opt com.docker.network.driver.mtu="$mtu" "$@"
 fi
 
-exec /usr/bin/docker "$@"
+exec $DOCKER "$@"

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -58,6 +58,7 @@ for process in "${processes[@]}"; do
     if [ $? -ne 0 ]; then
         log.error "$process is not running after max time"
         dump /var/log/dockerd.err.log 'Dumping {path} to aid investigation'
+        dump /var/log/supervisor/supervisord.log 'Dumping {path} to aid investigation'
         exit 1
     else
         log.debug "$process is running"


### PR DESCRIPTION
#1201 added MTU propagation docker-shim to the standard runner and dind runner.
This adds the same feature to rootless dind runners, by enhancing and adding the docker-shim to the rootless dind runner dockerfile.
I also added a QoL enhancement to the dind runner startup.sh so that it becomes easier to spot an issue like https://github.com/actions-runner-controller/actions-runner-controller/pull/1201#issuecomment-1255901580.

Other two commits are for updating the E2E testdata to the one that I used for testing the feature, and adding a lot of comments to the DockerMTU implementation so that you can understand how it works along with all the MTU-related settings present in ARC.