### PR TITLE
Allow `RunnerDeployment`s to configure `dnsPolicy` for runners

### DIFF
--- a/api/v1alpha1/runner_types.go
+++ b/api/v1alpha1/runner_types.go
@@ -171,6 +171,9 @@ type RunnerPodSpec struct {
 	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
 
 	// +optional
+	DnsPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// +optional
 	DnsConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
 
 	// +optional

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -1381,6 +1381,9 @@ spec:
                                 type: string
                               type: array
                           type: object
+                        dnsPolicy:
+                          description: DNSPolicy defines how a pod's DNS will be configured.
+                          type: string
                         dockerEnabled:
                           type: boolean
                         dockerEnv:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -1378,6 +1378,9 @@ spec:
                                 type: string
                               type: array
                           type: object
+                        dnsPolicy:
+                          description: DNSPolicy defines how a pod's DNS will be configured.
+                          type: string
                         dockerEnabled:
                           type: boolean
                         dockerEnv:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -1325,6 +1325,9 @@ spec:
                         type: string
                       type: array
                   type: object
+                dnsPolicy:
+                  description: DNSPolicy defines how a pod's DNS will be configured.
+                  type: string
                 dockerEnabled:
                   type: boolean
                 dockerEnv:

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -1381,6 +1381,9 @@ spec:
                                 type: string
                               type: array
                           type: object
+                        dnsPolicy:
+                          description: DNSPolicy defines how a pod's DNS will be configured.
+                          type: string
                         dockerEnabled:
                           type: boolean
                         dockerEnv:

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -1378,6 +1378,9 @@ spec:
                                 type: string
                               type: array
                           type: object
+                        dnsPolicy:
+                          description: DNSPolicy defines how a pod's DNS will be configured.
+                          type: string
                         dockerEnabled:
                           type: boolean
                         dockerEnv:

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -1325,6 +1325,9 @@ spec:
                         type: string
                       type: array
                   type: object
+                dnsPolicy:
+                  description: DNSPolicy defines how a pod's DNS will be configured.
+                  type: string
                 dockerEnabled:
                   type: boolean
                 dockerEnv:

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -650,6 +650,10 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 		pod.Spec.HostAliases = runnerSpec.HostAliases
 	}
 
+	if runnerSpec.DnsPolicy != "" {
+		pod.Spec.DNSPolicy = runnerSpec.DnsPolicy
+	}
+
 	if runnerSpec.DnsConfig != nil {
 		pod.Spec.DNSConfig = runnerSpec.DnsConfig
 	}


### PR DESCRIPTION
Closes #861

The linked issue includes a recommendation from @mumoshu to use a `RunnerSet` instead, as they already expose this functionality. I wasn't sure if that was a "hard" recommendation, implying `RunnerSet`s are a generally preferred API for complex configurations, or a "soft" recommendation, implying the addition of the `RunnerDeployment` functionality was low-priority. Apologies for the PR if it is the former!

For us at least, `RunnerDeployment`s seem more appropriate for our use case (other than the lack of a `dnsPolicy` option)

Tested in a local `kind` cluster with a locally-built image on Ubuntu 22.04