### PR TITLE
Ignore the new helm charts path for now.

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -10,6 +10,8 @@ on:
       - 'charts/**'
       - '.github/workflows/publish-chart.yaml'
       - '!charts/actions-runner-controller/docs/**'
+      - '!charts/actions-runner-controller-2/**'
+      - '!charts/auto-scaling-runner-set/**'
       - '!**.md'
   workflow_dispatch:
 

--- a/.github/workflows/validate-chart.yaml
+++ b/.github/workflows/validate-chart.yaml
@@ -6,6 +6,8 @@ on:
       - 'charts/**'
       - '.github/workflows/validate-chart.yaml'
       - '!charts/actions-runner-controller/docs/**'
+      - '!charts/actions-runner-controller-2/**'
+      - '!charts/auto-scaling-runner-set/**'
       - '!**.md'
   workflow_dispatch:
 env:


### PR DESCRIPTION
Pre-require for https://github.com/actions/actions-runner-controller/pull/2153

Both workflows are triggered for `- '.github/workflows/publish-chart.yaml'` and `- '.github/workflows/validate-chart.yaml'`, which means I can't introduce any file changes within the same PR to modify the workflow files.