### PR TITLE
Added `DEBIAN_FRONTEND=noninteractive` to `sudo`

### DIFF
--- a/runner/actions-runner-dind.dockerfile
+++ b/runner/actions-runner-dind.dockerfile
@@ -54,7 +54,8 @@ RUN adduser --disabled-password --gecos "" --uid 1000 runner \
     && groupadd docker \
     && usermod -aG sudo runner \
     && usermod -aG docker runner \
-    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
+    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 # arch command on OS X reports "i386" for Intel CPUs regardless of bitness
 # Docker download supports arm64 as aarch64 & amd64 / i386 as x86_64

--- a/runner/actions-runner.dockerfile
+++ b/runner/actions-runner.dockerfile
@@ -66,7 +66,8 @@ RUN set -vx; \
     && groupadd docker \
     && usermod -aG sudo runner \
     && usermod -aG docker runner \
-    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
+    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 # Uncomment the below COPY to use your own custom build of actions-runner.
 #


### PR DESCRIPTION
By default `sudo` drops all environment variables and executes its commands with a clean environment. This is by design, but for the `DEBIAN_FRONTEND` environment variable it is not what we want, since it results in installers being interactive. This adds the `env_keep` instruction to `/etc/sudoers` to keep `DEBIAN_FRONTEND` with its `noninteractive` value, and thus pass it on to commands that care about it. Note that this makes no difference in our builds, because we are running them directly as `root`. However, for users of our image this is going to make a difference, since they start out as `runner` and have to use `sudo`.
