### PR TITLE
Fix L0 test to make it more reliable.

### DIFF
--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -310,6 +310,7 @@ func (r *EphemeralRunnerReconciler) cleanupRunnerLinkedPods(ctx context.Context,
 	}
 
 	if len(runnerLinkedPodList.Items) == 0 {
+		log.Info("Runner-linked pods are deleted")
 		return true, nil
 	}
 
@@ -344,6 +345,7 @@ func (r *EphemeralRunnerReconciler) cleanupRunnerLinkedSecrets(ctx context.Conte
 	}
 
 	if len(runnerLinkedSecretList.Items) == 0 {
+		log.Info("Runner-linked secrets are deleted")
 		return true, nil
 	}
 

--- a/controllers/actions.github.com/ephemeralrunnerset_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	ephemeralRunnerSetTestTimeout     = time.Second * 5
+	ephemeralRunnerSetTestTimeout     = time.Second * 10
 	ephemeralRunnerSetTestInterval    = time.Millisecond * 250
 	ephemeralRunnerSetTestGitHubToken = "gh_token"
 )
@@ -172,6 +172,26 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 						return -1, err
 					}
 
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
+					}
+
 					return len(runnerList.Items), nil
 				},
 				ephemeralRunnerSetTestTimeout,
@@ -212,6 +232,26 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 					err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
 					if err != nil {
 						return -1, err
+					}
+
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
 					}
 
 					return len(runnerList.Items), nil
@@ -278,19 +318,30 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 						return -1, err
 					}
 
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
+					}
+
 					return len(runnerList.Items), nil
 				},
 				ephemeralRunnerSetTestTimeout,
 				ephemeralRunnerSetTestInterval).Should(BeEquivalentTo(5), "5 EphemeralRunner should be created")
-
-			// Set status to simulate a configured EphemeralRunner
-			for i, runner := range runnerList.Items {
-				updatedRunner := runner.DeepCopy()
-				updatedRunner.Status.Phase = corev1.PodRunning
-				updatedRunner.Status.RunnerId = i + 100
-				err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
-				Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
-			}
 
 			// Mark one of the EphemeralRunner as finished
 			finishedRunner := runnerList.Items[4].DeepCopy()
@@ -327,19 +378,30 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 						return -1, err
 					}
 
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
+					}
+
 					return len(runnerList.Items), nil
 				},
 				ephemeralRunnerSetTestTimeout,
 				ephemeralRunnerSetTestInterval).Should(BeEquivalentTo(5), "5 EphemeralRunner should be created")
-
-			// Set status to simulate a configured EphemeralRunner
-			for i, runner := range runnerList.Items {
-				updatedRunner := runner.DeepCopy()
-				updatedRunner.Status.Phase = corev1.PodRunning
-				updatedRunner.Status.RunnerId = i + 100
-				err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
-				Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
-			}
 
 			// Scale down the EphemeralRunnerSet
 			updated = created.DeepCopy()
@@ -354,6 +416,26 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 					err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
 					if err != nil {
 						return -1, err
+					}
+
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
 					}
 
 					return len(runnerList.Items), nil
@@ -387,6 +469,26 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 						return -1, err
 					}
 
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
+					}
+
 					return len(runnerList.Items), nil
 				},
 				ephemeralRunnerSetTestTimeout,
@@ -413,6 +515,26 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 						return -1, err
 					}
 
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
+					}
+
 					return len(runnerList.Items), nil
 				},
 				ephemeralRunnerSetTestTimeout,
@@ -434,6 +556,26 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 					err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
 					if err != nil {
 						return -1, err
+					}
+
+					// Set status to simulate a configured EphemeralRunner
+					refetch := false
+					for i, runner := range runnerList.Items {
+						if runner.Status.RunnerId == 0 {
+							updatedRunner := runner.DeepCopy()
+							updatedRunner.Status.Phase = corev1.PodRunning
+							updatedRunner.Status.RunnerId = i + 100
+							err = k8sClient.Status().Patch(ctx, updatedRunner, client.MergeFrom(&runner))
+							Expect(err).NotTo(HaveOccurred(), "failed to update EphemeralRunner")
+							refetch = true
+						}
+					}
+
+					if refetch {
+						err := k8sClient.List(ctx, runnerList, client.InNamespace(ephemeralRunnerSet.Namespace))
+						if err != nil {
+							return -1, err
+						}
 					}
 
 					return len(runnerList.Items), nil


### PR DESCRIPTION
There are some L0 tests are randomly failed during CI/PR run, but work fine in our dev environment.
I am going to try improving the tests or fixing the bug the test exposes depending on what I found.

- [x] Test: `It should delete finished EphemeralRunner and create new EphemeralRunner`
- [x] Test: `It should not re-create pod indefinitely`
- [x] Test: `It should create/add all required resources for a new EphemeralRunnerSet (finalizer)`
> Ex: 
>       https://github.com/actions/actions-runner-controller/actions/runs/3942825864/jobs/6746938772
>       https://github.com/actions/actions-runner-controller/actions/runs/3946185966/jobs/6760411672