### PR TITLE
chart: Bump chart and app versions for ARC 0.27.0

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.1
+version: 0.22.0
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.26.0
+appVersion: 0.27.0
 
 home: https://github.com/actions/actions-runner-controller
 


### PR DESCRIPTION
This is a routine pull request that we need to submit manually for each new ARC release, to make the default chart installation accommodates the new ARC version via the updated `appVersion`.