### PR TITLE
e2e: Fix continuous rolling updater to do stop on test completion

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -325,6 +325,7 @@ func TestE2E(t *testing.T) {
 					if !ok {
 						t.Logf("Stopping the continuous rolling-update of runners")
 					}
+					return
 				default:
 					time.Sleep(10 * time.Second)
 


### PR DESCRIPTION
This fixes a tiny, E2E-specific issue I found while running E2E tests.