### PR TITLE
Fix intermittent image push failures to GHCR

### DIFF
--- a/.github/workflows/publish-arc2.yaml
+++ b/.github/workflows/publish-arc2.yaml
@@ -66,10 +66,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          # Pinning v0.9.1 for Buildx which uses BuildKit v0.10
-          # Buildx v0.10 uses BuildKit v0.11 which has a bug causing intermittent 
+          # Pinning v0.9.1 for Buildx and BuildKit v0.10.6
+          # BuildKit v0.11 which has a bug causing intermittent 
           # failures pushing images to GHCR
           version: v0.9.1
+          driver-opts: image=moby/buildkit:v0.10.6
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/publish-arc2.yaml
+++ b/.github/workflows/publish-arc2.yaml
@@ -66,7 +66,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: latest
+          # Pinning v0.9.1 for Buildx which uses BuildKit v0.10
+          # Buildx v0.10 uses BuildKit v0.11 which has a bug causing intermittent 
+          # failures pushing images to GHCR
+          version: v0.9.1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
### Context

Pushing runner and controller images to GHCR were failing intermittently with the following error:

```text
[Build and push controller image](https://github.com/actions/actions-runner-controller/actions/runs/4005602725/jobs/6876155092#step:7:489)
buildx failed with: ERROR: failed to solve: failed to push ghcr.io/actions/actions-runner-controller-2:canary2: failed to copy: io: read/write on closed pipe
```
This is due to a regression in BuildKit v0.11 which is used in Buildx v0.10.0 (latest). To resolve this, this PR will pin Buildx to v0.9.1 until this issue is resolved.

**Example:**
![CleanShot 2023-01-26 at 10 57 53](https://user-images.githubusercontent.com/568794/214807678-7adf3de9-0eab-44d8-ba78-f3ac8adfa0ad.png)
https://github.com/actions/actions-runner-controller/actions/runs/4005602725