### PR TITLE
Modify startup scripts to support setting docker default cidr range.

### DIFF
--- a/runner/rootless-startup.sh
+++ b/runner/rootless-startup.sh
@@ -19,8 +19,8 @@ if [ -n "${DOCKER_REGISTRY_MIRROR}" ]; then
 jq ".\"registry-mirrors\"[0] = \"${DOCKER_REGISTRY_MIRROR}\"" /home/runner/.config/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /home/runner/.config/docker/daemon.json
 fi
 
-if [ -n "${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}" ]; then
-jq ".\"default-address-pools\" = {\"base\": \"${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}\", \"size\": 24}" /etc/docker/daemon.json > /tmp/.daemon.json && /tmp/.daemon.json /etc/docker/daemon.json
+if [ -n "${DOCKER_DEFAULT_ADDRESS_POOL_BASE}" ] && [ -n "${DOCKER_DEFAULT_ADDRESS_POOL_SIZE}" ]; then
+jq ".\"default-address-pools\" = [{\"base\": \"${DOCKER_DEFAULT_ADDRESS_POOL_BASE}\", \"size\": ${DOCKER_DEFAULT_ADDRESS_POOL_SIZE}}]" /etc/docker/daemon.json > /tmp/.daemon.json && /tmp/.daemon.json /etc/docker/daemon.json
 fi
 SCRIPT
 

--- a/runner/rootless-startup.sh
+++ b/runner/rootless-startup.sh
@@ -18,6 +18,10 @@ fi
 if [ -n "${DOCKER_REGISTRY_MIRROR}" ]; then
 jq ".\"registry-mirrors\"[0] = \"${DOCKER_REGISTRY_MIRROR}\"" /home/runner/.config/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /home/runner/.config/docker/daemon.json
 fi
+
+if [ -n "${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}" ]; then
+jq ".\"default-address-pools\" = {\"base\": \"${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}\", \"size\": 24}" /etc/docker/daemon.json > /tmp/.daemon.json && /tmp/.daemon.json /etc/docker/daemon.json
+fi
 SCRIPT
 
 log.notice "Starting Docker (rootless)"

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -37,7 +37,6 @@ fi
 if [ -n "${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}" ]; then
 jq ".\"default-address-pools\" = {\"base\": \"${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}\", \"size\": 24}" /etc/docker/daemon.json > /tmp/.daemon.json && /tmp/.daemon.json /etc/docker/daemon.json
 fi
-
 SCRIPT
 
 dump() {

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -33,6 +33,11 @@ fi
 if [ -n "${DOCKER_REGISTRY_MIRROR}" ]; then
 jq ".\"registry-mirrors\"[0] = \"${DOCKER_REGISTRY_MIRROR}\"" /etc/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /etc/docker/daemon.json
 fi
+
+if [ -n "${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}" ]; then
+jq ".\"default-address-pools\" = {\"base\": \"${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}\", \"size\": 24}" /etc/docker/daemon.json > /tmp/.daemon.json && /tmp/.daemon.json /etc/docker/daemon.json
+fi
+
 SCRIPT
 
 dump() {

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -34,8 +34,8 @@ if [ -n "${DOCKER_REGISTRY_MIRROR}" ]; then
 jq ".\"registry-mirrors\"[0] = \"${DOCKER_REGISTRY_MIRROR}\"" /etc/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /etc/docker/daemon.json
 fi
 
-if [ -n "${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}" ]; then
-jq ".\"default-address-pools\" = {\"base\": \"${DOCKER_DEFAULT_NETWORK_CIDR_RANGE}\", \"size\": 24}" /etc/docker/daemon.json > /tmp/.daemon.json && /tmp/.daemon.json /etc/docker/daemon.json
+if [ -n "${DOCKER_DEFAULT_ADDRESS_POOL_BASE}" ] && [ -n "${DOCKER_DEFAULT_ADDRESS_POOL_SIZE}" ]; then
+jq ".\"default-address-pools\" = [{\"base\": \"${DOCKER_DEFAULT_ADDRESS_POOL_BASE}\", \"size\": ${DOCKER_DEFAULT_ADDRESS_POOL_SIZE}}]" /etc/docker/daemon.json > /tmp/.daemon.json && /tmp/.daemon.json /etc/docker/daemon.json
 fi
 SCRIPT
 


### PR DESCRIPTION
Currently it's not easily possible to change the docker network CIDR range. This can lead to issues if there are networks with overlapping CIDR ranges in the same network, i.e. reachable by the same network interface. To avoid connectivity issues, it's possible to change the default CIDR range as follows:

```
{
  "default-address-pools": [{"base":"172.17.0.0/16","size":24}]
}
```

I've parametrized it and added it to the startup scripts, similar to how it's possible to set the MTU and registry mirrors. I would highly appreciate a quick review, let me know if I can assist in any way. This will allow for a much simpler runner setup.