### PR TITLE
Fix repositoryNames in workflow runs queued based HRA example

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,8 @@ spec:
   metrics:
   - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
     repositoryNames:
-    - example/myrepo
+    # A repository name is the REPO part of `github.com/OWNER/REPO`
+    - myrepo
 ```
 
 **PercentageRunnersBusy**


### PR DESCRIPTION
# What is changing?

As per the [MetricSpec](https://github.com/actions-runner-controller/actions-runner-controller/blob/3c4ab2d479c458197039baf634a0e1eca003f93e/api/v1alpha1/horizontalrunnerautoscaler_types.go#L142) type, the values for repositoryNames should be the repository name and **not** it's full name which is composed by owner + repo.

In the context of the current example, the owner would be "example", the repository name would be "myrepo" and the full name example/repo.

---

# Why is this change required?

When I used the example provided on its current version with Organization Runners I ran into an issue where the Controller was unable to list the queued workflow runs.

I believe this is because in  [suggestReplicasByQueuedAndInProgressWorkflowRuns](https://github.com/actions-runner-controller/actions-runner-controller/blob/3c4ab2d479c458197039baf634a0e1eca003f93e/controllers/autoscaling.go#L112) the Org name(example) and the full repo name `example/myrepo` are combined, resulting in the [Actions.ListRepositoryWorkflowRuns](https://github.com/actions-runner-controller/actions-runner-controller/blob/3c4ab2d479c458197039baf634a0e1eca003f93e/github/github.go#L380) being invoked with user=example and repoName=example/myrepo.

If one uses the current example as a model, he/she is likely to get an error similar to this:

```
2022-09-29T03:42:52Z	ERROR	Reconciler error	{"controller": "horizontalrunnerautoscaler-controller", "controllerGroup": "actions.summerwind.dev", "controllerKind": "HorizontalRunnerAutoscaler", "horizontalRunnerAutoscaler": {"name":"defaultorg-runner-pool-hra","namespace":"actions-runner-system"}, "namespace": "actions-runner-system", "name": "defaultorg-runner-pool-hra", "reconcileID": "1c2476d3-601a-487f-8b32-563e8c1d9004", "error": "listing queued workflow runs: failed to list workflow runs: GET https://hostname/api/v3/repos/example/example/myrepo/actions/runs?per_page=100&status=queued: 404 Not Found []"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:234
```
*(Output from v0.26.0)*

Note the duplicated `example/example` in the path /api/v3/repos/ **example/example** /myrepo/actions/runs