### PR TITLE
doc: Do not recommend combining pull-based autoscaling with webhook-based autoscaling

### DIFF
--- a/docs/detailed-docs.md
+++ b/docs/detailed-docs.md
@@ -916,10 +916,9 @@ The main use case for scaling from 0 is with the `HorizontalRunnerAutoscaler` ki
 
 - `TotalNumberOfQueuedAndInProgressWorkflowRuns`
 - `PercentageRunnersBusy` + `TotalNumberOfQueuedAndInProgressWorkflowRuns`
-- `PercentageRunnersBusy` + Webhook-based autoscaling
-- Webhook-based autoscaling only
+- Webhook-based autoscaling
 
-`PercentageRunnersBusy` can't be used alone as, by its definition, it needs one or more GitHub runners to become `busy` to be able to scale. If there isn't a runner to pick up a job and enter a `busy` state then the controller will never know to provision a runner to begin with as this metric has no knowledge of the job queue and is relying on using the number of busy runners as a means for calculating the desired replica count.
+`PercentageRunnersBusy` can't be used alone for scale-from-zero as, by its definition, it needs one or more GitHub runners to become `busy` to be able to scale. If there isn't a runner to pick up a job and enter a `busy` state then the controller will never know to provision a runner to begin with as this metric has no knowledge of the job queue and is relying on using the number of busy runners as a means for calculating the desired replica count.
 
 If a HorizontalRunnerAutoscaler is configured with a secondary metric of `TotalNumberOfQueuedAndInProgressWorkflowRuns` then be aware that the controller will check the primary metric of `PercentageRunnersBusy` first and will only use the secondary metric to calculate the desired replica count if the primary metric returns 0 desired replicas.
 


### PR DESCRIPTION
It turned out that combining the two can result in ARC and K8s cluster instability.
Assuming that the scale-from-zero use-case can be served fine by webhook-based autoscaling alone, and the inability to scale quickly after canceling a large matrix of workflow jobs can be worked around by increasing HRA minReplicas, I think just updating a few lines in the documentation would be enough to mitigate the issue.

Ref https://github.com/actions-runner-controller/actions-runner-controller/issues/1962