### PR TITLE
Fix broken links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ The maintainers will manage releases and publishing new charts.
 
 We always appreciate your help in testing open pull requests by deploying custom builds of actions-runner-controller onto your own environment, so that we are extra sure we didn't break anything.
 
-It is especially true when the pull request is about GitHub Enterprise, both GHEC and GHES, as [maintainers don't have GitHub Enterprise environments for testing](docs/detailed-docs.md#github-enterprise-support).
+It is especially true when the pull request is about GitHub Enterprise, both GHEC and GHES, as [maintainers don't have GitHub Enterprise environments for testing](docs/about-arc.md#github-enterprise-support).
 
 The process would look like the below:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The documentation is kept inline with master@HEAD, we do our best to highlight a
 ## Getting Started
 To give ARC a try with just a handful of commands, Please refer to the [Quickstart guide](/docs/quickstart.md). 
 
-For an overview of ARC, please refer to [ARC Overview](https://github.com/actions/actions-runner-controller/blob/master/docs/Actions-Runner-Controller-Overview.md)
+For an overview of ARC, please refer to [About ARC](https://github.com/actions/actions-runner-controller/blob/master/docs/about-arc.md)
 
 For more information, please refer to detailed documentation below!
 

--- a/docs/about-arc.md
+++ b/docs/about-arc.md
@@ -122,7 +122,7 @@ spec:
     scaleDownFactor: '0.5'
   ```
 
-For more details - please see "[Pull Driven Scaling](detailed-docs.md#pull-driven-scaling)."
+For more details - please see "[Pull Driven Scaling](automatically-scaling-runners.md#pull-driven-scaling)."
 
 *The period between polls is defined by the controller's `--sync-period` flag. If this flag isn't provided then the controller defaults to a sync period of `1m`, this can be configured in seconds or minutes.*
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ With ARC you can :
 
 ## Overview
 
-For an overview of ARC, please refer to "[ARC Overview](https://github.com/actions/actions-runner-controller/blob/master/docs/Actions-Runner-Controller-Overview.md)."
+For an overview of ARC, please refer to "[About ARC](https://github.com/actions/actions-runner-controller/blob/master/docs/about-arc.md)."
 
 ## Getting Started
 
@@ -140,7 +140,7 @@ There is also a quick start guide to get started on Actions, For more informatio
 
 ## Learn more
 
-For more detailed documentation, please refer to "[Detailed Documentation](https://github.com/actions/actions-runner-controller/blob/master/docs/detailed-docs.md)."
+For more detailed documentation, please refer to "[Actions Runner Controller Documentation](https://github.com/actions/actions-runner-controller/blob/master/README.md#documentation)."
 
 ## Contributing
 


### PR DESCRIPTION
When [restructuring the documentation](https://github.com/actions/actions-runner-controller/pull/2114), I deleted one file and renamed another. This caused some broken links in the existing documentation.

To resolve this, I ran a search for the two changed file names: `detailed-docs.md` and `Actions-Runner-Controller-Overview.md`. I updated any links to point to the new file names, and changed the link text where necessary.

There weren't too many broken links, so let me know if you think this strategy may have missed anything and I'll make those updates too. Thank you! 🚀 