### PR TITLE
Remove list/watch secrets permission from the manager cluster role.

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_role.yaml
@@ -133,8 +133,6 @@ rules:
   - create
   - delete
   - get
-  - list
-  - watch
   - update
 - apiGroups:
   - ""

--- a/controllers/actions.github.com/autoscalinglistener_controller.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller.go
@@ -86,7 +86,7 @@ func (r *AutoscalingListenerReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 		if !done {
 			log.Info("Waiting for resources to be deleted before removing finalizer")
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		log.Info("Removing finalizer")
@@ -204,7 +204,7 @@ func (r *AutoscalingListenerReconciler) Reconcile(ctx context.Context, req ctrl.
 		return r.createRoleBindingForListener(ctx, autoscalingListener, listenerRole, serviceAccount, log)
 	}
 
-	// Create a secret containing proxy config if specifiec
+	// Create a secret containing proxy config if specified
 	if autoscalingListener.Spec.Proxy != nil {
 		proxySecret := new(corev1.Secret)
 		if err := r.Get(ctx, types.NamespacedName{Namespace: autoscalingListener.Namespace, Name: proxyListenerSecretName(autoscalingListener)}, proxySecret); err != nil {
@@ -299,7 +299,6 @@ func (r *AutoscalingListenerReconciler) SetupWithManager(mgr ctrl.Manager) error
 		For(&v1alpha1.AutoscalingListener{}).
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.ServiceAccount{}).
-		Owns(&corev1.Secret{}).
 		Watches(&source.Kind{Type: &rbacv1.Role{}}, handler.EnqueueRequestsFromMapFunc(labelBasedWatchFunc)).
 		Watches(&source.Kind{Type: &rbacv1.RoleBinding{}}, handler.EnqueueRequestsFromMapFunc(labelBasedWatchFunc)).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
@@ -503,7 +502,7 @@ func (r *AutoscalingListenerReconciler) createSecretsForListener(ctx context.Con
 	}
 
 	logger.Info("Created listener secret", "namespace", newListenerSecret.Namespace, "name", newListenerSecret.Name)
-	return ctrl.Result{}, nil
+	return ctrl.Result{Requeue: true}, nil
 }
 
 func (r *AutoscalingListenerReconciler) createProxySecret(ctx context.Context, autoscalingListener *v1alpha1.AutoscalingListener, logger logr.Logger) (ctrl.Result, error) {
@@ -542,7 +541,7 @@ func (r *AutoscalingListenerReconciler) createProxySecret(ctx context.Context, a
 
 	logger.Info("Created listener proxy secret", "namespace", newProxySecret.Namespace, "name", newProxySecret.Name)
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{Requeue: true}, nil
 }
 
 func (r *AutoscalingListenerReconciler) updateSecretsForListener(ctx context.Context, secret *corev1.Secret, mirrorSecret *corev1.Secret, logger logr.Logger) (ctrl.Result, error) {
@@ -558,7 +557,7 @@ func (r *AutoscalingListenerReconciler) updateSecretsForListener(ctx context.Con
 	}
 
 	logger.Info("Updated listener mirror secret", "namespace", updatedMirrorSecret.Namespace, "name", updatedMirrorSecret.Name, "hash", dataHash)
-	return ctrl.Result{}, nil
+	return ctrl.Result{Requeue: true}, nil
 }
 
 func (r *AutoscalingListenerReconciler) createRoleForListener(ctx context.Context, autoscalingListener *v1alpha1.AutoscalingListener, logger logr.Logger) (ctrl.Result, error) {

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -107,7 +107,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		if !done {
 			log.Info("Waiting for ephemeral runner owned resources to be deleted")
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		done, err = r.cleanupContainerHooksResources(ctx, ephemeralRunner, log)
@@ -643,7 +643,7 @@ func (r *EphemeralRunnerReconciler) createSecret(ctx context.Context, runner *v1
 	}
 
 	log.Info("Created ephemeral runner secret", "secretName", jitSecret.Name)
-	return ctrl.Result{}, nil
+	return ctrl.Result{Requeue: true}, nil
 }
 
 // updateRunStatusFromPod is responsible for updating non-exiting statuses.
@@ -792,7 +792,6 @@ func (r *EphemeralRunnerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.EphemeralRunner{}).
 		Owns(&corev1.Pod{}).
-		Owns(&corev1.Secret{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Named("ephemeral-runner-controller").
 		Complete(r)

--- a/main.go
+++ b/main.go
@@ -32,10 +32,12 @@ import (
 	"github.com/actions/actions-runner-controller/github/actions"
 	"github.com/actions/actions-runner-controller/logging"
 	"github.com/kelseyhightower/envconfig"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -160,6 +162,10 @@ func main() {
 		Port:               port,
 		SyncPeriod:         &syncPeriod,
 		Namespace:          namespace,
+		ClientDisableCacheFor: []client.Object{
+			&corev1.Secret{},
+			&corev1.ConfigMap{},
+		},
 	})
 	if err != nil {
 		log.Error(err, "unable to start manager")


### PR DESCRIPTION
The first part of the prototype changes for https://github.com/actions/actions-runner-controller/pull/2275

Changes:
- Remove `list/watch` permission on secrets for cluster scope
- Disable cache on secrets for the default manager client, so it won't complain about not having `list/watch` permission for secrets in cluster scope.
- Requeue reconciliation after any secret operations.

