### PR TITLE
runner: Make WAIT_FOR_DOCKER_SECONDS configurable and working

### DIFF
--- a/acceptance/testdata/runnerdeploy.envsubst.yaml
+++ b/acceptance/testdata/runnerdeploy.envsubst.yaml
@@ -74,7 +74,6 @@ spec:
         value: "172.17.0.0/12"
       - name: DOCKER_DEFAULT_ADDRESS_POOL_SIZE
         value: "24"
-      # https://github.com/actions-runner-controller/actions-runner-controller/issues/1830
       - name: WAIT_FOR_DOCKER_SECONDS
         value: "3"
 

--- a/acceptance/testdata/runnerdeploy.envsubst.yaml
+++ b/acceptance/testdata/runnerdeploy.envsubst.yaml
@@ -74,6 +74,9 @@ spec:
         value: "172.17.0.0/12"
       - name: DOCKER_DEFAULT_ADDRESS_POOL_SIZE
         value: "24"
+      # https://github.com/actions-runner-controller/actions-runner-controller/issues/1830
+      - name: WAIT_FOR_DOCKER_SECONDS
+        value: "3"
 
       dockerMTU: 1400
 

--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1574,6 +1574,12 @@ spec:
         # Issues a sleep command at the start of the entrypoint
         - name: STARTUP_DELAY_IN_SECONDS
           value: "2"
+        # Specify the duration to wait for the docker daemon to be available
+        # The default duration of 120 seconds is sometimes too short
+        # to reliably qwait for the docker daemon.
+        # See https://github.com/actions-runner-controller/actions-runner-controller/issues/1804
+        - name: WAIT_FOR_DOCKER_SECONDS
+          value: 120
         # Disables the wait for the docker daemon to be available check
         - name: DISABLE_WAIT_FOR_DOCKER
           value: "true"

--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1576,7 +1576,7 @@ spec:
           value: "2"
         # Specify the duration to wait for the docker daemon to be available
         # The default duration of 120 seconds is sometimes too short
-        # to reliably qwait for the docker daemon.
+        # to reliably wait for the docker daemon to start
         # See https://github.com/actions-runner-controller/actions-runner-controller/issues/1804
         - name: WAIT_FOR_DOCKER_SECONDS
           value: 120

--- a/runner/startup.sh
+++ b/runner/startup.sh
@@ -145,10 +145,14 @@ if [ -z "${UNITTEST:-}" ] && [ -e ./externalstmp ]; then
   mv ./externalstmp/* ./externals/
 fi
 
+WAIT_FOR_DOCKER_SECONDS=${WAIT_FOR_DOCKER_SECONDS:-120}
 if [[ "${DISABLE_WAIT_FOR_DOCKER}" != "true" ]] && [[ "${DOCKER_ENABLED}" == "true" ]]; then
     log.debug 'Docker enabled runner detected and Docker daemon wait is enabled'
-    log.debug 'Waiting until Docker is available or the timeout is reached'
-    timeout 120s bash -c 'until docker ps ;do sleep 1; done'
+    log.debug "Waiting until Docker is available or the timeout of ${WAIT_FOR_DOCKER_SECONDS} seconds is reached"
+    if ! timeout "${WAIT_FOR_DOCKER_SECONDS}s" bash -c 'until docker ps ;do sleep 1; done'; then
+      log.notice "Docker has not become available within ${WAIT_FOR_DOCKER_SECONDS} seconds. Exiting with status 1."
+      exit 1
+    fi
 else
   log.notice 'Docker wait check skipped. Either Docker is disabled or the wait is disabled, continuing with entrypoint'
 fi


### PR DESCRIPTION
The hard-coded wait-for-docker timeout had been 120s. It's still 120 by default but you can now customize it via the new WAIT_FOR_DOCKER_SECONDS  envvar. See the updated documentation for more information.

This also fixes the bug in the wait-for-docker feature that it didn't actually exited the runner startup script on timeout, which made the runner not restart immediately when it somehow failed to start the docker daemon!

Ref #1830
Ref #1804