### PR TITLE
runner: Fix rootless dind to respect specified MTU

### DIFF
--- a/runner/entrypoint-dind-rootless.sh
+++ b/runner/entrypoint-dind-rootless.sh
@@ -14,7 +14,7 @@ fi
 if [ -n "${MTU}" ]; then
 jq ".\"mtu\" = ${MTU}" /home/runner/.config/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /home/runner/.config/docker/daemon.json
 # See https://docs.docker.com/engine/security/rootless/ and https://github.com/docker/engine/blob/8955d8da8951695a98eb7e15bead19d402c6eb27/contrib/dockerd-rootless.sh#L13
-echo "DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=${MTU}" >> /etc/environment
+echo "DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=${MTU}" | sudo tee -a /etc/environment
 fi
 
 if [ -n "${DOCKER_REGISTRY_MIRROR}" ]; then


### PR DESCRIPTION
While testing #1759, I found an issue in the rootless dind entrypoint that it was not respecting the configured MTU for dind docker due to a permission issue. This fixes that.