### PR TITLE
runner: Add LOG_DEBUG_DISABLED

### DIFF
--- a/acceptance/testdata/runnerdeploy.envsubst.yaml
+++ b/acceptance/testdata/runnerdeploy.envsubst.yaml
@@ -69,6 +69,9 @@ spec:
         value: "${ROLLING_UPDATE_PHASE}"
       - name: ARC_DOCKER_MTU_PROPAGATION
         value: "true"
+      # https://github.com/actions-runner-controller/actions-runner-controller/issues/1939
+      # - name: LOG_DEBUG_DISABLED
+      #   value: "yes"
       # https://github.com/docker/docs/issues/8663
       - name: DOCKER_DEFAULT_ADDRESS_POOL_BASE
         value: "172.17.0.0/12"

--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1583,6 +1583,10 @@ spec:
         # actions/runner software after 30 days.
         - name: DISABLE_RUNNER_UPDATE
           value: "true"
+        # Disables debug logging in runner containers
+        # See also https://github.com/actions-runner-controller/actions-runner-controller/issues/1939
+        - name: LOG_DEBUG_DISABLED
+          value: "yes"
 ```
 
 There are a few advanced envvars also that are available only for dind runners:

--- a/runner/logger.sh
+++ b/runner/logger.sh
@@ -65,7 +65,11 @@ __log() {
 #     "log.$level" message
 #
 # @formatter:off
-log.debug   () { __log 37 "$@"; } # white
+if [ "$LOG_DEBUG_DISABLED" != "" ]; then
+log.debug   () { : ; }
+else
+log.debug   () { __log 37 "$@"; } # whit
+fi
 log.notice  () { __log 34 "$@"; } # blue
 log.warning () { __log 33 "$@"; } # yellow
 log.error   () { __log 31 "$@"; } # red


### PR DESCRIPTION
We add a new runner pod/container envvar `LOG_DEBUG_DISABLED ` which suppresses the debug logs when set to a non-empty value. This is handy when you want to reduce the amount logs for cost saving, and crucial if you want to deploy ARC onto production clusters and you do NOT want some runner related secret values exposed in the logs.
Beware to ENABLE the debug logs whenever possible when submitting a bug report, manually replacing secret values in it, though! The debug logs make us diagnose your issue faster and better.

