### PR TITLE
Fix URL for authenticating using a GitHub app

### DIFF
--- a/github/actions/url_test.go
+++ b/github/actions/url_test.go
@@ -1,0 +1,48 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGithubAPIURL(t *testing.T) {
+	tests := []struct {
+		configURL string
+		path      string
+		expected  string
+	}{
+		{
+			configURL: "https://github.com/org/repo",
+			path:      "/app/installations/123/access_tokens",
+			expected:  "https://api.github.com/app/installations/123/access_tokens",
+		},
+		{
+			configURL: "https://www.github.com/org/repo",
+			path:      "/app/installations/123/access_tokens",
+			expected:  "https://api.github.com/app/installations/123/access_tokens",
+		},
+		{
+			configURL: "http://github.localhost/org/repo",
+			path:      "/app/installations/123/access_tokens",
+			expected:  "http://api.github.localhost/app/installations/123/access_tokens",
+		},
+		{
+			configURL: "https://my-instance.com/org/repo",
+			path:      "/app/installations/123/access_tokens",
+			expected:  "https://my-instance.com/api/v3/app/installations/123/access_tokens",
+		},
+		{
+			configURL: "http://localhost/org/repo",
+			path:      "/app/installations/123/access_tokens",
+			expected:  "http://localhost/api/v3/app/installations/123/access_tokens",
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := githubAPIURL(test.configURL, test.path)
+		require.NoError(t, err)
+		assert.Equal(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION
This fixes the URL used to fetch an access token for users authenticating using a GitHub app (`github.com` -> `api.github.com`). This also adds a helper to get the right API url based on config URL, but it's not widely used yet (we should review all urls used throughout the application, ensuring they work for both hosted and GHES but that's outside the scope of this bug fix).