### PR TITLE
Fix `admissionWebHooks.caBundle` template formatting

### DIFF
--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
         {{- if .Values.runner.statusUpdateHook.enabled }}
         - "--runner-status-update-hook"
         {{- end }}
+        {{- if .Values.logFormat  }}  
+        - "--log-format={{ .Values.logFormat }}"
+        {{- end }}
         command:
         - "/manager"
         env:

--- a/charts/actions-runner-controller/templates/deployment.yaml
+++ b/charts/actions-runner-controller/templates/deployment.yaml
@@ -67,9 +67,6 @@ spec:
         {{- if .Values.runner.statusUpdateHook.enabled }}
         - "--runner-status-update-hook"
         {{- end }}
-        {{- if .Values.logFormat  }}  
-        - "--log-format={{ .Values.logFormat }}"
-        {{- end }}
         command:
         - "/manager"
         env:

--- a/charts/actions-runner-controller/templates/webhook_configs.yaml
+++ b/charts/actions-runner-controller/templates/webhook_configs.yaml
@@ -53,7 +53,7 @@ webhooks:
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
-    caBundle: {{ .Values.admissionWebHooks.caBundle }}
+    caBundle: {{ quote .Values.admissionWebHooks.caBundle }}
     {{- else if not .Values.certManagerEnabled }}
     caBundle: {{ $ca.Cert | b64enc | quote }}
     {{- end }}
@@ -83,7 +83,7 @@ webhooks:
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
-    caBundle: {{ .Values.admissionWebHooks.caBundle }}
+    caBundle: {{ quote .Values.admissionWebHooks.caBundle }}
     {{- else if not .Values.certManagerEnabled }}
     caBundle: {{ $ca.Cert | b64enc | quote }}
     {{- end }}
@@ -113,7 +113,7 @@ webhooks:
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
-    caBundle: {{ .Values.admissionWebHooks.caBundle }}
+    caBundle: {{ quote .Values.admissionWebHooks.caBundle }}
     {{- else if not .Values.certManagerEnabled }}
     caBundle: {{ $ca.Cert | b64enc | quote }}
     {{- end }}
@@ -156,7 +156,7 @@ webhooks:
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
-    caBundle: {{ .Values.admissionWebHooks.caBundle }}
+    caBundle: {{ quote .Values.admissionWebHooks.caBundle }}
     {{- else if not .Values.certManagerEnabled }}
     caBundle: {{ $ca.Cert | b64enc | quote }}
     {{- end }}
@@ -186,7 +186,7 @@ webhooks:
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
-    caBundle: {{ .Values.admissionWebHooks.caBundle }}
+    caBundle: {{ quote .Values.admissionWebHooks.caBundle }}
     {{- else if not .Values.certManagerEnabled }}
     caBundle: {{ $ca.Cert | b64enc | quote }}
     {{- end }}
@@ -216,7 +216,7 @@ webhooks:
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
-    caBundle: {{ .Values.admissionWebHooks.caBundle }}
+    caBundle: {{ quote .Values.admissionWebHooks.caBundle }}
     {{- else if not .Values.certManagerEnabled }}
     caBundle: {{ $ca.Cert | b64enc | quote }}
     {{- end }}

--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1699,8 +1699,8 @@ There are two methods of deploying without cert-manager, you can generate your o
 
 Assuming you are installing in the default namespace, ensure your certificate has SANs:
 
-* `webhook-service.actions-runner-system.svc`
-* `webhook-service.actions-runner-system.svc.cluster.local`
+* `actions-runner-controller-webhook.actions-runner-system.svc`
+* `actions-runner-controller-webhook.actions-runner-system.svc.cluster.local`
 
 It is possible to use a self-signed certificate by following a guide like
 [this one](https://mariadb.com/docs/security/encryption/in-transit/create-self-signed-certificates-keys-openssl/)
@@ -1709,7 +1709,7 @@ using `openssl`.
 Install your certificate as a TLS secret:
 
 ```shell
-$ kubectl create secret tls webhook-server-cert \
+$ kubectl create secret tls actions-runner-controller-serving-cert \
   -n actions-runner-system \
   --cert=path/to/cert/file \
   --key=path/to/key/file


### PR DESCRIPTION
Hello 👋

This is a PR for addressing https://github.com/actions-runner-controller/actions-runner-controller/issues/2045

One thing did stick out as odd in this commit d76dd67317713fd70438e25399ca7c9cf8b1ac95. After the cert changes the manager container errors on an unrecognized arg `--log-format`. It doesn't show as a value in `./manager --help` but is defined in the default chart values and is still a flag in the controllers code. Additionally, deploying the latest controller chart without the cert changes doesn't have any issues with that arg. Is the that arg not supported on the `./manager` cmd anymore or is there any context I'm missing?

### Testing

Pull down this branch and have a k8s cluster ready and accessible.
```bash
mkdir certs && cd certs
openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -out certificate.pem \
    -addext "subjectAltName = DNS:actions-runner-controller-webhook.actions-runner-system.svc"
kubectl create secret tls actions-runner-controller-serving-cert -n actions-runner-system --cert=certificate.pem --key=key.pem
export CA_BUNDLE=$(cat certificate.pem | base64)
export GITHUB_PAT="YOUR_TOKEN_HERE"
helm upgrade --install --namespace actions-runner-system --create-namespace \
    --set=certManagerEnabled=false \
    --set=admissionWebHooks.caBundle=${CA_BUNDLE} \
    --set=authSecret.create=true \
    --set=authSecret.github_token=${GITHUB_PAT} \
    --wait actions-runner-controller ../charts/actions-runner-controller
```
