### PR TITLE
EphemeralRunner: On cleanup, if pod is pending, delete from service

### DIFF
--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -271,7 +271,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *EphemeralRunnerReconciler) cleanupRunnerFromService(ctx context.Context, ephemeralRunner *v1alpha1.EphemeralRunner, log logr.Logger) (ctrl.Result, error) {
 	actionsError := &actions.ActionsError{}
 	err := r.deleteRunnerFromService(ctx, ephemeralRunner, log)
-	if err != nill {
+	if err != nil {
 		if errors.As(err, &actionsError) &&
 			actionsError.StatusCode == http.StatusBadRequest &&
 			strings.Contains(actionsError.ExceptionName, "JobStillRunningException") {
@@ -284,7 +284,7 @@ func (r *EphemeralRunnerReconciler) cleanupRunnerFromService(ctx context.Context
 	}
 
 	log.Info("Successfully removed runner registration from service")
-	err := patch(ctx, r.Client, ephemeralRunner, func(obj *v1alpha1.EphemeralRunner) {
+	err = patch(ctx, r.Client, ephemeralRunner, func(obj *v1alpha1.EphemeralRunner) {
 		controllerutil.RemoveFinalizer(obj, ephemeralRunnerActionsFinalizerName)
 	})
 	if err != nil {

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -92,6 +92,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 					log.Error(err, "Failed to update ephemeral runner without runner registration finalizer")
 					return ctrl.Result{}, err
 				}
+                                 log.Info("Successfully removed runner registration finalizer")
 				return ctrl.Result{}, nil
 			default:
 				return r.cleanupRunnerFromService(ctx, ephemeralRunner, log)

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -92,7 +92,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 					log.Error(err, "Failed to update ephemeral runner without runner registration finalizer")
 					return ctrl.Result{}, err
 				}
-                                 log.Info("Successfully removed runner registration finalizer")
+				log.Info("Successfully removed runner registration finalizer")
 				return ctrl.Result{}, nil
 			default:
 				return r.cleanupRunnerFromService(ctx, ephemeralRunner, log)
@@ -272,25 +272,25 @@ func (r *EphemeralRunnerReconciler) cleanupRunnerFromService(ctx context.Context
 	actionsError := &actions.ActionsError{}
 	err := r.deleteRunnerFromService(ctx, ephemeralRunner, log)
 	if err != nill {
-	   if errors.As(err, &actionsError) &&
-	      actionsError.StatusCode == http.StatusBadRequest &&
-	      strings.Contains(actionsError.ExceptionName, "JobStillRunningException") {
-	        log.Info("Runner is still running the job. Re-queue in 30 seconds")
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	   }
-	   
-	   log.Error(err, "Failed clean up runner from the service")
-           return ctrl.Result{}, err
+		if errors.As(err, &actionsError) &&
+			actionsError.StatusCode == http.StatusBadRequest &&
+			strings.Contains(actionsError.ExceptionName, "JobStillRunningException") {
+			log.Info("Runner is still running the job. Re-queue in 30 seconds")
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+
+		log.Error(err, "Failed clean up runner from the service")
+		return ctrl.Result{}, err
 	}
-        
-       	log.Info("Successfully removed runner registration from service")
+
+	log.Info("Successfully removed runner registration from service")
 	err := patch(ctx, r.Client, ephemeralRunner, func(obj *v1alpha1.EphemeralRunner) {
 		controllerutil.RemoveFinalizer(obj, ephemeralRunnerActionsFinalizerName)
 	})
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	
+
 	log.Info("Successfully removed runner registration finalizer")
 	return ctrl.Result{}, nil
 }

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -274,9 +274,9 @@ func (r *EphemeralRunnerReconciler) cleanupRunnerFromService(ctx context.Context
 			controllerutil.RemoveFinalizer(obj, ephemeralRunnerActionsFinalizerName)
 		})
 		if err != nil {
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil
 	}
 
 	actionsError := &actions.ActionsError{}

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -153,19 +153,21 @@ var _ = Describe("EphemeralRunner", func() {
 			created := new(v1alpha1.EphemeralRunner)
 			// Check if finalizer is added
 			Eventually(
-				func() (string, error) {
+				func() ([]string, error) {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, created)
 					if err != nil {
-						return "", err
+						return nil, err
 					}
 					if len(created.Finalizers) == 0 {
-						return "", nil
+						return nil, nil
 					}
-					return created.Finalizers[0], nil
+
+					n := len(created.Finalizers) // avoid capacity mismatch
+					return created.Finalizers[:n:n], nil
 				},
 				timeout,
 				interval,
-			).Should(BeEquivalentTo(ephemeralRunnerFinalizerName))
+			).Should(BeEquivalentTo([]string{ephemeralRunnerActionsFinalizerName, ephemeralRunnerFinalizerName}))
 
 			Eventually(
 				func() (bool, error) {


### PR DESCRIPTION
If pod is unable to start due to image pull issue, the pod will get stuck in Pending phase. It would require manual intervention to delete that ephemeral runner.

This change removes runner from the service if pod is pending (never actually started).