### PR TITLE
Add documentation to update ARC with prometheus CRDs needed by actions metrics server

### DIFF
--- a/charts/actions-runner-controller/docs/UPGRADING.md
+++ b/charts/actions-runner-controller/docs/UPGRADING.md
@@ -29,6 +29,15 @@ curl -L https://github.com/actions/actions-runner-controller/releases/download/a
 kubectl replace -f crds/
 ```
 
+For CHART_VERSION=0.22.0+, deploy Prometheus CRDs
+```
+$ helm repo add appscode https://charts.appscode.com/stable/
+$ helm repo update
+$ helm search repo appscode/prometheus-operator-crds --version=v0.60.1
+$ helm upgrade -i prometheus-operator-crds appscode/prometheus-operator-crds -n kube-system --create-namespace --version=v0.60.1
+```
+
+
 2. Upgrade the Helm release
 
 ```shell

--- a/charts/actions-runner-controller/docs/UPGRADING.md
+++ b/charts/actions-runner-controller/docs/UPGRADING.md
@@ -29,16 +29,7 @@ curl -L https://github.com/actions/actions-runner-controller/releases/download/a
 kubectl replace -f crds/
 ```
 
-In case you're going to create prometheus-operator `ServiceMonitor` resources via the chart, you'd need to deploy prometheus-operator-related CRDs as well.
-
-For example, you can use the `appscode/prometheus-operator-crds` to deploy those CRDs with Helm:
-```
-$ helm repo add appscode https://charts.appscode.com/stable/
-$ helm repo update
-$ helm search repo appscode/prometheus-operator-crds --version=v0.60.1
-$ helm upgrade -i prometheus-operator-crds appscode/prometheus-operator-crds -n kube-system --create-namespace --version=v0.60.1
-```
-
+Note that in case you're going to create prometheus-operator `ServiceMonitor` resources via the chart, you'd need to deploy prometheus-operator-related CRDs as well.
 
 2. Upgrade the Helm release
 

--- a/charts/actions-runner-controller/docs/UPGRADING.md
+++ b/charts/actions-runner-controller/docs/UPGRADING.md
@@ -29,7 +29,9 @@ curl -L https://github.com/actions/actions-runner-controller/releases/download/a
 kubectl replace -f crds/
 ```
 
-For CHART_VERSION=0.22.0+, deploy Prometheus CRDs
+In case you're going to create prometheus-operator `ServiceMonitor` resources via the chart, you'd need to deploy prometheus-operator-related CRDs as well.
+
+For example, you can use the `appscode/prometheus-operator-crds` to deploy those CRDs with Helm:
 ```
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update


### PR DESCRIPTION
Deploy prometheus CRDs needed by actions metrics server to fix the following upgrade issue:
```
upgrade.go:142: [debug] preparing upgrade for actions-runner-controller
Error: UPGRADE FAILED: resource mapping not found for name: "arc-service-monitor" namespace: "actions-runner-system" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
helm.go:84: [debug] resource mapping not found for name: "arc-service-monitor" namespace: "actions-runner-system" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
```