### PR TITLE
ci: use github-pr-check reporter for shellcheck

### DIFF
--- a/.github/workflows/validate-runners.yaml
+++ b/.github/workflows/validate-runners.yaml
@@ -22,7 +22,6 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
           path: "./runner"
           pattern: |
             *.sh

--- a/.github/workflows/validate-runners.yaml
+++ b/.github/workflows/validate-runners.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: shellcheck
+          reporter: github-pr-review
           path: "./runner"
           pattern: |
             *.sh


### PR DESCRIPTION
we've set the reporter to a value that doesn't seem to be part of the action https://github.com/reviewdog/action-shellcheck/blob/master/action.yml#L15

```
      Reporter of reviewdog command [github-pr-check,github-pr-review,github-check].
      Default is github-pr-check.
      github-pr-review can use Markdown and add a link to rule page in reviewdog reports.
```