### PR TITLE
Fix runner pod to not stuck in Terminating when runner got deleted before pod scheduling

### DIFF
--- a/controllers/runner_graceful_stop.go
+++ b/controllers/runner_graceful_stop.go
@@ -102,7 +102,7 @@ func ensureRunnerUnregistration(ctx context.Context, retryDelay time.Duration, l
 		!podIsPending(pod) {
 
 		log.Info(
-			"Unregistration started before runner obtains ID. Waiting for the regisration timeout to elapse, or the runner to obtain ID, or the runner pod to stop",
+			"Unregistration started before runner obtains ID. Waiting for the registration timeout to elapse, or the runner to obtain ID, or the runner pod to stop",
 			"registrationTimeout", registrationTimeout,
 		)
 		return &ctrl.Result{RequeueAfter: retryDelay}, nil


### PR DESCRIPTION
This fixes the said issue that I found while I was running a series of E2E tests to test other features and pull requestes I have recently contributed.