### PR TITLE
Avoid deleting scale set if annotation is not parsable or if it does not exist

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -412,8 +412,11 @@ func (r *AutoscalingRunnerSetReconciler) deleteRunnerScaleSet(ctx context.Contex
 	logger.Info("Deleting the runner scale set from Actions service")
 	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdKey])
 	if err != nil {
-		logger.Error(err, "Failed to parse runner scale set ID")
-		return err
+		// If the annotation is not set correctly, or if it does not exist, we are going to get stuck in a loop trying to parse the scale set id.
+		// If the configuration is invalid (secret does not exist for example), we never get to the point to create runner set. But then, manual cleanup
+		// would get stuck finalizing the resource trying to parse annotation indefinitely
+		logger.Info("autoscaling runner set does not have annotation describing scale set id. Skip deletion")
+		return nil
 	}
 
 	actionsClient, err := r.actionsClientFor(ctx, autoscalingRunnerSet)

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -418,7 +418,6 @@ func (r *AutoscalingRunnerSetReconciler) deleteRunnerScaleSet(ctx context.Contex
 		logger.Info("autoscaling runner set does not have annotation describing scale set id. Skip deletion", "err", err.Error())
 		return nil
 	}
-	fmt.Println("Well, that is wierd")
 
 	actionsClient, err := r.actionsClientFor(ctx, autoscalingRunnerSet)
 	if err != nil {

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -415,9 +415,10 @@ func (r *AutoscalingRunnerSetReconciler) deleteRunnerScaleSet(ctx context.Contex
 		// If the annotation is not set correctly, or if it does not exist, we are going to get stuck in a loop trying to parse the scale set id.
 		// If the configuration is invalid (secret does not exist for example), we never get to the point to create runner set. But then, manual cleanup
 		// would get stuck finalizing the resource trying to parse annotation indefinitely
-		logger.Info("autoscaling runner set does not have annotation describing scale set id. Skip deletion")
+		logger.Info("autoscaling runner set does not have annotation describing scale set id. Skip deletion", "err", err.Error())
 		return nil
 	}
+	fmt.Println("Well, that is wierd")
 
 	actionsClient, err := r.actionsClientFor(ctx, autoscalingRunnerSet)
 	if err != nil {

--- a/github/actions/fake/client.go
+++ b/github/actions/fake/client.go
@@ -31,6 +31,13 @@ func WithGetRunner(runner *actions.RunnerReference, err error) Option {
 	}
 }
 
+func WithCreateRunnerScaleSet(scaleSet *actions.RunnerScaleSet, err error) Option {
+	return func(f *FakeClient) {
+		f.createRunnerScaleSetResult.RunnerScaleSet = scaleSet
+		f.createRunnerScaleSetResult.err = err
+	}
+}
+
 var defaultRunnerScaleSet = &actions.RunnerScaleSet{
 	Id:                 1,
 	Name:               "testset",


### PR DESCRIPTION
If autoscaling runner set is applied without secret, the controller will not be able to create scale set.
It does not annotate the resource with an ID.

If you try to manually delete the autoscaling runner set, the controller will get stuck reporting an error trying to parse scale set id.
This change skips the deletion if annotation contains invalid ID or if it does not exist. In that case, deletion of a resource will proceed and cleanup would be successful