### PR TITLE
Fix typo in release note for ARC 0.27.0

### DIFF
--- a/docs/releasenotes/0.27.md
+++ b/docs/releasenotes/0.27.md
@@ -40,7 +40,7 @@ spec:
         pullRequest: {}
 ```
 
-You need to update the spec to look like the below, along with enabling the `Workflow Job` events(and disabling unneeded `Push`, `Check Run`, and `Pull Request` evenst) on your webhook setting page on GitHub.
+You need to update the spec to look like the below, along with enabling the `Workflow Job` events(and disabling unneeded `Push`, `Check Run`, and `Pull Request` events) on your webhook setting page on GitHub.
 
 ```yaml
 kind: HorizontalRunnerAutoscaler

--- a/docs/releasenotes/app-version-mapping.md
+++ b/docs/releasenotes/app-version-mapping.md
@@ -4,7 +4,8 @@ The following table summarizes the version mapping between controller and chart 
 
 |Controller (App) Version|Chart Version|
 |---|---|
-|0.26.0|0.21.0|
+|0.27.0|0.22.0|
+|0.26.0|0.21.1/0.21.0|
 |0.25.2|0.20.2|
 |0.25.1|0.20.1|
 |0.25.0|0.20.0|


### PR DESCRIPTION
Just a minor typo fix for the documentation! Thanks and congratulations on the 0.27.0 release!!