### PR TITLE
e2e: Bump runner version to 2.297.0

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,7 +40,7 @@ var (
 
 	testResultCMNamePrefix = "test-result-"
 
-	RunnerVersion = "2.296.2"
+	RunnerVersion = "2.297.0"
 )
 
 // If you're willing to run this test via VS Code "run test" or "debug test",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,7 +40,7 @@ var (
 
 	testResultCMNamePrefix = "test-result-"
 
-	RunnerVersion = "2.296.0"
+	RunnerVersion = "2.296.2"
 )
 
 // If you're willing to run this test via VS Code "run test" or "debug test",


### PR DESCRIPTION
Otherwise, every runner brought up by the E2E test needs to auto-update itself before running any jobs, which results in more time until the jobs are run and the E2E test finishes.