### PR TITLE
ci: replace set-output

### DIFF
--- a/.github/actions/setup-docker-environment/action.yaml
+++ b/.github/actions/setup-docker-environment/action.yaml
@@ -14,18 +14,13 @@ inputs:
     description: "GHCR password. Usually set from the secrets.GITHUB_TOKEN variable"
     required: true
 
-outputs:
-  sha_short:
-    description: "The short SHA used for image builds"
-    value: ${{ steps.vars.outputs.sha_short }}
-
 runs:
   using: "composite"
   steps:
     - name: Get Short SHA
       id: vars
       run: |
-        echo ::set-output name=sha_short::${GITHUB_SHA::7}
+        echo "sha_short::${GITHUB_SHA::7}" >> $GITHUB_ENV
       shell: bash
 
     - name: Set up QEMU

--- a/.github/actions/setup-docker-environment/action.yaml
+++ b/.github/actions/setup-docker-environment/action.yaml
@@ -20,7 +20,7 @@ runs:
     - name: Get Short SHA
       id: vars
       run: |
-        echo "sha_short::${GITHUB_SHA::7}" >> $GITHUB_ENV
+        echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_ENV
       shell: bash
 
     - name: Set up QEMU

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -45,7 +45,6 @@ jobs:
           make github-release
 
       - name: Setup Docker Environment
-        id: vars
         uses: ./.github/actions/setup-docker-environment
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -63,9 +62,9 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:latest
             ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:${{ env.VERSION }}
-            ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:${{ env.VERSION }}-${{ steps.vars.outputs.sha_short }}
+            ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:${{ env.VERSION }}-${{ env.sha_short }}
             ghcr.io/actions-runner-controller/actions-runner-controller:latest
             ghcr.io/actions-runner-controller/actions-runner-controller:${{ env.VERSION }}
-            ghcr.io/actions-runner-controller/actions-runner-controller:${{ env.VERSION }}-${{ steps.vars.outputs.sha_short }}
+            ghcr.io/actions-runner-controller/actions-runner-controller:${{ env.VERSION }}-${{ env.sha_short }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Docker Environment
-        id: vars
         uses: ./.github/actions/setup-docker-environment
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -77,10 +76,10 @@ jobs:
             RUNNER_CONTAINER_HOOKS_VERSION=${{ env.RUNNER_CONTAINER_HOOKS_VERSION }}
           tags: |
             ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}-${{ steps.vars.outputs.sha_short }}
+            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}-${{ env.sha_short }}
             ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:latest
             ghcr.io/${{ github.repository }}/${{ matrix.name }}:latest
             ghcr.io/${{ github.repository }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}
-            ghcr.io/${{ github.repository }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}-${{ steps.vars.outputs.sha_short }}
+            ghcr.io/${{ github.repository }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}-${{ env.sha_short }}
           cache-from: type=gha,scope=build-${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.name }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

set-output is being removed