### PR TITLE
runner: Expose dind runner dockerd logs via stdout/stderr

### DIFF
--- a/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update -y \
     python3-pip \
     rsync \
     shellcheck \
-    supervisor \
     software-properties-common \
     sudo \
     telnet \

--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update -y \
     iproute2 \
     iptables \
     jq \
-    supervisor \
     sudo \
     uidmap \
     unzip \

--- a/runner/actions-runner-dind.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-20.04.dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update -y \
     python3-pip \
     rsync \
     shellcheck \
-    supervisor \
     software-properties-common \
     sudo \
     telnet \
@@ -113,7 +112,6 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
 # We place the scripts in `/usr/bin` so that users who extend this image can
 # override them with scripts of the same name placed in `/usr/local/bin`.
 COPY entrypoint-dind.sh startup.sh logger.sh wait.sh graceful-stop.sh update-status /usr/bin/
-COPY supervisor/ /etc/supervisor/conf.d/
 RUN chmod +x /usr/bin/entrypoint-dind.sh /usr/bin/startup.sh
 
 # Copy the docker shim which propagates the docker MTU to underlying networks

--- a/runner/actions-runner-dind.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-22.04.dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update -y \
     git-lfs \
     iptables \
     jq \
-    supervisor \
     software-properties-common \
     sudo \
     unzip \
@@ -89,7 +88,6 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
 # We place the scripts in `/usr/bin` so that users who extend this image can
 # override them with scripts of the same name placed in `/usr/local/bin`.
 COPY entrypoint-dind.sh startup.sh logger.sh wait.sh graceful-stop.sh update-status /usr/bin/
-COPY supervisor/ /etc/supervisor/conf.d/
 RUN chmod +x /usr/bin/entrypoint-dind.sh /usr/bin/startup.sh
 
 # Copy the docker shim which propagates the docker MTU to underlying networks

--- a/runner/entrypoint-dind.sh
+++ b/runner/entrypoint-dind.sh
@@ -41,8 +41,8 @@ for config in /etc/docker/daemon.json /etc/supervisor/conf.d/dockerd.conf; do
   dump "$config" 'Using {path} with the following content:'
 done
 
-log.debug 'Starting supervisor daemon'
-sudo /usr/bin/supervisord -n >> /dev/null 2>&1 &
+log.debug 'Starting Docker daemon'
+sudo /usr/bin/dockerd &
 
 log.debug 'Waiting for processes to be running...'
 processes=(dockerd)

--- a/runner/entrypoint-dind.sh
+++ b/runner/entrypoint-dind.sh
@@ -13,7 +13,7 @@ fi
 if [ -n "${MTU}" ]; then
 jq ".\"mtu\" = ${MTU}" /etc/docker/daemon.json > /tmp/.daemon.json && mv /tmp/.daemon.json /etc/docker/daemon.json
 # See https://docs.docker.com/engine/security/rootless/
-echo "environment=DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=${MTU}" >> /etc/supervisor/conf.d/dockerd.conf
+export DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=${MTU}
 fi
 
 if [ -n "${DOCKER_DEFAULT_ADDRESS_POOL_BASE}" ] && [ -n "${DOCKER_DEFAULT_ADDRESS_POOL_SIZE}" ]; then
@@ -37,7 +37,7 @@ dump() {
   printf -- '---\n' 1>&2
 }
 
-for config in /etc/docker/daemon.json /etc/supervisor/conf.d/dockerd.conf; do
+for config in /etc/docker/daemon.json; do
   dump "$config" 'Using {path} with the following content:'
 done
 
@@ -50,8 +50,6 @@ processes=(dockerd)
 for process in "${processes[@]}"; do
     if ! wait_for_process "$process"; then
         log.error "$process is not running after max time"
-        dump /var/log/dockerd.err.log 'Dumping {path} to aid investigation'
-        dump /var/log/supervisor/supervisord.log 'Dumping {path} to aid investigation'
         exit 1
     else
         log.debug "$process is running"

--- a/runner/supervisor/dockerd.conf
+++ b/runner/supervisor/dockerd.conf
@@ -1,6 +1,0 @@
-[program:dockerd]
-command=/usr/bin/dockerd
-autostart=true
-autorestart=true
-stderr_logfile=/var/log/dockerd.err.log
-stdout_logfile=/var/log/dockerd.out.log


### PR DESCRIPTION
We've been letting supervisord run dockerd within the dind runner container presuming it would avoid producing zombie processes. However, we used dumb-init to wrap supervisord to wrap dockerd. In this picture, supervisord might be unnecessary, because dumb-init is a correct PID 0 for containers.

Removing supervisord removes this unnecessary complexity while saving a little memory, and more importantly, logs from dockerd are exposed via stdout/stderr of the container for easy access from kubectl-logs, fluentd, and so on.

Note that our rootless-dind-runner already exposes rootless dockerd logs via stdout/stderr. So this change is useful also for consistency with the rootless runner image.