### PR TITLE
docs: add the limitation to disabling updates

### DIFF
--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1578,6 +1578,8 @@ spec:
         - name: DISABLE_WAIT_FOR_DOCKER
           value: "true"
         # Disables automatic runner updates
+        # WARNING : Upon a new version of the actions/runner software being released 
+        # GitHub stop allocating jobs to runners on older versions after 30 days.
         - name: DISABLE_RUNNER_UPDATE
           value: "true"
 ```

--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1579,7 +1579,7 @@ spec:
           value: "true"
         # Disables automatic runner updates
         # WARNING : Upon a new version of the actions/runner software being released 
-        # GitHub stop allocating jobs to runners on older versions after 30 days.
+        # GitHub stop allocating jobs to runners on old versions after 30 days.
         - name: DISABLE_RUNNER_UPDATE
           value: "true"
 ```


### PR DESCRIPTION
We get issues and dicussions raised a lot for this limitation, it's documented in GitHub's docs (which we try not to document again in ARC) but it doesn't seem to get seen a lot. We get raised issues / dicussions frequently enough that we should document it here too to cut down on raised issues / dicussions.

https://docs.github.com/en/actions/hosting-your-own-runners/autoscaling-with-self-hosted-runners#controlling-runner-software-updates-on-self-hosted-runners