### PR TITLE
runner: Address all shellcheck findings

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -11,9 +11,9 @@ RUNNER_HOME=${RUNNER_HOME:-/runner}
 export ACTIONS_RUNNER_HOOK_JOB_STARTED=/etc/arc/hooks/job-started.sh
 export ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/etc/arc/hooks/job-completed.sh
 
-if [ ! -z "${STARTUP_DELAY_IN_SECONDS}" ]; then
+if [ -n "${STARTUP_DELAY_IN_SECONDS}" ]; then
   log.notice "Delaying startup by ${STARTUP_DELAY_IN_SECONDS} seconds"
-  sleep ${STARTUP_DELAY_IN_SECONDS}
+  sleep "${STARTUP_DELAY_IN_SECONDS}"
 fi
 
 if [ -z "${GITHUB_URL}" ]; then
@@ -71,11 +71,15 @@ if [[ "${UNITTEST:-}" == '' ]]; then
   shopt -u dotglob
 fi
 
-cd ${RUNNER_HOME}
+if ! cd "${RUNNER_HOME}"; then
+  log.error "Failed to cd into ${RUNNER_HOME}"
+  exit 1
+fi
+
 # past that point, it's all relative pathes from /runner
 
 config_args=()
-if [ "${RUNNER_FEATURE_FLAG_ONCE:-}" != "true" -a "${RUNNER_EPHEMERAL}" == "true" ]; then
+if [ "${RUNNER_FEATURE_FLAG_ONCE:-}" != "true" ] && [ "${RUNNER_EPHEMERAL}" == "true" ]; then
   config_args+=(--ephemeral)
   log.debug 'Passing --ephemeral to config.sh to enable the ephemeral runner.'
 fi

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -54,8 +54,7 @@ log.debug 'Waiting for processes to be running...'
 processes=(dockerd)
 
 for process in "${processes[@]}"; do
-    wait_for_process "$process"
-    if [ $? -ne 0 ]; then
+    if ! wait_for_process "$process"; then
         log.error "$process is not running after max time"
         dump /var/log/dockerd.err.log 'Dumping {path} to aid investigation'
         dump /var/log/supervisor/supervisord.log 'Dumping {path} to aid investigation'
@@ -66,7 +65,7 @@ for process in "${processes[@]}"; do
 done
 
 if [ -n "${MTU}" ]; then
-  sudo ifconfig docker0 mtu ${MTU} up
+  sudo ifconfig docker0 mtu "${MTU}" up
 fi
 
 # Wait processes to be running


### PR DESCRIPTION
I am about to revisit #1517, #1454, #1561, and #1560 as a part of our on-going effort for a major enhancement to the runner entrypoints being made in #1759.

This change updates and reintroduces #1517 contributed by @CASABECI in a way it becomes applicable to today's code-base.

Here's all the shellcheck findings this change is intended to address:

`shellcheck --shell bash --source-path runner runner/*.bash runner/*.sh`:

<details>

```
In runner/entrypoint.sh line 14:
if [ ! -z "${STARTUP_DELAY_IN_SECONDS}" ]; then
     ^-- SC2236 (style): Use -n instead of ! -z.


In runner/entrypoint.sh line 16:
  sleep ${STARTUP_DELAY_IN_SECONDS}
        ^-------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  sleep "${STARTUP_DELAY_IN_SECONDS}"


In runner/entrypoint.sh line 74:
cd ${RUNNER_HOME}
^---------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "${RUNNER_HOME}" || exit


In runner/entrypoint.sh line 78:
if [ "${RUNNER_FEATURE_FLAG_ONCE:-}" != "true" -a "${RUNNER_EPHEMERAL}" == "true" ]; then
                                               ^-- SC2166 (warning): Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.


In runner/startup.sh line 58:
    if [ $? -ne 0 ]; then
         ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In runner/startup.sh line 69:
  sudo ifconfig docker0 mtu ${MTU} up
                            ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  sudo ifconfig docker0 mtu "${MTU}" up

For more information:
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC2166 -- Prefer [ p ] && [ q ] as [ p -a q...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```
</details>

Thanks again for contributing the original work @CASABECI! I couldn't have finished this so quickly without your work.
