### PR TITLE
Include extra user-agent for runners created by actions-runner-controller.

### DIFF
--- a/cmd/githubrunnerscalesetlistener/main.go
+++ b/cmd/githubrunnerscalesetlistener/main.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/actions/actions-runner-controller/build"
 	"github.com/actions/actions-runner-controller/github/actions"
 	"github.com/actions/actions-runner-controller/logging"
 	"github.com/go-logr/logr"
@@ -83,7 +84,7 @@ func run(rc RunnerScaleSetListenerConfig, logger logr.Logger) error {
 		}
 	}
 
-	actionsServiceClient, err := actions.NewClient(ctx, rc.ConfigureUrl, creds, "actions-runner-controller", logger)
+	actionsServiceClient, err := actions.NewClient(ctx, rc.ConfigureUrl, creds, fmt.Sprintf("actions-runner-controller/%s", build.Version), logger)
 	if err != nil {
 		return fmt.Errorf("failed to create an Actions Service client: %w", err)
 	}

--- a/controllers/actions.github.com/constants.go
+++ b/controllers/actions.github.com/constants.go
@@ -6,5 +6,6 @@ const (
 )
 
 const (
-	EnvVarRunnerJITConfig = "ACTIONS_RUNNER_INPUT_JITCONFIG"
+	EnvVarRunnerJITConfig      = "ACTIONS_RUNNER_INPUT_JITCONFIG"
+	EnvVarRunnerExtraUserAgent = "GITHUB_ACTIONS_RUNNER_EXTRA_USER_AGENT"
 )


### PR DESCRIPTION
Follow-up PR to https://github.com/actions/actions-runner-controller/pull/2155
Both ARC modes will set the same user-agent (actions-runner-controller/0.xx.x) for requests made by the runner inside the pod.