### PR TITLE
e2e: Make docker build timeout longer

### DIFF
--- a/testing/testing.go
+++ b/testing/testing.go
@@ -113,7 +113,7 @@ func (e *Env) DeleteTestID(t *testing.T) {
 func (e *Env) DockerBuild(t *testing.T, builds []DockerBuild) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 450*time.Second)
 	defer cancel()
 
 	if err := e.docker.Build(ctx, builds); err != nil {


### PR DESCRIPTION
Depending on the host machine spec and load, it can take more time than 5 minutes. This change adhocly increases the timeout by 1.5x to address that.