### PR TITLE
e2e: Do honor the runner graceful stop timeout also in the dockerd sidecar prestop hook

### DIFF
--- a/acceptance/testdata/runnerdeploy.envsubst.yaml
+++ b/acceptance/testdata/runnerdeploy.envsubst.yaml
@@ -76,6 +76,9 @@ spec:
         value: "24"
 
       dockerMTU: 1400
+      dockerEnv:
+      - name: RUNNER_GRACEFUL_STOP_TIMEOUT
+        value: "${RUNNER_GRACEFUL_STOP_TIMEOUT}"
 
       # Fix the following no space left errors with rootless-dind runners that can happen while running buildx build:
       #   ------


### PR DESCRIPTION
The runner graceful stop timeout has never been propagated to the dind sidecar due to configuration error in E2E. This fixes it, so that we can verify that the dind sidecar prestop can respect the graceful stop timeout.

Related to #1759