### PR TITLE
Allow update runner group for AutoScalingRunnerSet

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/actions/actions-runner-controller/apis/actions.github.com/v1alpha1"
 	"github.com/actions/actions-runner-controller/github/actions"
@@ -47,6 +48,7 @@ const (
 	LabelKeyAutoScaleRunnerSetName    = "auto-scale-runner-set-name"
 	autoscalingRunnerSetFinalizerName = "autoscalingrunnerset.actions.github.com/finalizer"
 	runnerScaleSetIdKey               = "runner-scale-set-id"
+	runnerScaleSetRunnerGroupNameKey  = "runner-scale-set-runner-group-name"
 
 	// scaleSetListenerLabel is the key of pod.meta.labels to label
 	// that the pod is a listener application
@@ -148,6 +150,13 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 		log.Info("Runner scale set id annotation is not an id, or is <= 0. Creating a new runner scale set.")
 		// something modified the scaleSetId. Try to create one
 		return r.createRunnerScaleSet(ctx, autoscalingRunnerSet, log)
+	}
+
+	// Make sure the runner group of the scale set is up to date
+	currentRunnerGroupName, ok := autoscalingRunnerSet.Annotations[runnerScaleSetRunnerGroupNameKey]
+	if !ok || !strings.EqualFold(currentRunnerGroupName, autoscalingRunnerSet.Spec.RunnerGroup) {
+		log.Info("AutoScalingRunnerSet runner group changed. Updating the runner scale set.")
+		return r.updateRunnerScaleSetRunnerGroup(ctx, autoscalingRunnerSet, log)
 	}
 
 	secret := new(corev1.Secret)
@@ -299,8 +308,8 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 		return ctrl.Result{}, err
 	}
 
+	runnerGroupId := 1
 	if runnerScaleSet == nil {
-		runnerGroupId := 1
 		if len(autoscalingRunnerSet.Spec.RunnerGroup) > 0 {
 			runnerGroup, err := actionsClient.GetRunnerGroupByName(ctx, autoscalingRunnerSet.Spec.RunnerGroup)
 			if err != nil {
@@ -338,14 +347,56 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 		autoscalingRunnerSet.Annotations = map[string]string{}
 	}
 
-	autoscalingRunnerSet.Annotations[runnerScaleSetIdKey] = strconv.Itoa(runnerScaleSet.Id)
-	logger.Info("Adding runner scale set ID as an annotation")
-	if err := r.Update(ctx, autoscalingRunnerSet); err != nil {
-		logger.Error(err, "Failed to add runner scale set ID")
+	logger.Info("Adding runner scale set ID and runner group name as an annotation")
+	err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
+		obj.Annotations[runnerScaleSetIdKey] = strconv.Itoa(runnerScaleSet.Id)
+		obj.Annotations[runnerScaleSetRunnerGroupNameKey] = runnerScaleSet.RunnerGroupName
+	})
+
+	if err != nil && !kerrors.IsNotFound(err) {
+		logger.Error(err, "Failed to add runner scale set ID and runner group name as an annotation")
 		return ctrl.Result{}, err
 	}
 
 	logger.Info("Updated with runner scale set ID as an annotation")
+	return ctrl.Result{}, nil
+}
+
+func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetRunnerGroup(ctx context.Context, autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet, logger logr.Logger) (ctrl.Result, error) {
+	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdKey])
+	if err != nil {
+		logger.Error(err, "Failed to parse runner scale set ID")
+		return ctrl.Result{}, err
+	}
+
+	actionsClient, err := r.actionsClientFor(ctx, autoscalingRunnerSet)
+	if err != nil {
+		logger.Error(err, "Failed to initialize Actions service client for updating a existing runner scale set")
+		return ctrl.Result{}, err
+	}
+
+	runnerGroup, err := actionsClient.GetRunnerGroupByName(ctx, autoscalingRunnerSet.Spec.RunnerGroup)
+	if err != nil {
+		logger.Error(err, "Failed to get runner group by name", "runnerGroup", autoscalingRunnerSet.Spec.RunnerGroup)
+		return ctrl.Result{}, err
+	}
+
+	updatedRunnerScaleSet, err := actionsClient.UpdateRunnerScaleSet(ctx, runnerScaleSetId, &actions.RunnerScaleSet{Name: autoscalingRunnerSet.Name, RunnerGroupId: int(runnerGroup.ID)})
+	if err != nil {
+		logger.Error(err, "Failed to update runner scale set", "runnerScaleSetId", runnerScaleSetId)
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("Adding runner scale set runner group name as an annotation")
+	err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
+		obj.Annotations[runnerScaleSetRunnerGroupNameKey] = updatedRunnerScaleSet.RunnerGroupName
+	})
+	if err != nil && !kerrors.IsNotFound(err) {
+		logger.Error(err, "Failed to update runner group name annotation")
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("Updated runner scale set with match runner group", "runnerGroup", updatedRunnerScaleSet.RunnerGroupName)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -348,12 +348,10 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 	}
 
 	logger.Info("Adding runner scale set ID and runner group name as an annotation")
-	err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
+	if err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
 		obj.Annotations[runnerScaleSetIdKey] = strconv.Itoa(runnerScaleSet.Id)
 		obj.Annotations[runnerScaleSetRunnerGroupNameKey] = runnerScaleSet.RunnerGroupName
-	})
-
-	if err != nil && !kerrors.IsNotFound(err) {
+	}); err != nil {
 		logger.Error(err, "Failed to add runner scale set ID and runner group name as an annotation")
 		return ctrl.Result{}, err
 	}
@@ -387,11 +385,10 @@ func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetRunnerGroup(ctx con
 		return ctrl.Result{}, err
 	}
 
-	logger.Info("Adding runner scale set runner group name as an annotation")
-	err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
+	logger.Info("Updating runner scale set runner group name as an annotation")
+	if err := patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
 		obj.Annotations[runnerScaleSetRunnerGroupNameKey] = updatedRunnerScaleSet.RunnerGroupName
-	})
-	if err != nil && !kerrors.IsNotFound(err) {
+	}); err != nil {
 		logger.Error(err, "Failed to update runner group name annotation")
 		return ctrl.Result{}, err
 	}

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 				GitHubConfigSecret: configSecret.Name,
 				MaxRunners:         &max,
 				MinRunners:         &min,
+				RunnerGroup:        "testgroup",
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -144,10 +145,14 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", nil
 					}
 
-					return created.Annotations[runnerScaleSetIdKey], nil
+					if _, ok := created.Annotations[runnerScaleSetRunnerGroupNameKey]; !ok {
+						return "", nil
+					}
+
+					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdKey], created.Annotations[runnerScaleSetRunnerGroupNameKey]), nil
 				},
 				autoscalingRunnerSetTestTimeout,
-				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("1"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's annotation")
+				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("1_testgroup"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's annotation")
 
 			// Check if ephemeral runner set is created
 			Eventually(

--- a/github/actions/fake/client.go
+++ b/github/actions/fake/client.go
@@ -36,6 +36,18 @@ var defaultRunnerScaleSet = &actions.RunnerScaleSet{
 	Statistics:         nil,
 }
 
+var defaultUpdatedRunnerScaleSet = &actions.RunnerScaleSet{
+	Id:                 1,
+	Name:               "testset",
+	RunnerGroupId:      2,
+	RunnerGroupName:    "testgroup",
+	Labels:             []actions.Label{{Type: "test", Name: "test"}},
+	RunnerSetting:      actions.RunnerSetting{},
+	CreatedOn:          time.Now(),
+	RunnerJitConfigUrl: "test.test.test",
+	Statistics:         nil,
+}
+
 var defaultRunnerGroup = &actions.RunnerGroup{
 	ID:        1,
 	Name:      "testgroup",
@@ -107,6 +119,10 @@ type FakeClient struct {
 		*actions.RunnerScaleSet
 		err error
 	}
+	updateRunnerScaleSetResult struct {
+		*actions.RunnerScaleSet
+		err error
+	}
 	createMessageSessionResult struct {
 		*actions.RunnerScaleSetSession
 		err error
@@ -164,6 +180,7 @@ func (f *FakeClient) applyDefaults() {
 	f.getRunnerScaleSetByIdResult.RunnerScaleSet = defaultRunnerScaleSet
 	f.getRunnerGroupByNameResult.RunnerGroup = defaultRunnerGroup
 	f.createRunnerScaleSetResult.RunnerScaleSet = defaultRunnerScaleSet
+	f.updateRunnerScaleSetResult.RunnerScaleSet = defaultUpdatedRunnerScaleSet
 	f.createMessageSessionResult.RunnerScaleSetSession = defaultRunnerScaleSetSession
 	f.refreshMessageSessionResult.RunnerScaleSetSession = defaultRunnerScaleSetSession
 	f.acquireJobsResult.ids = []int64{1}
@@ -188,6 +205,10 @@ func (f *FakeClient) GetRunnerGroupByName(ctx context.Context, runnerGroup strin
 
 func (f *FakeClient) CreateRunnerScaleSet(ctx context.Context, runnerScaleSet *actions.RunnerScaleSet) (*actions.RunnerScaleSet, error) {
 	return f.createRunnerScaleSetResult.RunnerScaleSet, f.createRunnerScaleSetResult.err
+}
+
+func (f *FakeClient) UpdateRunnerScaleSet(ctx context.Context, runnerScaleSetId int, runnerScaleSet *actions.RunnerScaleSet) (*actions.RunnerScaleSet, error) {
+	return f.updateRunnerScaleSetResult.RunnerScaleSet, f.updateRunnerScaleSetResult.err
 }
 
 func (f *FakeClient) CreateMessageSession(ctx context.Context, runnerScaleSetId int, owner string) (*actions.RunnerScaleSetSession, error) {

--- a/github/actions/mock_ActionsService.go
+++ b/github/actions/mock_ActionsService.go
@@ -332,6 +332,29 @@ func (_m *MockActionsService) RemoveRunner(ctx context.Context, runnerId int64) 
 	return r0
 }
 
+// UpdateRunnerScaleSet provides a mock function with given fields: ctx, runnerScaleSetId, runnerScaleSet
+func (_m *MockActionsService) UpdateRunnerScaleSet(ctx context.Context, runnerScaleSetId int, runnerScaleSet *RunnerScaleSet) (*RunnerScaleSet, error) {
+	ret := _m.Called(ctx, runnerScaleSetId, runnerScaleSet)
+
+	var r0 *RunnerScaleSet
+	if rf, ok := ret.Get(0).(func(context.Context, int, *RunnerScaleSet) *RunnerScaleSet); ok {
+		r0 = rf(ctx, runnerScaleSetId, runnerScaleSet)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*RunnerScaleSet)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int, *RunnerScaleSet) error); ok {
+		r1 = rf(ctx, runnerScaleSetId, runnerScaleSet)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewMockActionsService interface {
 	mock.TestingT
 	Cleanup(func())


### PR DESCRIPTION
https://github.com/github/c2c-actions-runtime/issues/2267

Support update the deployed `AutoScalingRunnerSet` and move it between different runner groups.

Ex:
```
helm upgrade arc-test --namespace demo ./charts/auto-scaling-runner-set --set runnerGroup=newgroup
```