### PR TITLE
Include actions-runner-controller in runner's User-Agent for better telemetry in Actions service.

### DIFF
--- a/controllers/actions.summerwind.net/new_runner_pod_test.go
+++ b/controllers/actions.summerwind.net/new_runner_pod_test.go
@@ -132,6 +132,10 @@ func TestNewRunnerPod(t *testing.T) {
 							Value: "false",
 						},
 						{
+							Name:  "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT",
+							Value: "actions-runner-controller/NA",
+						},
+						{
 							Name:  "DOCKER_HOST",
 							Value: "tcp://localhost:2376",
 						},
@@ -274,6 +278,10 @@ func TestNewRunnerPod(t *testing.T) {
 							Name:  "RUNNER_STATUS_UPDATE_HOOK",
 							Value: "false",
 						},
+						{
+							Name:  "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT",
+							Value: "actions-runner-controller/NA",
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -355,6 +363,10 @@ func TestNewRunnerPod(t *testing.T) {
 						{
 							Name:  "RUNNER_STATUS_UPDATE_HOOK",
 							Value: "false",
+						},
+						{
+							Name:  "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT",
+							Value: "actions-runner-controller/NA",
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
@@ -650,6 +662,10 @@ func TestNewRunnerPodFromRunnerController(t *testing.T) {
 							Value: "false",
 						},
 						{
+							Name:  "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT",
+							Value: "actions-runner-controller/NA",
+						},
+						{
 							Name:  "DOCKER_HOST",
 							Value: "tcp://localhost:2376",
 						},
@@ -808,6 +824,10 @@ func TestNewRunnerPodFromRunnerController(t *testing.T) {
 							Value: "false",
 						},
 						{
+							Name:  "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT",
+							Value: "actions-runner-controller/NA",
+						},
+						{
 							Name:  "RUNNER_NAME",
 							Value: "runner",
 						},
@@ -907,6 +927,10 @@ func TestNewRunnerPodFromRunnerController(t *testing.T) {
 						{
 							Name:  "RUNNER_STATUS_UPDATE_HOOK",
 							Value: "false",
+						},
+						{
+							Name:  "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT",
+							Value: "actions-runner-controller/NA",
 						},
 						{
 							Name:  "RUNNER_NAME",

--- a/controllers/actions.summerwind.net/runner_controller.go
+++ b/controllers/actions.summerwind.net/runner_controller.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/actions/actions-runner-controller/build"
 	"github.com/actions/actions-runner-controller/hash"
 	"github.com/go-logr/logr"
 
@@ -834,6 +835,10 @@ func newRunnerPodWithContainerMode(containerMode string, template corev1.Pod, ru
 		{
 			Name:  "RUNNER_STATUS_UPDATE_HOOK",
 			Value: fmt.Sprintf("%v", useRunnerStatusUpdateHook),
+		},
+		{
+			Name:  "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT",
+			Value: fmt.Sprintf("actions-runner-controller/%s", build.Version),
 		},
 	}
 


### PR DESCRIPTION
We want to get a general idea about how many runners on the Actions service are coming from the actions-runner-controller.

- In a future runner release, the runner will read ENV `GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT` on startup and add the value of the env as part of the User-Agent header for every HTTP request to Actions service.
- We can check telemetry on the Actions service's backend to see which runner is configured by actions-runner-controller.

With this data, we can better optimize backend performance for customers using the actions-runner-controller. 🙇 