### PR TITLE
feat: 22.04 default runner image

### DIFF
--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -45,6 +45,10 @@ jobs:
             os-name: ubuntu
             os-version: 20.04
             latest: "true"
+          - name: actions-runner
+            os-name: ubuntu
+            os-version: 22.04
+            latest: "false"
           - name: actions-runner-dind
             os-name: ubuntu
             os-version: 20.04

--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -1655,16 +1655,15 @@ spec:
 The project supports being deployed on the various cloud Kubernetes platforms (e.g. EKS), it does not however aim to go beyond that. No cloud specific tooling is bundled in the base runner, this is an active decision to keep the overhead of maintaining the solution manageable.
 
 **Bundled Software**<br />
-The GitHub hosted runners include a large amount of pre-installed software packages. GitHub maintains a list in README files at <https://github.com/actions/virtual-environments/tree/main/images/linux>
+The GitHub hosted runners include a large amount of pre-installed software packages. GitHub maintains a list in README files at <https://github.com/actions/virtual-environments/tree/main/images/linux>.
 
-This solution maintains a few runner images with `latest` aligning with GitHub's Ubuntu version, these images do not contain all of the software installed on the GitHub runners. The images contain the following subset of packages from the GitHub runners:
+This solution maintains a few Ubuntu based runner images, these images do not contain all of the software installed on the GitHub runners. The images contain the following subset of packages from the GitHub runners:
 
-- Basic CLI packages
+- Some basic CLI packages
 - Git
 - Git LFS
 - Docker
 - Docker Compose
-- build-essentials
 
 The virtual environments from GitHub contain a lot more software packages (different versions of Java, Node.js, Golang, .NET, etc) which are not provided in the runner image. Most of these have dedicated setup actions which allow the tools to be installed on-demand in a workflow, for example: `actions/setup-java` or `actions/setup-node`
 
@@ -1673,21 +1672,21 @@ If there is a need to include packages in the runner image for which there is no
 ```shell
 FROM summerwind/actions-runner:latest
 
-RUN sudo apt update -y \
-  && sudo apt install YOUR_PACKAGE
+RUN sudo apt-get update -y \
+  && sudo apt-get install $YOUR_PACKAGES
   && sudo rm -rf /var/lib/apt/lists/*
 ```
 
-You can then configure the runner to use a custom docker image by configuring the `image` field of a `Runner` or `RunnerDeployment`:
+You can then configure the runner to use a custom docker image by configuring the `image` field of a `RunnerDeployment` or `RunnerSet`:
 
 ```yaml
 apiVersion: actions.summerwind.dev/v1alpha1
-kind: Runner
+kind: RunnerDeployment
 metadata:
   name: custom-runner
 spec:
   repository: actions-runner-controller/actions-runner-controller
-  image: YOUR_CUSTOM_DOCKER_IMAGE
+  image: YOUR_CUSTOM_RUNNER_IMAGE
 ```
 
 ### Using without cert-manager

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -92,8 +92,6 @@ COPY docker-shim.sh /usr/local/bin/docker
 # Configure hooks folder structure.
 COPY hooks /etc/arc/hooks/
 
-# Add the Python "User Script Directory" to the PATH
-ENV PATH="${PATH}:${HOME}/.local/bin/"
 ENV ImageOS=ubuntu22
 
 RUN echo "PATH=${PATH}" > /etc/environment \

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -9,8 +9,6 @@ ARG DOCKER_VERSION=20.10.21
 ARG DOCKER_COMPOSE_VERSION=v2.12.2
 ARG DUMB_INIT_VERSION=1.2.5
 
-RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)
-
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
     && apt-get install -y software-properties-common \

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    build-essential \
     curl \
     ca-certificates \
     git \

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -1,0 +1,108 @@
+FROM ubuntu:22.04
+
+ARG TARGETPLATFORM
+ARG RUNNER_VERSION=2.299.1
+ARG RUNNER_CONTAINER_HOOKS_VERSION=0.1.3
+# Docker and Docker Compose arguments
+ARG CHANNEL=stable
+ARG DOCKER_VERSION=20.10.21
+ARG DOCKER_COMPOSE_VERSION=v2.12.2
+ARG DUMB_INIT_VERSION=1.2.5
+
+RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    ca-certificates \
+    git \
+    git-lfs \
+    jq \
+    sudo \
+    unzip \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --disabled-password --gecos "" --uid 1000 runner \
+    && groupadd docker \
+    && usermod -aG sudo runner \
+    && usermod -aG docker runner \
+    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
+
+ENV HOME=/home/runner
+
+RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
+    && chmod +x /usr/bin/dumb-init
+
+ENV RUNNER_ASSETS_DIR=/runnertmp
+RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x64 ; fi \
+    && mkdir -p "$RUNNER_ASSETS_DIR" \
+    && cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh \
+    && mv ./externals ./externalstmp \
+    # libyaml-dev is required for ruby/setup-ruby action.
+    # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
+    # to avoid rerunning apt-update on its own.
+    && apt-get install -y libyaml-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
+RUN mkdir /opt/hostedtoolcache \
+    && chgrp docker /opt/hostedtoolcache \
+    && chmod g+rwx /opt/hostedtoolcache
+
+RUN cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner-container-hooks.zip https://github.com/actions/runner-container-hooks/releases/download/v${RUNNER_CONTAINER_HOOKS_VERSION}/actions-runner-hooks-k8s-${RUNNER_CONTAINER_HOOKS_VERSION}.zip \
+    && unzip ./runner-container-hooks.zip -d ./k8s \
+    && rm -f runner-container-hooks.zip
+
+RUN set -vx; \
+    export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && curl -fLo docker.tgz https://download.docker.com/linux/static/${CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
+    && tar zxvf docker.tgz \
+    && install -o root -g root -m 755 docker/docker /usr/bin/docker \
+    && rm -rf docker docker.tgz
+
+RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && curl -fLo /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
+    && chmod +x /usr/bin/docker-compose
+
+# We place the scripts in `/usr/bin` so that users who extend this image can
+# override them with scripts of the same name placed in `/usr/local/bin`.
+COPY entrypoint.sh startup.sh logger.sh graceful-stop.sh update-status /usr/bin/
+
+# Copy the docker shim which propagates the docker MTU to underlying networks
+# to replace the docker binary in the PATH.
+COPY docker-shim.sh /usr/local/bin/docker
+
+# Configure hooks folder structure.
+COPY hooks /etc/arc/hooks/
+
+# Add the Python "User Script Directory" to the PATH
+ENV PATH="${PATH}:${HOME}/.local/bin/"
+ENV ImageOS=ubuntu22
+
+RUN echo "PATH=${PATH}" > /etc/environment \
+    && echo "ImageOS=${ImageOS}" >> /etc/environment
+
+USER runner
+
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["entrypoint.sh"]


### PR DESCRIPTION
Depends on https://github.com/actions-runner-controller/actions-runner-controller/pull/2036 https://github.com/actions-runner-controller/actions-runner-controller/pull/2063

Resolves https://github.com/actions-runner-controller/actions-runner-controller/issues/2006

To Do
- [x] write up justification in this PR for why we've removed what we've removed and what the policy is going forward

**Preample**
A new Ubuntu version represents an opportunity for the ARC maintainers to cut down on the installed software in the runner. The existing runner images contain a lot of sofware that would not typically be needed in CI/CD environment or has a niche use case, by including it we get the following negatives:

1. a larger image for the sake of including some tools a small percentage of the consumers use
2. more points of failure
3. a more insecure base imaage

The software that is included in the runner as it is today was largely inherited and not active choices made by the current maintainers.

**Things Removed and Why**
build-essential - CI/CD unrelated / niche use case
dnsutils - CI/CD unrelated
ftp - CI/CD unrelated / niche use case
iproute2 - CI/CD unrelated
iputils-ping - CI/CD unrelated
libunwind8 - CI/CD unrelated
locales - CI/CD unrelated
netcat - CI/CD unrelated
openssh-client - CI/CD unrelated / niche use case
parallel - niche use case
rsync - CI/CD unrelated / niche use case
shellcheck - various actions exist to run shellcheck, too opinionated to be in the base runner  https://github.com/search?q=shellcheck+action https://github.com/github/super-linter
telnet - CI/CD unrelated
time - CI/CD unrelated
tzdata - CI/CD unrelated
upx - CI/CD unrelated
wget - we already bundle curl which covers the same use case
zstd - CI/CD unrelated

**Python**
python - there is a official set-up action for Python so no need to bundle it making the base image larger https://github.com/actions/setup-python
python3-pip - python has been removed

When our runner images were first produced GitHub Actions offered very poor support for managing runners and so there was a strong incentive for ARC to have a fatter more inclusive image over a slimmer image. Since those days GitHub has introduced the `--disableupdate` flag enabling ARC administrators to more easily use their own runners built from ours without significant operational impacts lessening the incentive to bundle as much as possible in the ARC runners themselves.