### PR TITLE
Fix helm charts when pass values file. 

### DIFF
--- a/charts/.ci/ct-config.yaml
+++ b/charts/.ci/ct-config.yaml
@@ -1,4 +1,5 @@
 # This file defines the config for "ct" (chart tester) used by the helm linting GitHub workflow
+all: true
 lint-conf: charts/.ci/lint-config.yaml
 chart-repos:
   - jetstack=https://charts.jetstack.io

--- a/charts/auto-scaling-runner-set/templates/autoscalingrunnerset.yaml
+++ b/charts/auto-scaling-runner-set/templates/autoscalingrunnerset.yaml
@@ -12,21 +12,21 @@ spec:
   runnerGroup: {{ . }}
   {{- end }}
 
-  {{- if and (or (kindIs "int64" .Values.minRunners) (kindIs "float" .Values.minRunners)) (or (kindIs "int64" .Values.maxRunners) (kindIs "float" .Values.maxRunners)) }}
+  {{- if and (or (kindIs "int64" .Values.minRunners) (kindIs "float64" .Values.minRunners)) (or (kindIs "int64" .Values.maxRunners) (kindIs "float64" .Values.maxRunners)) }}
     {{- if gt .Values.minRunners .Values.maxRunners }}
       {{- fail "maxRunners has to be greater or equal to minRunners" }}
     {{- end }}
   {{- end }}
 
-  {{- if or (kindIs "int64" .Values.maxRunners) (kindIs "float" .Values.maxRunners) }}
-    {{- if lt .Values.maxRunners 0 }}
+  {{- if or (kindIs "int64" .Values.maxRunners) (kindIs "float64" .Values.maxRunners) }}
+    {{- if lt (.Values.maxRunners | int) 0 }}
       {{- fail "maxRunners has to be greater or equal to 0" }}
     {{- end }}
   maxRunners: {{ .Values.maxRunners | int }}
   {{- end }}
 
-  {{- if or (kindIs "int64" .Values.minRunners) (kindIs "float" .Values.minRunners) }}
-    {{- if lt .Values.minRunners 0 }}
+  {{- if or (kindIs "int64" .Values.minRunners) (kindIs "float64" .Values.minRunners) }}
+    {{- if lt (.Values.minRunners | int) 0 }}
       {{- fail "minRunners has to be greater or equal to 0" }}
     {{- end }}
   minRunners: {{ .Values.minRunners | int }}

--- a/charts/auto-scaling-runner-set/templates/autoscalingrunnerset.yaml
+++ b/charts/auto-scaling-runner-set/templates/autoscalingrunnerset.yaml
@@ -12,20 +12,20 @@ spec:
   runnerGroup: {{ . }}
   {{- end }}
 
-  {{- if and (kindIs "int64" .Values.minRunners) (kindIs "int64" .Values.maxRunners) }}
+  {{- if and (or (kindIs "int64" .Values.minRunners) (kindIs "float" .Values.minRunners)) (or (kindIs "int64" .Values.maxRunners) (kindIs "float" .Values.maxRunners)) }}
     {{- if gt .Values.minRunners .Values.maxRunners }}
       {{- fail "maxRunners has to be greater or equal to minRunners" }}
     {{- end }}
   {{- end }}
 
-  {{- if kindIs "int64" .Values.maxRunners }}
+  {{- if or (kindIs "int64" .Values.maxRunners) (kindIs "float" .Values.maxRunners) }}
     {{- if lt .Values.maxRunners 0 }}
       {{- fail "maxRunners has to be greater or equal to 0" }}
     {{- end }}
   maxRunners: {{ .Values.maxRunners | int }}
   {{- end }}
 
-  {{- if kindIs "int64" .Values.minRunners }}
+  {{- if or (kindIs "int64" .Values.minRunners) (kindIs "float" .Values.minRunners) }}
     {{- if lt .Values.minRunners 0 }}
       {{- fail "minRunners has to be greater or equal to 0" }}
     {{- end }}

--- a/charts/auto-scaling-runner-set/tests/values.yaml
+++ b/charts/auto-scaling-runner-set/tests/values.yaml
@@ -1,0 +1,5 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+maxRunners: 10
+minRunners: 5


### PR DESCRIPTION
Apparently, pass value via `--set foo=bar` and `--file values.yaml` will end up with a different data type. 😢 

Ex:
`--set foo=5` -> `typeOf(foo)=int64`

`--file values.yaml` with `foo: 5` in the yaml -> `typeOf(foo)=float64`