### PR TITLE
use v1 policy api

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.21.1
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
 appVersion: 0.26.0

--- a/charts/actions-runner-controller/templates/controller.pdb.yaml
+++ b/charts/actions-runner-controller/templates/controller.pdb.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 apiVersion: policy/v1
-{{- else -}}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/actions-runner-controller/templates/controller.pdb.yaml
+++ b/charts/actions-runner-controller/templates/controller.pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/actions-runner-controller/templates/githubwebhook.pdb.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.githubWebhookServer.podDisruptionBudget.enabled }}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/actions-runner-controller/templates/githubwebhook.pdb.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.pdb.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.githubWebhookServer.podDisruptionBudget.enabled }}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 apiVersion: policy/v1
-{{- else -}}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
```
❯ helm upgrade -n actions-runner-system snip actions-runner-controller/actions-runner-controller -f manifests/snip/values.yaml --install --version $CHART_VERSION
Error: UPGRADE FAILED: resource mapping not found for name: "snip-pdb" namespace: "actions-runner-system" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
ensure CRDs are installed first
```