### PR TITLE
Skip CT when list-changed=false.

### DIFF
--- a/.github/workflows/validate-chart.yaml
+++ b/.github/workflows/validate-chart.yaml
@@ -78,5 +78,6 @@ jobs:
           helm install cert-manager jetstack/cert-manager --set installCRDs=true --wait
 
       - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config charts/.ci/ct-config.yaml


### PR DESCRIPTION
A [recent change](https://github.com/actions/actions-runner-controller/pull/2222/files#diff-f3e3affad266b1c3ce013eeac7b3b4fb3a9d55d1d2fc9f884c87abcc6a24aa55R2) will cause CT always run time execute even `list-changed` return `false`

I am changing the step to use the same `if` condition as the previous steps to skip running CT if there are no changes.