### PR TITLE
Docs: fix broken link to readme

### DIFF
--- a/docs/Actions-Runner-Controller-Overview.md
+++ b/docs/Actions-Runner-Controller-Overview.md
@@ -53,7 +53,7 @@ Once the custom resources are installed, another command deploys ARC into your K
 
 
 The `Deployment and Configure ARC` section in the `Quick Start guide` lists the steps to deploy ARC using a `runnerdeployment.yaml` file. Here, we will explain the details
-For more details, see "[QuickStart Guide](QuickStartGuide.md)."
+For more details, see "[QuickStart Guide](/README.md#getting-started)."
 
 ```yaml
 apiVersion: actions.summerwind.dev/v1alpha1


### PR DESCRIPTION
Just fixing the link in the documentation that is no longer working.


Thanks!