### PR TITLE
fix(e2e): Use the correct full chart name in test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -106,7 +106,7 @@ func TestE2E(t *testing.T) {
 			label:         "stable",
 			controller:    "summerwind/actions-runner-controller",
 			controllerVer: "v0.25.2",
-			chart:         "actions/actions-runner-controller",
+			chart:         "actions-runner-controller/actions-runner-controller",
 			// 0.20.2 accidentally added support for runner-status-update which isn't supported by ARC 0.25.2.
 			// With some chart values, the controller end up with crashlooping with `flag provided but not defined: -runner-status-update-hook`.
 			chartVer: "0.20.1",


### PR DESCRIPTION
The whole E2E test breaks due to the invalid chart name without this fix.
This should be merged before finishing the work towards the next ARC 0.27.0 release.