### PR TITLE
Resolve CI break due to bad merge.

### DIFF
--- a/github/actions/client_runner_scale_set_test.go
+++ b/github/actions/client_runner_scale_set_test.go
@@ -393,7 +393,7 @@ func TestDeleteRunnerScaleSet(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
 
-		client, err := actions.NewClient(ctx, server.configURLForOrg("my-org"), auth)
+		client, err := actions.NewClient(server.configURLForOrg("my-org"), auth)
 		require.NoError(t, err)
 
 		err = client.DeleteRunnerScaleSet(ctx, 10)
@@ -408,7 +408,7 @@ func TestDeleteRunnerScaleSet(t *testing.T) {
 			w.Write([]byte(`{"message": "test error"}`))
 		}))
 
-		client, err := actions.NewClient(ctx, server.configURLForOrg("my-org"), auth)
+		client, err := actions.NewClient(server.configURLForOrg("my-org"), auth)
 		require.NoError(t, err)
 
 		err = client.DeleteRunnerScaleSet(ctx, 10)


### PR DESCRIPTION
https://github.com/actions/actions-runner-controller/pull/2223 merged without rebasing against https://github.com/actions/actions-runner-controller/pull/2219 (Removed `ctx` from `actions.NewClient()`)

![image](https://user-images.githubusercontent.com/1750815/215877175-da4081dc-f2cd-4171-9788-6c968a38f9df.png)
