### PR TITLE
admissionWebHooks: fix checking for caBundle

### DIFF
--- a/charts/actions-runner-controller/templates/webhook_configs.yaml
+++ b/charts/actions-runner-controller/templates/webhook_configs.yaml
@@ -237,7 +237,7 @@ webhooks:
     resources:
     - runnerreplicasets
   sideEffects: None
-{{ if not (or .Values.admissionWebHooks.caBundle .Values.certManagerEnabled) }}
+{{ if not (or (hasKey .Values.admissionWebHooks "caBundle") .Values.certManagerEnabled) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1621,7 +1621,6 @@ $ helm --upgrade install actions-runner-controller/actions-runner-controller \
 Set the Helm chart values as follows:
 
 ```shell
-$ CA_BUNDLE=$(cat path/to/ca.pem | base64)
 $ helm --upgrade install actions-runner-controller/actions-runner-controller \
   certManagerEnabled=false
 ```


### PR DESCRIPTION
This PR fixes a check for `caBundle` being present in the configured values. Previous check would always fail due to `.Values.admissionWebHooks` being `{}`.

This also fixes the example in the docs when relying on helm generated tls certificates for the web hook.