### PR TITLE
chore: add new label to bug form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,6 +68,8 @@ body:
       required: true
     - label: I've already upgraded ARC (including the CRDs, see charts/actions-runner-controller/docs/UPGRADING.md for details) to the latest and it didn't fix the issue
       required: true
+    - label: I've migrated to the workflow job webhook event (if you using webhook driven scaling)
+      required: true
 - type: textarea
   id: resource-definitions
   attributes:


### PR DESCRIPTION
We no longer support any webhook other than the workflow job event and the other events will be removed next release https://github.com/actions-runner-controller/actions-runner-controller/issues/1607. As a result we require everyone to move to this event in order to get any support.