### PR TITLE
Allow provide pre-defined kubernetes secret when helm-install AutoScalingRunnerSet

### DIFF
--- a/charts/auto-scaling-runner-set/templates/_helpers.tpl
+++ b/charts/auto-scaling-runner-set/templates/_helpers.tpl
@@ -51,7 +51,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "auto-scaling-runner-set.githubsecret" -}}
+  {{- if kindIs "string" .Values.githubConfigSecret }}
+    {{- if not (empty .Values.githubConfigSecret) }}
+{{- .Values.githubConfigSecret }}
+    {{- else}}
+{{- fail "Values.githubConfigSecret is required for setting auth with GitHub server." }}
+    {{- end }}
+  {{- else }}
 {{- include "auto-scaling-runner-set.fullname" . }}-github-secret
+  {{- end }}
 {{- end }}
 
 {{- define "auto-scaling-runner-set.noPermissionServiceAccountName" -}}

--- a/charts/auto-scaling-runner-set/templates/githubsecret.yaml
+++ b/charts/auto-scaling-runner-set/templates/githubsecret.yaml
@@ -1,3 +1,4 @@
+{{- if not (kindIs "string" .Values.githubConfigSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -35,3 +36,4 @@ data:
   {{- if and $hasAppId (or (not $hasInstallationId) (not $hasPrivateKey)) }}
     {{- fail "A valid .Values.githubConfigSecret is required for setting auth with GitHub server, provide .Values.githubConfigSecret.github_app_installation_id and .Values.githubConfigSecret.github_app_private_key." }}
   {{- end }}
+{{- end}}

--- a/charts/auto-scaling-runner-set/values.yaml
+++ b/charts/auto-scaling-runner-set/values.yaml
@@ -13,6 +13,14 @@ githubConfigSecret:
 
   ### GitHub PAT Configuration
   github_token: ""
+## If you have a pre-define Kubernetes secret in the same namespace the auto-scaling-runner-set is going to deploy,
+## you can also reference it via `githubConfigSecret: pre-defined-secret`.
+## You need to make sure your predefined secret has all the required secret data set properly.
+##   For a pre-defined secret using GitHub PAT, the secret needs to be created like this:
+##   > kubectl create secret generic pre-defined-secret --namespace=my_namespace --from-literal=github_token='ghp_your_pat'
+##   For a pre-defined secret using GitHub App, the secret needs to be created like this:
+##   > kubectl create secret generic pre-defined-secret --namespace=my_namespace --from-literal=github_app_id=123456 --from-literal=github_app_installation_id=654321 --from-literal=github_app_private_key='-----BEGIN CERTIFICATE-----*******'
+# githubConfigSecret: pre-defined-secret
 
 ## maxRunners is the max number of runners the auto scaling runner set will scale up to.
 # maxRunners: 5


### PR DESCRIPTION
In case the customer has created a secret with all the required data, we will just reference it instead of creating a new one.