### PR TITLE
Restricting the RBAC rules on secrets

### DIFF
--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -61,6 +61,9 @@ if [ "${tool}" == "helm" ]; then
     flags+=( --set githubWebhookServer.imagePullSecrets[0].name=${IMAGE_PULL_SECRET})
     flags+=( --set actionsMetricsServer.imagePullSecrets[0].name=${IMAGE_PULL_SECRET})
   fi
+  if [ "${WATCH_NAMESPACE}" != "" ]; then
+    flags+=( --set watchNamespace=${WATCH_NAMESPACE} --set singleNamespace=true)
+  fi
   if [ "${CHART_VERSION}" != "" ]; then
     flags+=( --version ${CHART_VERSION})
   fi

--- a/charts/actions-runner-controller/templates/manager_role.yaml
+++ b/charts/actions-runner-controller/templates/manager_role.yaml
@@ -250,14 +250,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
 {{- if .Values.runner.statusUpdateHook.enabled }}
 - apiGroups:
   - ""
@@ -309,13 +301,6 @@ rules:
   verbs:
   - get
   - list
-  - create
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
   - create
   - delete
 {{- end }}

--- a/charts/actions-runner-controller/templates/manager_role_binding_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_role_binding_secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.scope.singleNamespace }}
+kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
+{{- end }}
+metadata:
+  name: {{ include "actions-runner-controller.managerRoleName" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.scope.singleNamespace }}
+  kind: Role
+  {{- else }}
+  kind: ClusterRole
+  {{- end }}
+  name: {{ include "actions-runner-controller.managerRoleName" . }}-secrets
+subjects:
+- kind: ServiceAccount
+  name: {{ include "actions-runner-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/actions-runner-controller/templates/manager_role_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_role_secrets.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.scope.singleNamespace }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+  creationTimestamp: null
+  name: {{ include "actions-runner-controller.managerRoleName" . }}-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- if .Values.rbac.allowGrantingKubernetesContainerModePermissions }}
+{{/* These permissions are required by ARC to create RBAC resources for the runner pod to use the kubernetes container mode. */}}
+{{/* See https://github.com/actions/actions-runner-controller/pull/1268/files#r917331632 */}}
+  - create
+  - delete
+{{- end }}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -415,6 +415,7 @@ type env struct {
 	remoteKubeconfig                            string
 	imagePullSecretName                         string
 	imagePullPolicy                             string
+	watchNamespace                              string
 
 	vars          vars
 	VerifyTimeout time.Duration
@@ -555,6 +556,8 @@ func initTestEnv(t *testing.T, k8sMinorVer string, vars vars) *env {
 	} else {
 		e.imagePullPolicy = "IfNotPresent"
 	}
+
+	e.watchNamespace = testing.Getenv(t, "TEST_WATCH_NAMESPACE", "")
 
 	if e.remoteKubeconfig == "" {
 		e.Kind = testing.StartKind(t, k8sMinorVer, testing.Preload(images...))
@@ -726,6 +729,7 @@ func (e *env) installActionsRunnerController(t *testing.T, repo, tag, testID, ch
 		"VERSION=" + tag,
 		"IMAGE_PULL_SECRET=" + e.imagePullSecretName,
 		"IMAGE_PULL_POLICY=" + e.imagePullPolicy,
+		"WATCH_NAMESPACE=" + e.watchNamespace,
 	}
 
 	if e.useApp {


### PR DESCRIPTION
The PR is aiming at reducing the scope of the permissions for secrets.

As it stands the cluster-wide permissions are granted by default, therefore the service account used by the actions runner controller can see all the secrets from the entire cluster - even if it's not a desired behaviour.
We can easily imagine the shared cluster where we are only interested in a specific namespace. Whether we want it or not, the namespace admin can see all the secrets since we bind the ClusterRole using the ClusterRoleBinding is is not namespace-scoped.

See #2264 

Fix here is relatively simple and it doesn't involve any code level change:
1. Extracting the rules related to secrets and forming a dedicated set of role/binding
2. Reacting on `scope.singleNamespace` and switching between cluster-wide and namespace wide roles(`ClusterRole/ClusteRoleBinding` vs `Role/RoleBinding`) depending on the value. By default the current behaviour is preserved i.e. cluster-wide scope, otherwise it's limited to a namespace.