### PR TITLE
Adding parameter to configure the runner set name.

### DIFF
--- a/apis/actions.github.com/v1alpha1/autoscalingrunnerset_types.go
+++ b/apis/actions.github.com/v1alpha1/autoscalingrunnerset_types.go
@@ -58,6 +58,9 @@ type AutoscalingRunnerSetSpec struct {
 	RunnerGroup string `json:"runnerGroup,omitempty"`
 
 	// +optional
+	RunnerScaleSetName string `json:"runnerScaleSetName,omitempty"`
+
+	// +optional
 	Proxy *ProxyConfig `json:"proxy,omitempty"`
 
 	// +optional
@@ -205,6 +208,7 @@ func (ars *AutoscalingRunnerSet) RunnerSetSpecHash() string {
 		GitHubConfigUrl    string
 		GitHubConfigSecret string
 		RunnerGroup        string
+		RunnerScaleSetName string
 		Proxy              *ProxyConfig
 		GitHubServerTLS    *GitHubServerTLSConfig
 		Template           corev1.PodTemplateSpec
@@ -213,6 +217,7 @@ func (ars *AutoscalingRunnerSet) RunnerSetSpecHash() string {
 		GitHubConfigUrl:    ars.Spec.GitHubConfigUrl,
 		GitHubConfigSecret: ars.Spec.GitHubConfigSecret,
 		RunnerGroup:        ars.Spec.RunnerGroup,
+		RunnerScaleSetName: ars.Spec.RunnerScaleSetName,
 		Proxy:              ars.Spec.Proxy,
 		GitHubServerTLS:    ars.Spec.GitHubServerTLS,
 		Template:           ars.Spec.Template,

--- a/charts/gha-runner-scale-set-controller/crds/actions.github.com_autoscalingrunnersets.yaml
+++ b/charts/gha-runner-scale-set-controller/crds/actions.github.com_autoscalingrunnersets.yaml
@@ -86,6 +86,8 @@ spec:
                   type: object
                 runnerGroup:
                   type: string
+                runnerScaleSetName:
+                  type: string
                 template:
                   description: Required
                   properties:

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.runnerGroup }}
   runnerGroup: {{ . }}
   {{- end }}
+  {{- with .Values.runnerScaleSetName }}
+  runnerScaleSetName: {{ . }}
+  {{- end }}
 
   {{- if .Values.proxy }}
   proxy:

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -44,6 +44,9 @@ githubConfigSecret:
 
 # runnerGroup: "default"
 
+## name of the runner scale set to create.  Defaults to the helm release name
+# runnerScaleSetName: ""
+
 ## template is the PodSpec for each runner Pod
 template:
   spec:

--- a/config/crd/bases/actions.github.com_autoscalingrunnersets.yaml
+++ b/config/crd/bases/actions.github.com_autoscalingrunnersets.yaml
@@ -86,6 +86,8 @@ spec:
                   type: object
                 runnerGroup:
                   type: string
+                runnerScaleSetName:
+                  type: string
                 template:
                   description: Required
                   properties:

--- a/controllers/actions.github.com/autoscalinglistener_controller.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller.go
@@ -99,6 +99,7 @@ func (r *AutoscalingListenerReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 
 		log.Info("Successfully removed finalizer after cleanup")
+		return ctrl.Result{}, nil
 	}
 
 	if !controllerutil.ContainsFinalizer(autoscalingListener, autoscalingListenerFinalizerName) {

--- a/github/actions/fake/client.go
+++ b/github/actions/fake/client.go
@@ -38,6 +38,13 @@ func WithCreateRunnerScaleSet(scaleSet *actions.RunnerScaleSet, err error) Optio
 	}
 }
 
+func WithUpdateRunnerScaleSet(scaleSet *actions.RunnerScaleSet, err error) Option {
+	return func(f *FakeClient) {
+		f.updateRunnerScaleSetResult.RunnerScaleSet = scaleSet
+		f.updateRunnerScaleSetResult.err = err
+	}
+}
+
 var defaultRunnerScaleSet = &actions.RunnerScaleSet{
 	Id:                 1,
 	Name:               "testset",


### PR DESCRIPTION
Currently the runner set name is always the same as the helm release name.  However, there are scenarios where one might want to have the same runner names across multiple runner groups and organizations.  Given the helm release still has to be unique per namespace it would be useful to optionally provide a runner set name.