### PR TITLE
Update Etcd To Make `make test-with-deps` Work On macOS 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,12 +287,10 @@ ifeq (, $(wildcard $(TEST_ASSETS)/etcd))
 	set -xe ;\
 	INSTALL_TMP_DIR=$$(mktemp -d) ;\
 	cd $$INSTALL_TMP_DIR ;\
-	wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_$(OS_NAME)_amd64.tar.gz ;\
+	wget https://github.com/coreos/etcd/releases/download/v3.4.22/etcd-v3.4.22-$(OS_NAME)-amd64.zip;\
 	mkdir -p $(TEST_ASSETS) ;\
-	tar zxvf kubebuilder_2.3.2_$(OS_NAME)_amd64.tar.gz ;\
-	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/etcd $(TEST_ASSETS)/etcd ;\
-	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/kube-apiserver $(TEST_ASSETS)/kube-apiserver ;\
-	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/kubectl $(TEST_ASSETS)/kubectl ;\
+	unzip etcd-v3.4.22-$(OS_NAME)-amd64.zip ;\
+	mv etcd-v3.4.22-$(OS_NAME)-amd64/etcd $(TEST_ASSETS)/etcd ;\
 	rm -rf $$INSTALL_TMP_DIR ;\
 	}
 ETCD_BIN=$(TEST_ASSETS)/etcd
@@ -314,9 +312,7 @@ ifeq (, $(wildcard $(TEST_ASSETS)/kube-apiserver))
 	wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_$(OS_NAME)_amd64.tar.gz ;\
 	mkdir -p $(TEST_ASSETS) ;\
 	tar zxvf kubebuilder_2.3.2_$(OS_NAME)_amd64.tar.gz ;\
-	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/etcd $(TEST_ASSETS)/etcd ;\
 	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/kube-apiserver $(TEST_ASSETS)/kube-apiserver ;\
-	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/kubectl $(TEST_ASSETS)/kubectl ;\
 	rm -rf $$INSTALL_TMP_DIR ;\
 	}
 KUBE_APISERVER_BIN=$(TEST_ASSETS)/kube-apiserver
@@ -338,8 +334,6 @@ ifeq (, $(wildcard $(TEST_ASSETS)/kubectl))
 	wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_$(OS_NAME)_amd64.tar.gz ;\
 	mkdir -p $(TEST_ASSETS) ;\
 	tar zxvf kubebuilder_2.3.2_$(OS_NAME)_amd64.tar.gz ;\
-	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/etcd $(TEST_ASSETS)/etcd ;\
-	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/kube-apiserver $(TEST_ASSETS)/kube-apiserver ;\
 	mv kubebuilder_2.3.2_$(OS_NAME)_amd64/bin/kubectl $(TEST_ASSETS)/kubectl ;\
 	rm -rf $$INSTALL_TMP_DIR ;\
 	}

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,17 @@ TOOLS_PATH=$(PWD)/.tools
 
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 
+# The etcd packages that coreos maintain use different extensions for each *nix OS on their github release page.
+# ETCD_EXTENSION: the storage format file extension listed on the release page.
+# EXTRACT_COMMAND: the  appropriate CLI command for extracting this file format.
+ifeq ($(OS_NAME), darwin)
+ETCD_EXTENSION:=zip
+EXTRACT_COMMAND:=unzip
+else
+ETCD_EXTENSION:=tar.gz
+EXTRACT_COMMAND:=tar -xzf
+endif
+
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
 	export PLATFORMS="linux/amd64,linux/arm64"
@@ -287,9 +298,9 @@ ifeq (, $(wildcard $(TEST_ASSETS)/etcd))
 	set -xe ;\
 	INSTALL_TMP_DIR=$$(mktemp -d) ;\
 	cd $$INSTALL_TMP_DIR ;\
-	wget https://github.com/coreos/etcd/releases/download/v3.4.22/etcd-v3.4.22-$(OS_NAME)-amd64.zip;\
+	wget https://github.com/coreos/etcd/releases/download/v3.4.22/etcd-v3.4.22-$(OS_NAME)-amd64.$(ETCD_EXTENSION);\
 	mkdir -p $(TEST_ASSETS) ;\
-	unzip etcd-v3.4.22-$(OS_NAME)-amd64.zip ;\
+	$(EXTRACT_COMMAND) etcd-v3.4.22-$(OS_NAME)-amd64.$(ETCD_EXTENSION) ;\
 	mv etcd-v3.4.22-$(OS_NAME)-amd64/etcd $(TEST_ASSETS)/etcd ;\
 	rm -rf $$INSTALL_TMP_DIR ;\
 	}


### PR DESCRIPTION
## This PR makes the `make test-with-deps` task work on macOS and linux
I tried to run `make test-with-deps` on macOS Ventura and got a stack trace in the test logs. The stack trace is:

```bash
  Unexpected error:
      <*fmt.wrapError | 0xc0004f4360>: {
          msg: "unable to start control plane itself: failed to start the controlplane. retried 5 times: timeout waiting for process etcd to start successfully (it may have failed to start, or stopped unexpectedly before becoming ready)",
      }
      unable to start control plane itself: failed to start the controlplane. retried 5 times: timeout waiting for process etcd to start successfully (it may have failed to start, or stopped unexpectedly before becoming ready)
  occurred

  /Users/gwyn/Developer/actions-runner-controller/controllers/suite_test.go:75

------------------------------
```


I read the rest of the Makefile and it looked like all that the `make tests-with-deps` subcommand does to invoke etcd is to extract etcd from the kubebuilder_2.3.2 directory into the test-assets/ directory. I manually invoked the test-assetcs/etcd binary and got the error:

```bash
; ./etcd                                                                                                                                                                                                        Developer/actions-runner-controller/test-assets
fatal error: runtime: bsdthread_register error

runtime stack:
runtime.throw(0x1bed3fa, 0x21)
	/usr/local/go/src/runtime/panic.go:616 +0x81 fp=0x7ff7bfeff588 sp=0x7ff7bfeff568 pc=0x102a871
runtime.goenvs()
	/usr/local/go/src/runtime/os_darwin.go:129 +0x83 fp=0x7ff7bfeff5b8 sp=0x7ff7bfeff588 pc=0x10283f3
runtime.schedinit()
	/usr/local/go/src/runtime/proc.go:501 +0xd6 fp=0x7ff7bfeff620 sp=0x7ff7bfeff5b8 pc=0x102d166
runtime.rt0_go(0x7ff7bfeff650, 0x1, 0x7ff7bfeff650, 0x1000000, 0x1, 0x7ff7bfeff818, 0x0, 0x7ff7bfeff81f, 0x7ff7bfeff829, 0x7ff7bfeff83f, ...)
	/usr/local/go/src/runtime/asm_amd64.s:252 +0x1f4 fp=0x7ff7bfeff628 sp=0x7ff7bfeff620 pc=0x1056474
```

I cross-verified that the error comes from the kube_builder tarball by directly downloading the upstream's github release for kubebuilder_2.3.2 and extracting etcd; it has the same checksum and the same error.

I decided to see if the newest version of etcd can make the tests pass on both linux and macOS. 

To get the newest version of etcd, I checked out what current day  kubebuilder does in their test assets repository and they simply use curl to download the etcd release from the coreos github releases of etcd  (https://github.com/kubernetes-sigs/kubebuilder/blob/d63a7cd30ae3e36b01e6264b63ff19083add8961/build/thirdparty/darwin/Dockerfile#L52)

I duplicated their logic to download the current version of etcd in this pull request. This version of etcd works correctly on macOS and on debian.

I left kubebuilder as the older version for now, and it seems like `make test-with-deps` passes now on macOS. 

## I removed several statements that seemed redundant
It looked to me like each task to install `kubectl`, `etcd` and `kubeapiserver` was reduntantly also managing the other two binaries. It looked like the same few lines of code had been duplicated into all of the test dependencies make sections.

## Testing

In all my tests, I manually ran `rm -rf test-assets` to prepare for the test run.

I verified that `make test-with-deps` pass on macOS. The build log is in the file 
[macos_make_with_deps.txt](https://github.com/actions-runner-controller/actions-runner-controller/files/9999478/macos_make_with_deps.txt)

I also ran `make test-with-deps` on Debian and verified that the tests pass there also. The build log is in the file 
[macos_make_with_deps.txt](https://github.com/actions-runner-controller/actions-runner-controller/files/9999511/macos_make_with_deps.txt)

## How Can I work with you to have this merged?
Would you prefer that I upgrade all of the test dependencies, instead of having an old kube_builder and a new etcd?
Are there more thorough tests that I can run?

