### PR TITLE
Do not explicitly set Privileged to false.

### DIFF
--- a/controllers/new_runner_pod_test.go
+++ b/controllers/new_runner_pod_test.go
@@ -160,9 +160,7 @@ func TestNewRunnerPod(t *testing.T) {
 						},
 					},
 					ImagePullPolicy: corev1.PullAlways,
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: func() *bool { v := false; return &v }(),
-					},
+					SecurityContext: &corev1.SecurityContext{},
 				},
 				{
 					Name:  "docker",
@@ -366,9 +364,7 @@ func TestNewRunnerPod(t *testing.T) {
 						},
 					},
 					ImagePullPolicy: corev1.PullAlways,
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: boolPtr(false),
-					},
+					SecurityContext: &corev1.SecurityContext{},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -690,9 +686,7 @@ func TestNewRunnerPodFromRunnerController(t *testing.T) {
 						},
 					},
 					ImagePullPolicy: corev1.PullAlways,
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: func() *bool { v := false; return &v }(),
-					},
+					SecurityContext: &corev1.SecurityContext{},
 				},
 				{
 					Name:  "docker",
@@ -930,9 +924,7 @@ func TestNewRunnerPodFromRunnerController(t *testing.T) {
 						},
 					},
 					ImagePullPolicy: corev1.PullAlways,
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: boolPtr(false),
-					},
+					SecurityContext: &corev1.SecurityContext{},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,

--- a/controllers/runner_controller.go
+++ b/controllers/runner_controller.go
@@ -849,10 +849,6 @@ func newRunnerPodWithContainerMode(containerMode string, template corev1.Pod, ru
 		runnerContainerIndex = -1
 		runnerContainer = &corev1.Container{
 			Name: containerName,
-			SecurityContext: &corev1.SecurityContext{
-				// Runner need to run privileged if it contains DinD
-				Privileged: &dockerdInRunnerPrivileged,
-			},
 		}
 	}
 
@@ -887,8 +883,10 @@ func newRunnerPodWithContainerMode(containerMode string, template corev1.Pod, ru
 		runnerContainer.SecurityContext = &corev1.SecurityContext{}
 	}
 
-	if runnerContainer.SecurityContext.Privileged == nil {
-		// Runner need to run privileged if it contains DinD
+	// Runner need to run privileged if it contains DinD.
+	// Do not explicitly set SecurityContext.Privileged to false which is default,
+	// otherwise Windows pods don't get admitted on GKE.
+	if dockerdInRunnerPrivileged {
 		runnerContainer.SecurityContext.Privileged = &dockerdInRunnerPrivileged
 	}
 


### PR DESCRIPTION
Setting SecurityContext.Privileged bit to false, which is default, prevents GKE from admitting Windows pods.  Privileged bit is not supported on Windows.