### PR TITLE
Return error for non-existing runner group.

### DIFF
--- a/github/actions/client.go
+++ b/github/actions/client.go
@@ -300,7 +300,7 @@ func (c *Client) GetRunnerGroupByName(ctx context.Context, runnerGroup string) (
 	}
 
 	if runnerGroupList.Count == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("no runner group found with name '%s'", runnerGroup)
 	}
 
 	if runnerGroupList.Count > 1 {

--- a/github/actions/client_runner_test.go
+++ b/github/actions/client_runner_test.go
@@ -173,3 +173,69 @@ func TestDeleteRunner(t *testing.T) {
 		assert.Equalf(t, actualRetry, expectedRetry, "A retry was expected after the first request but got: %v", actualRetry)
 	})
 }
+
+func TestGetRunnerGroupByName(t *testing.T) {
+	ctx := context.Background()
+	auth := &actions.ActionsAuth{
+		Token: "token",
+	}
+
+	t.Run("Get RunnerGroup by Name", func(t *testing.T) {
+		var runnerGroupID int64 = 1
+		var runnerGroupName string = "test-runner-group"
+		want := &actions.RunnerGroup{
+			ID:   runnerGroupID,
+			Name: runnerGroupName,
+		}
+		response := []byte(`{"count": 1, "value": [{"id": 1, "name": "test-runner-group"}]}`)
+
+		server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write(response)
+		}))
+
+		client, err := actions.NewClient(ctx, server.configURLForOrg("my-org"), auth)
+		require.NoError(t, err)
+
+		got, err := client.GetRunnerGroupByName(ctx, runnerGroupName)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("Get RunnerGroup by name with not exist runner group", func(t *testing.T) {
+		var runnerGroupName string = "test-runner-group"
+		response := []byte(`{"count": 0, "value": []}`)
+
+		server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write(response)
+		}))
+
+		client, err := actions.NewClient(ctx, server.configURLForOrg("my-org"), auth)
+		require.NoError(t, err)
+
+		got, err := client.GetRunnerGroupByName(ctx, runnerGroupName)
+		assert.ErrorContains(t, err, "no runner group found with name")
+		assert.Nil(t, got)
+	})
+
+	t.Run("Default retries on server error", func(t *testing.T) {
+		var runnerGroupName string = "test-runner-group"
+
+		retryWaitMax := 1 * time.Millisecond
+		retryMax := 1
+
+		actualRetry := 0
+		expectedRetry := retryMax + 1
+
+		server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			actualRetry++
+		}))
+
+		client, err := actions.NewClient(ctx, server.configURLForOrg("my-org"), auth, actions.WithRetryMax(retryMax), actions.WithRetryWaitMax(retryWaitMax))
+		require.NoError(t, err)
+
+		_, err = client.GetRunnerByName(ctx, runnerGroupName)
+		require.Error(t, err)
+		assert.Equalf(t, actualRetry, expectedRetry, "A retry was expected after the first request but got: %v", actualRetry)
+	})
+}

--- a/github/actions/client_runner_test.go
+++ b/github/actions/client_runner_test.go
@@ -216,26 +216,4 @@ func TestGetRunnerGroupByName(t *testing.T) {
 		assert.ErrorContains(t, err, "no runner group found with name")
 		assert.Nil(t, got)
 	})
-
-	t.Run("Default retries on server error", func(t *testing.T) {
-		var runnerGroupName string = "test-runner-group"
-
-		retryWaitMax := 1 * time.Millisecond
-		retryMax := 1
-
-		actualRetry := 0
-		expectedRetry := retryMax + 1
-
-		server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			actualRetry++
-		}))
-
-		client, err := actions.NewClient(ctx, server.configURLForOrg("my-org"), auth, actions.WithRetryMax(retryMax), actions.WithRetryWaitMax(retryWaitMax))
-		require.NoError(t, err)
-
-		_, err = client.GetRunnerByName(ctx, runnerGroupName)
-		require.Error(t, err)
-		assert.Equalf(t, actualRetry, expectedRetry, "A retry was expected after the first request but got: %v", actualRetry)
-	})
 }


### PR DESCRIPTION
The controller currently crashes when you provide a non-existing runner group.
![image](https://user-images.githubusercontent.com/1750815/214896256-2234dcfc-4779-4987-bb5e-e43ec11378d9.png)

https://github.com/github/c2c-actions-runtime/issues/2268
