### PR TITLE
Update release workflows

### DIFF
--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -68,8 +68,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "RELEASE_TAG_NAME=$(cat ${GITHUB_EVENT_PATH} | jq -r '.release.tag_name')" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-              echo "RELEASE_TAG_NAME=${{ github.event.inputs.release_tag_name }}" >> $GITHUB_ENV
+            echo "RELEASE_TAG_NAME=${{ github.event.inputs.release_tag_name }}" >> $GITHUB_ENV
           fi
+          echo "release tag: $RELEASE_TAG_NAME"
 
           # Authenticate
           gh auth login --with-token ${{ steps.get_workflow_token.outputs.token }}

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -70,10 +70,9 @@ jobs:
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "RELEASE_TAG_NAME=${{ github.event.inputs.release_tag_name }}" >> $GITHUB_ENV
           fi
-          echo "release tag: $RELEASE_TAG_NAME"
 
           # Authenticate
-          gh auth login --with-token ${{ steps.get_workflow_token.outputs.token }}
+          gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
 
           # Trigger the workflow
           jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${RELEASE_TAG_NAME}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -82,11 +82,11 @@ jobs:
 
       - name: Job summary
         run: |
-          echo "The publish-arc workflow has been triggered!" >> $GITHUB_STEP_SUMMARY
+          echo "The [publish-arc](https://github.com/actions-runner-controller/releases/blob/main/.github/workflows/publish-arc.yaml) workflow has been triggered!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Parameters:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Release tag: ${{ env.RELEASE_TAG_NAME }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Push to registries: ${{ inputs.push_to_registries }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Release tag: `${{ env.RELEASE_TAG_NAME }}`" >> $GITHUB_STEP_SUMMARY
+          echo "- Push to registries: `${{ inputs.push_to_registries }}`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:**" >> $GITHUB_STEP_SUMMARY
           echo "[https://github.com/actions-runner-controller/releases/actions/workflows/publish-arc.yaml](https://github.com/actions-runner-controller/releases/actions/workflows/publish-arc.yaml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v1
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db
         with:
           application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
           application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -85,8 +85,8 @@ jobs:
           echo "The [publish-arc](https://github.com/actions-runner-controller/releases/blob/main/.github/workflows/publish-arc.yaml) workflow has been triggered!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Parameters:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Release tag: `${{ env.RELEASE_TAG_NAME }}`" >> $GITHUB_STEP_SUMMARY
-          echo "- Push to registries: `${{ inputs.push_to_registries }}`" >> $GITHUB_STEP_SUMMARY
+          echo "- Release tag: ${{ env.RELEASE_TAG_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Push to registries: ${{ inputs.push_to_registries }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:**" >> $GITHUB_STEP_SUMMARY
           echo "[https://github.com/actions-runner-controller/releases/actions/workflows/publish-arc.yaml](https://github.com/actions-runner-controller/releases/actions/workflows/publish-arc.yaml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -75,5 +75,5 @@ jobs:
           gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
 
           # Trigger the workflow
-          jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${RELEASE_TAG_NAME}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
+          jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${{ env.RELEASE_TAG_NAME }}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -60,20 +60,22 @@ jobs:
           application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}
           organization: ${{ env.TARGET_ORG }}
 
+      - name: Set release tag name
+        run: |
+          # Define the release tag name based on the event type
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "RELEASE_TAG_NAME=$(cat ${GITHUB_EVENT_PATH} | jq -r '.release.tag_name')" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "RELEASE_TAG_NAME=${{ github.event.inputs.release_tag_name }}" >> $GITHUB_ENV
+          fi
+
       - name: Trigger Build And Push Images To Registries
         # Revert to https://github.com/actions-runner-controller/releases#releases
         # for details on why we use this approach
         run: |
-          # Define the release tag name based on the event type
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            export RELEASE_TAG_NAME="$(cat ${GITHUB_EVENT_PATH} | jq -r '.release.tag_name')"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            export RELEASE_TAG_NAME="${{ github.event.inputs.release_tag_name }}"
-          fi
-
           # Authenticate
           gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
 
           # Trigger the workflow
-          jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${RELEASE_TAG_NAME}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
+          jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${{ env.RELEASE_TAG_NAME }}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -7,10 +7,10 @@ on:
   workflow_dispatch:
     inputs:
       release_tag_name:
-        description: 'The tag name of the release to publish'
+        description: 'Tag name of the release to publish'
         required: true
       push_to_registries:
-        description: 'Whether to push the image to registries'
+        description: 'Push images to registries'
         required: true
         type: boolean
         default: false

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -66,14 +66,14 @@ jobs:
         run: |
           # Define the release tag name based on the event type
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "RELEASE_TAG_NAME=$(cat ${GITHUB_EVENT_PATH} | jq -r '.release.tag_name')" >> $GITHUB_ENV
+            export RELEASE_TAG_NAME="$(cat ${GITHUB_EVENT_PATH} | jq -r '.release.tag_name')"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "RELEASE_TAG_NAME=${{ github.event.inputs.release_tag_name }}" >> $GITHUB_ENV
+            export RELEASE_TAG_NAME="${{ github.event.inputs.release_tag_name }}"
           fi
 
           # Authenticate
           gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
 
           # Trigger the workflow
-          jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${{ env.RELEASE_TAG_NAME }}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
+          jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${RELEASE_TAG_NAME}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -1,5 +1,7 @@
 name: Publish ARC
 
+# Revert to https://github.com/actions-runner-controller/releases#releases
+# for details on why we use this approach
 on:
   release:
     types:
@@ -70,8 +72,6 @@ jobs:
           fi
 
       - name: Trigger Build And Push Images To Registries
-        # Revert to https://github.com/actions-runner-controller/releases#releases
-        # for details on why we use this approach
         run: |
           # Authenticate
           gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -31,6 +31,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18.2'
+
+      - name: Install tools
+        run: |
+          curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.2.0/kubebuilder_2.2.0_linux_amd64.tar.gz
+          tar zxvf kubebuilder_2.2.0_linux_amd64.tar.gz
+          sudo mv kubebuilder_2.2.0_linux_amd64 /usr/local/kubebuilder
+          curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
+          sudo mv kustomize /usr/local/bin
+          curl -L -O https://github.com/tcnksm/ghr/releases/download/v0.13.0/ghr_v0.13.0_linux_amd64.tar.gz
+          tar zxvf ghr_v0.13.0_linux_amd64.tar.gz
+          sudo mv ghr_v0.13.0_linux_amd64/ghr /usr/local/bin
+
       - name: Upload artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -76,6 +76,6 @@ jobs:
           # Authenticate
           gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
 
-          # Trigger the workflow
+          # Trigger the workflow run
           jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${{ env.RELEASE_TAG_NAME }}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -79,3 +79,14 @@ jobs:
           # Trigger the workflow run
           jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${{ env.RELEASE_TAG_NAME }}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -
+
+      - name: Job summary
+        run: |
+          echo "The publish-arc workflow has been triggered!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Parameters:**" >> $GITHUB_STEP_SUMMARY
+          echo "- Release tag: ${{ env.RELEASE_TAG_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Push to registries: ${{ inputs.push_to_registries }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:**" >> $GITHUB_STEP_SUMMARY
+          echo "[https://github.com/actions-runner-controller/releases/actions/workflows/publish-arc.yaml](https://github.com/actions-runner-controller/releases/actions/workflows/publish-arc.yaml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -4,39 +4,32 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      release_tag_name:
+        description: 'The tag name of the release to publish'
+        required: true
+      push_to_registries:
+        description: 'Whether to push the image to registries'
+        required: true
+        type: boolean
+        default: false
 
-# https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
 permissions:
  contents: write 
  packages: write
+
+env:
+  TARGET_ORG: actions-runner-controller
+  TARGET_REPO: actions-runner-controller
 
 jobs:
   release-controller:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.18.2'
-
-      - name: Install tools
-        run: |
-          curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.2.0/kubebuilder_2.2.0_linux_amd64.tar.gz
-          tar zxvf kubebuilder_2.2.0_linux_amd64.tar.gz
-          sudo mv kubebuilder_2.2.0_linux_amd64 /usr/local/kubebuilder
-          curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
-          sudo mv kustomize /usr/local/bin
-          curl -L -O https://github.com/tcnksm/ghr/releases/download/v0.13.0/ghr_v0.13.0_linux_amd64.tar.gz
-          tar zxvf ghr_v0.13.0_linux_amd64.tar.gz
-          sudo mv ghr_v0.13.0_linux_amd64/ghr /usr/local/bin
-
-      - name: Set version
-        run: echo "VERSION=$(cat ${GITHUB_EVENT_PATH} | jq -r '.release.tag_name')" >> $GITHUB_ENV
 
       - name: Upload artifacts
         env:
@@ -44,27 +37,28 @@ jobs:
         run: |
           make github-release
 
-      - name: Setup Docker Environment
-        uses: ./.github/actions/setup-docker-environment
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-          ghcr_username: ${{ github.actor }}
-          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
+          application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}
+          organization: ${{ env.TARGET_ORG }}
 
-      - name: Build and Push
-        uses: docker/build-push-action@v3
-        with:
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          build-args: VERSION=${{ env.VERSION }}
-          push: true
-          tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:latest
-            ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:${{ env.VERSION }}
-            ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:${{ env.VERSION }}-${{ env.sha_short }}
-            ghcr.io/actions-runner-controller/actions-runner-controller:latest
-            ghcr.io/actions-runner-controller/actions-runner-controller:${{ env.VERSION }}
-            ghcr.io/actions-runner-controller/actions-runner-controller:${{ env.VERSION }}-${{ env.sha_short }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Trigger Build And Push Images To Registries
+        # Revert to https://github.com/actions-runner-controller/releases#releases
+        # for details on why we use this approach
+        run: |
+          # Define the release tag name based on the event type
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "RELEASE_TAG_NAME=$(cat ${GITHUB_EVENT_PATH} | jq -r '.release.tag_name')" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+              echo "RELEASE_TAG_NAME=${{ github.event.inputs.release_tag_name }}" >> $GITHUB_ENV
+          fi
+
+          # Authenticate
+          gh auth login --with-token ${{ steps.get_workflow_token.outputs.token }}
+
+          # Trigger the workflow
+          jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${RELEASE_TAG_NAME}", "push_to_registries": ${{ inputs.push_to_registries }}}}' \
+            | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -63,7 +63,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Parameters:**" >> $GITHUB_STEP_SUMMARY
           echo "- sha: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Push to registries: ${{ inputs.push_to_registries }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Push to registries: ${{ env.PUSH_TO_REGISTRIES }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:**" >> $GITHUB_STEP_SUMMARY
           echo "[https://github.com/actions-runner-controller/releases/actions/workflows/publish-canary.yaml](https://github.com/actions-runner-controller/releases/actions/workflows/publish-canary.yaml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -19,10 +19,14 @@ on:
       - 'LICENSE'
       - 'Makefile'
 
+env:
+  PUSH_TO_REGISTRIES: false
+  TARGET_ORG: actions-runner-controller
+  TARGET_REPO: actions-runner-controller
+
 # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
 permissions:
   contents: read
-  packages: write
 
 jobs:
   canary-build:
@@ -34,26 +38,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Docker Environment
-        id: vars
-        uses: ./.github/actions/setup-docker-environment
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-          ghcr_username: ${{ github.actor }}
-          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
+          application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}
+          organization: ${{ env.TARGET_ORG }}
 
-      # Considered unstable builds
-      # See Issue #285, PR #286, and PR #323 for more information
-      - name: Build and Push
-        uses: docker/build-push-action@v3
-        with:
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          build-args: VERSION=canary-${{ github.sha }}
-          push: true
-          tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/actions-runner-controller:canary
-            ghcr.io/${{ github.repository }}:canary
-          cache-from: type=gha,scope=arc-canary
-          cache-to: type=gha,mode=max,scope=arc-canary
+      - name: Trigger Build And Push Images To Registries
+        run: |
+          # Authenticate
+          gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
+
+          # Trigger the workflow run
+          jq -n '{"event_type": "canary", "client_payload": {"sha": "${{ github.sha }}", "push_to_registries": ${{ env.PUSH_TO_REGISTRIES }}}}' \
+            | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -62,8 +62,8 @@ jobs:
           echo "The [publish-canary](https://github.com/actions-runner-controller/releases/blob/main/.github/workflows/publish-canary.yaml) workflow has been triggered!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Parameters:**" >> $GITHUB_STEP_SUMMARY
-          echo "- sha: `${{ github.sha }}`" >> $GITHUB_STEP_SUMMARY
-          echo "- Push to registries: `${{ inputs.push_to_registries }}`" >> $GITHUB_STEP_SUMMARY
+          echo "- sha: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Push to registries: ${{ inputs.push_to_registries }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:**" >> $GITHUB_STEP_SUMMARY
           echo "[https://github.com/actions-runner-controller/releases/actions/workflows/publish-canary.yaml](https://github.com/actions-runner-controller/releases/actions/workflows/publish-canary.yaml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v1
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db
         with:
           application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
           application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -36,7 +36,7 @@ jobs:
     name: Build and Publish Canary Image
     runs-on: ubuntu-latest
     env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USER }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -56,3 +56,14 @@ jobs:
           # Trigger the workflow run
           jq -n '{"event_type": "canary", "client_payload": {"sha": "${{ github.sha }}", "push_to_registries": ${{ env.PUSH_TO_REGISTRIES }}}}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -
+
+      - name: Job summary
+        run: |
+          echo "The [publish-canary](https://github.com/actions-runner-controller/releases/blob/main/.github/workflows/publish-canary.yaml) workflow has been triggered!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Parameters:**" >> $GITHUB_STEP_SUMMARY
+          echo "- sha: `${{ github.sha }}`" >> $GITHUB_STEP_SUMMARY
+          echo "- Push to registries: `${{ inputs.push_to_registries }}`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:**" >> $GITHUB_STEP_SUMMARY
+          echo "[https://github.com/actions-runner-controller/releases/actions/workflows/publish-canary.yaml](https://github.com/actions-runner-controller/releases/actions/workflows/publish-canary.yaml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -1,5 +1,7 @@
 name: Publish Canary Image
 
+# Revert to https://github.com/actions-runner-controller/releases#releases
+# for details on why we use this approach
 on:
   push:
     branches:

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -22,6 +22,7 @@ on:
       - 'Makefile'
 
 env:
+  # Safeguard to prevent pushing images to registeries after build
   PUSH_TO_REGISTRIES: false
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: actions-runner-controller

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -23,7 +23,7 @@ on:
 
 env:
   # Safeguard to prevent pushing images to registeries after build
-  PUSH_TO_REGISTRIES: false
+  PUSH_TO_REGISTRIES: true
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: actions-runner-controller
 

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -122,7 +122,7 @@ jobs:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
     env:
       CHART_TARGET_ORG: actions-runner-controller
-      CHART_TARGET_REPO: charts-test-repo
+      CHART_TARGET_REPO: actions-runner-controller.github.io
       CHART_TARGET_BRANCH: main
     
     steps:

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -186,14 +186,14 @@ jobs:
         run: |
           cp ${{ github.workspace }}/index.yaml ${{ env.CHART_TARGET_REPO }}/actions-runner-controller/index.yaml
       
-      - name: Commit and Push
-        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a
-        with:
-          commit_message: Update index.yaml
-          repository: ${{ github.workspace }}/${{ env.CHART_TARGET_REPO }}
-          commit_user_name: ${{ github.actor }}
-          commit_user_email: ${{ github.actor }}@users.noreply.github.com
-          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+      - name: Commit and push
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add .
+          git commit -m "Update index.yaml"
+          git push
+        working-directory: ${{ github.workspace }}/${{ env.CHART_TARGET_REPO }}
 
       - name: Job summary
         run: |

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -96,10 +96,12 @@ jobs:
           NEW_CHART_VERSION=$(echo "$CHART_TEXT" | grep version: | cut -d ' ' -f 2)
           RELEASE_LIST=$(curl -fs https://api.github.com/repos/actions/actions-runner-controller/releases  | jq .[].tag_name | grep actions-runner-controller | cut -d '"' -f 2 | cut -d '-' -f 4)
           LATEST_RELEASED_CHART_VERSION=$(echo $RELEASE_LIST | cut -d ' ' -f 1)
-          echo "Chart version in master : $NEW_CHART_VERSION"
-          echo "Latest release chart version : $LATEST_RELEASED_CHART_VERSION"
+          echo "CHART_VERSION_IN_MASTER=$NEW_CHART_VERSION" >> $GITHUB_ENV
+          echo "LATEST_CHART_VERSION=$LATEST_RELEASED_CHART_VERSION" >> $GITHUB_ENV
           if [[ $NEW_CHART_VERSION != $LATEST_RELEASED_CHART_VERSION ]]; then
             echo "publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "publish=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Job summary
@@ -107,6 +109,8 @@ jobs:
           echo "Chart linting has been completed." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:**" >> $GITHUB_STEP_SUMMARY
+          echo "- chart version in master: ${{ env.CHART_VERSION_IN_MASTER }}" >> $GITHUB_STEP_SUMMARY
+          echo "- latest chart version: ${{ env.LATEST_CHART_VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "- publish new chart: ${{ steps.publish-chart-step.outputs.publish }}" >> $GITHUB_STEP_SUMMARY
 
   publish-chart:

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -165,8 +165,10 @@ jobs:
       - name: Generate updated index.yaml
         run: |
           cr index \
+            --owner "${{ env.CHART_TARGET_ORG }}" \
+            --git-repo "${{ env.CHART_TARGET_REPO }}" \
             --index-path ${{ github.workspace }}/index.yaml \
-            --pages-branch 'gh-pages' \
+            --pages-branch '${{ env.CHART_TARGET_BRANCH }}' \
             --pages-index-path 'index.yaml'
 
       - name: Checkout pages repository

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -92,9 +92,9 @@ jobs:
       - name: Check if Chart Publish is Needed
         id: publish-chart-step
         run: |
-          CHART_TEXT=$(curl -fs https://raw.githubusercontent.com/actions/actions-runner-controller/master/charts/actions-runner-controller/Chart.yaml)
+          CHART_TEXT=$(curl -fs https://raw.githubusercontent.com/${{ github.repository }}/master/charts/actions-runner-controller/Chart.yaml)
           NEW_CHART_VERSION=$(echo "$CHART_TEXT" | grep version: | cut -d ' ' -f 2)
-          RELEASE_LIST=$(curl -fs https://api.github.com/repos/actions/actions-runner-controller/releases  | jq .[].tag_name | grep actions-runner-controller | cut -d '"' -f 2 | cut -d '-' -f 4)
+          RELEASE_LIST=$(curl -fs https://api.github.com/repos/${{ github.repository }}/releases  | jq .[].tag_name | grep actions-runner-controller | cut -d '"' -f 2 | cut -d '-' -f 4)
           LATEST_RELEASED_CHART_VERSION=$(echo $RELEASE_LIST | cut -d ' ' -f 1)
           echo "CHART_VERSION_IN_MASTER=$NEW_CHART_VERSION" >> $GITHUB_ENV
           echo "LATEST_CHART_VERSION=$LATEST_RELEASED_CHART_VERSION" >> $GITHUB_ENV
@@ -157,7 +157,8 @@ jobs:
             --package-path .cr-release-packages
 
           cr upload \
-            --git-repo ${{ github.repository }} \
+            --owner "$(echo ${{ github.repository }} | cut -d '/' -f 1)" \
+            --git-repo "$(echo ${{ github.repository }} | cut -d '/' -f 2)" \
             --package-path .cr-release-packages \
             --token ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,5 +1,7 @@
 name: Publish Helm Chart
 
+# Revert to https://github.com/actions-runner-controller/releases#releases
+# for details on why we use this approach
 on:
   push:
     branches:

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -88,7 +88,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config charts/.ci/ct-config.yaml
 
-      # WARNING: This relies on the latest release being inat the top of the JSON from GitHub and a clean chart.yaml
+      # WARNING: This relies on the latest release being at the top of the JSON from GitHub and a clean chart.yaml
       - name: Check if Chart Publish is Needed
         id: publish-chart-step
         run: |

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -109,8 +109,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
+    env:
+      CHART_TARGET_ORG: actions-runner-controller
+      CHART_TARGET_REPO: charts-test-repo
+      CHART_TARGET_BRANCH: main
     
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -122,8 +125,54 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
+        with:
+          application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
+          application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}
+          organization: ${{ env.CHART_TARGET_ORG }}
 
+      - name: Install chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        with:
+          install_only: true
+          install_dir: ${{ github.workspace }}/bin
+
+      - name: Package and upload release assets
+        run: |
+          cr package \
+            ${{ github.workspace }}/charts/actions-runner-controller/ \
+            --package-path .cr-release-packages
+
+          cr upload \
+            --package-path .cr-release-packages \
+            --token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate updated index.yaml
+        run: |
+          cr index \
+            --index-path ${{ github.workspace }}/index.yaml \
+            --pages-branch 'gh-pages' \
+            --pages-index-path 'index.yaml'
+
+      - name: Checkout pages repository
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.CHART_TARGET_ORG }}/${{ env.CHART_TARGET_REPO }}
+          path: ${{ env.CHART_TARGET_REPO }}
+          ref: ${{ env.CHART_TARGET_BRANCH }}
+          token: ${{ steps.get_workflow_token.outputs.token }}
+
+      - name: Copy index.yaml
+        run: |
+          cp ${{ github.workspace }}/index.yaml ${{ env.CHART_TARGET_REPO }}/index.yaml
+      
+      - name: Commit and Push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update index.yaml
+          repository: ${{ github.workspace }}/${{ env.CHART_TARGET_REPO }}
+          commit_user_name: ${{ github.actor }}
+          commit_user_email: ${{ github.actor }}@users.noreply.github.com
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -165,12 +165,15 @@ jobs:
       - name: Generate updated index.yaml
         run: |
           cr index \
-            --owner "${{ env.CHART_TARGET_ORG }}" \
-            --git-repo "${{ env.CHART_TARGET_REPO }}" \
+            --owner "$(echo ${{ github.repository }} | cut -d '/' -f 1)" \
+            --git-repo "$(echo ${{ github.repository }} | cut -d '/' -f 2)" \
             --index-path ${{ github.workspace }}/index.yaml \
-            --pages-branch '${{ env.CHART_TARGET_BRANCH }}' \
+            --pages-branch 'gh-pages' \
             --pages-index-path 'index.yaml'
 
+      # Chart Release was never intended to publish to a different repo
+      # this workaround is intended to move the index.yaml to the target repo
+      # where the github pages are hosted
       - name: Checkout pages repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -107,7 +107,7 @@ jobs:
           echo "Chart linting has been completed." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:**" >> $GITHUB_STEP_SUMMARY
-          echo "- publish?: ${{ steps.publish-chart-step.outputs.publish }}" >> $GITHUB_STEP_SUMMARY
+          echo "- publish new chart: ${{ steps.publish-chart-step.outputs.publish }}" >> $GITHUB_STEP_SUMMARY
 
   publish-chart:
     if: needs.lint-chart.outputs.publish-chart == 'true'
@@ -153,6 +153,7 @@ jobs:
             --package-path .cr-release-packages
 
           cr upload \
+            --git-repo ${{ github.repository }} \
             --package-path .cr-release-packages \
             --token ${{ secrets.GITHUB_TOKEN }}
 
@@ -176,7 +177,7 @@ jobs:
           cp ${{ github.workspace }}/index.yaml ${{ env.CHART_TARGET_REPO }}/actions-runner-controller/index.yaml
       
       - name: Commit and Push
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a
         with:
           commit_message: Update index.yaml
           repository: ${{ github.workspace }}/${{ env.CHART_TARGET_REPO }}

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -99,8 +99,15 @@ jobs:
           echo "Chart version in master : $NEW_CHART_VERSION"
           echo "Latest release chart version : $LATEST_RELEASED_CHART_VERSION"
           if [[ $NEW_CHART_VERSION != $LATEST_RELEASED_CHART_VERSION ]]; then
-            echo "::set-output name=publish::true"
+            echo "publish=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Job summary
+        run: |
+          echo "Chart linting has been completed." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:**" >> $GITHUB_STEP_SUMMARY
+          echo "- publish?: ${{ steps.publish-chart-step.outputs.publish }}" >> $GITHUB_STEP_SUMMARY
 
   publish-chart:
     if: needs.lint-chart.outputs.publish-chart == 'true'
@@ -166,7 +173,7 @@ jobs:
 
       - name: Copy index.yaml
         run: |
-          cp ${{ github.workspace }}/index.yaml ${{ env.CHART_TARGET_REPO }}/index.yaml
+          cp ${{ github.workspace }}/index.yaml ${{ env.CHART_TARGET_REPO }}/actions-runner-controller/index.yaml
       
       - name: Commit and Push
         uses: stefanzweifel/git-auto-commit-action@v4
@@ -176,3 +183,10 @@ jobs:
           commit_user_name: ${{ github.actor }}
           commit_user_email: ${{ github.actor }}@users.noreply.github.com
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+
+      - name: Job summary
+        run: |
+          echo "New helm chart has been published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:**" >> $GITHUB_STEP_SUMMARY
+          echo "- New [index.yaml](https://github.com/${{ env.CHART_TARGET_ORG }}/${{ env.CHART_TARGET_REPO }}/tree/main/actions-runner-controller) pushed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v1
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db
         with:
           application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
           application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -27,11 +27,13 @@ on:
       - '!**.md'
 
 env:
+  # Safeguard to prevent pushing images to registeries after build  
+  PUSH_TO_REGISTRIES: false
+  TARGET_ORG: actions-runner-controller
+  TARGET_WORKFLOW: release-runners.yaml
   RUNNER_VERSION: 2.299.1
   DOCKER_VERSION: 20.10.21
   RUNNER_CONTAINER_HOOKS_VERSION: 0.1.3
-  TARGET_ORG: actions-runner-controller
-  PUSH_TO_REGISTRIES: false
 
 jobs:
   build-runners:
@@ -52,7 +54,7 @@ jobs:
           gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
 
           # Trigger the workflow run
-          gh workflow run release-runners.yaml -R actions-runner-controller/releases \
+          gh workflow run ${{ env.TARGET_WORKFLOW }} -R ${{ env.TARGET_ORG }}/releases \
             -f runner_version=${{ env.RUNNER_VERSION }} \
             -f docker_version=${{ env.DOCKER_VERSION }} \
             -f runner_container_hooks_version=${{ env.RUNNER_CONTAINER_HOOKS_VERSION }} \

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -31,6 +31,7 @@ env:
   DOCKER_VERSION: 20.10.21
   RUNNER_CONTAINER_HOOKS_VERSION: 0.1.3
   TARGET_ORG: actions-runner-controller
+  PUSH_TO_REGISTRIES: false
 
 jobs:
   build-runners:
@@ -56,4 +57,4 @@ jobs:
             -f docker_version=${{ env.DOCKER_VERSION }} \
             -f runner_container_hooks_version=${{ env.RUNNER_CONTAINER_HOOKS_VERSION }} \
             -f sha='${{ github.sha }}' \
-            -f push_to_registries=false
+            -f push_to_registries=${{ env.PUSH_TO_REGISTRIES }}

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -28,7 +28,7 @@ on:
 
 env:
   # Safeguard to prevent pushing images to registeries after build  
-  PUSH_TO_REGISTRIES: false
+  PUSH_TO_REGISTRIES: true
   TARGET_ORG: actions-runner-controller
   TARGET_WORKFLOW: release-runners.yaml
   RUNNER_VERSION: 2.299.1

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v1
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db
         with:
           application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
           application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -1,5 +1,7 @@
 name: Runners
 
+# Revert to https://github.com/actions-runner-controller/releases#releases
+# for details on why we use this approach
 on:
   pull_request:
     types:
@@ -32,90 +34,26 @@ env:
 
 jobs:
   build-runners:
-    name: Build ${{ matrix.name }}-${{ matrix.os-name }}-${{ matrix.os-version }}
+    name: Trigger Build and Push of Runner Images
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: actions-runner
-            os-name: ubuntu
-            os-version: 20.04
-            latest: "true"
-          - name: actions-runner
-            os-name: ubuntu
-            os-version: 22.04
-            latest: "false"
-          - name: actions-runner-dind
-            os-name: ubuntu
-            os-version: 20.04
-            latest: "true"
-          - name: actions-runner-dind
-            os-name: ubuntu
-            os-version: 22.04
-            latest: "false"
-          - name: actions-runner-dind-rootless
-            os-name: ubuntu
-            os-version: 20.04
-            latest: "true"
-          - name: actions-runner-dind-rootless
-            os-name: ubuntu
-            os-version: 22.04
-            latest: "false"
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Docker Environment
-        uses: ./.github/actions/setup-docker-environment
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-          ghcr_username: ${{ github.actor }}
-          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          application_id: ${{ secrets.ACTIONS_ACCESS_APP_ID }}
+          application_private_key: ${{ secrets.ACTIONS_ACCESS_PK }}
+          organization: ${{ env.TARGET_ORG }}
 
-      - name: Build and Push Versioned Tags
-        uses: docker/build-push-action@v3
-        with:
-          context: ./runner
-          file: ./runner/${{ matrix.name }}.${{ matrix.os-name }}-${{ matrix.os-version }}.dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-          build-args: |
-            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
-            DOCKER_VERSION=${{ env.DOCKER_VERSION }}
-            RUNNER_CONTAINER_HOOKS_VERSION=${{ env.RUNNER_CONTAINER_HOOKS_VERSION }}
-          tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}-${{ env.sha_short }}
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:${{ matrix.os-name }}-${{ matrix.os-version }}
-            ghcr.io/${{ github.repository }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}
-            ghcr.io/${{ github.repository }}/${{ matrix.name }}:v${{ env.RUNNER_VERSION }}-${{ matrix.os-name }}-${{ matrix.os-version }}-${{ env.sha_short }}
-            ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ matrix.os-name }}-${{ matrix.os-version }}
-          cache-from: type=gha,scope=build-${{ matrix.name }}-${{ matrix.os-name }}-${{ matrix.os-version }}
-          cache-to: type=gha,mode=max,scope=build-${{ matrix.name }}-${{ matrix.os-name }}-${{ matrix.os-version }}
+      - name: Trigger Build And Push Runner Images To Registries
+        run: |
+          # Authenticate
+          gh auth login --with-token <<< ${{ steps.get_workflow_token.outputs.token }}
 
-      # NOTE : Only to be used on the 20.04 image until we remove the latest tag entirely
-      # at which point this step needs to be deleted
-      # https://github.com/actions/actions-runner-controller/issues/2056
-      - name: Build and Push Latest Tags
-        if: ${{ matrix.latest == 'true' }}
-        uses: docker/build-push-action@v3
-        with:
-          context: ./runner
-          file: ./runner/${{ matrix.name }}.${{ matrix.os-name }}-${{ matrix.os-version }}.dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-          build-args: |
-            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
-            DOCKER_VERSION=${{ env.DOCKER_VERSION }}
-            RUNNER_CONTAINER_HOOKS_VERSION=${{ env.RUNNER_CONTAINER_HOOKS_VERSION }}
-          tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.name }}:latest
-            ghcr.io/${{ github.repository }}/${{ matrix.name }}:latest
-          cache-from: type=gha,scope=build-${{ matrix.name }}-${{ matrix.os-name }}-${{ matrix.os-version }}
-          cache-to: type=gha,mode=max,scope=build-${{ matrix.name }}-${{ matrix.os-name }}-${{ matrix.os-version }}
+          # Trigger the workflow run
+          gh workflow run release-runners.yaml -R actions-runner-controller/releases \
+            -f runner_version=${{ env.RUNNER_VERSION }} \
+            -f docker_version=${{ env.DOCKER_VERSION }} \
+            -f runner_container_hooks_version=${{ env.RUNNER_CONTAINER_HOOKS_VERSION }} \
+            -f sha='${{ github.sha }}' \
+            -f push_to_registries=false

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -30,7 +30,7 @@ env:
   RUNNER_VERSION: 2.299.1
   DOCKER_VERSION: 20.10.21
   RUNNER_CONTAINER_HOOKS_VERSION: 0.1.3
-  DOCKERHUB_USERNAME: summerwind
+  TARGET_ORG: actions-runner-controller
 
 jobs:
   build-runners:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,3 +211,9 @@ The process would look like the below:
 - Update your actions-runner-controller's controller-manager deployment to use the new image, `$DOCKER_USER/actions-runner-controller:canary`
 
 Please also note that you need to replace `$DOCKER_USER` with your own DockerHub account name.
+
+## Release process
+
+Only the maintainers can release a new version of actions-runner-controller, publish a new version of the helm charts, and runner images.
+
+All release workflows have been moved to [actions-runner-controller/releases](https://github.com/actions-runner-controller/releases) since the packages are owned by the former organization.


### PR DESCRIPTION
- resolves https://github.com/github/c2c-actions-runtime/issues/2221
- resolves https://github.com/github/c2c-actions-runtime/issues/2194
- resolves https://github.com/github/c2c-actions-runtime/issues/2212

### Summary

Following the transfer of `actions-runner-controller` to the `actions` organisation, the controller and runner release workflows have been broken.

This PR intends to fix those workflows while introducing the least amount of changes. The fact that packages (all images pushed to GHCR) remain under [the old organisation](https://github.com/orgs/actions-runner-controller/packages) – which is intentional to avoid breaking end-user environments – introduced unnecessary complexity to these workflows.

As we work on improving our posture, this PR remedies the situation and provides a mechanism to publish changes until the permanent fixes are introduced.

The behaviour of these workflows is fully described here: https://github.com/actions-runner-controller/releases

### Caveats

For all of these workflows, the image pushing after build has not been tested (to avoid polluting registries). This needs to be verified after we merge.

### TODO before merge

- [x] Commit all TODO suggestions
- [x] Test & confirm the [publish-chart.yaml workflow](https://github.com/actions/actions-runner-controller/blob/c407b33040afd6ca6ad6347105a30f8a94ac8824/.github/workflows/publish-chart.yaml) is working as expected
- [x] Remove all references to `set-output`: [ref1](https://github.com/actions/actions-runner-controller/blob/c407b33040afd6ca6ad6347105a30f8a94ac8824/.github/workflows/publish-chart.yaml#L102)
- [x] Update `DOCKER_ACCESS_TOKEN` and `DOCKER_USER` secrets in this repo and in actions-runner-controller/releases