### PR TITLE
doc: Fix chart name for helm commands in docs

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -67,7 +67,7 @@ To fix this, you may either:
    # With helm, you'd set `webhookPort` to the port number of your choice
    # See https://github.com/actions/actions-runner-controller/pull/1410/files for more information
    helm upgrade --install --namespace actions-runner-system --create-namespace \
-                --wait actions-runner-controller actions/actions-runner-controller \
+                --wait actions-runner-controller actions-runner-controller/actions-runner-controller \
                 --set webhookPort=10250
    ```
 

--- a/docs/about-arc.md
+++ b/docs/about-arc.md
@@ -44,7 +44,7 @@ The helm command (in the QuickStart guide) installs the custom resources into th
 ```console
 helm install -f custom-values.yaml --wait --namespace actions-runner-system \
   --create-namespace actions-runner-controller \
-  actions/actions-runner-controller
+  actions-runner-controller/actions-runner-controller
  ```
 
 ### Runner deployment

--- a/docs/authenticating-to-the-github-api.md
+++ b/docs/authenticating-to-the-github-api.md
@@ -160,7 +160,7 @@ Set the Helm chart values as follows:
 
 ```shell
 $ CA_BUNDLE=$(cat path/to/ca.pem | base64)
-$ helm upgrade --install actions/actions-runner-controller \
+$ helm upgrade --install actions-runner-controller/actions-runner-controller \
   certManagerEnabled=false \
   admissionWebHooks.caBundle=${CA_BUNDLE}
 ```
@@ -170,7 +170,7 @@ $ helm upgrade --install actions/actions-runner-controller \
 Set the Helm chart values as follows:
 
 ```shell
-$ helm upgrade --install actions/actions-runner-controller \
+$ helm upgrade --install actions-runner-controller/actions-runner-controller \
   certManagerEnabled=false
 ```
 

--- a/docs/automatically-scaling-runners.md
+++ b/docs/automatically-scaling-runners.md
@@ -260,7 +260,7 @@ _[see the values documentation for all configuration options](../charts/actions-
 
 ```console
 $ helm upgrade --install --namespace actions-runner-system --create-namespace \
-             --wait actions-runner-controller actions/actions-runner-controller \
+             --wait actions-runner-controller actions-runner-controller/actions-runner-controller \
              --set "githubWebhookServer.enabled=true,service.type=NodePort,githubWebhookServer.ports[0].nodePort=33080"
 ```
 
@@ -282,7 +282,7 @@ If you plan to expose ARC via Ingress, you might not be required to make it a `N
 
 ```console
 $ helm upgrade --install --namespace actions-runner-system --create-namespace \
-             --wait actions-runner-controller actions/actions-runner-controller \
+             --wait actions-runner-controller actions-runner-controller/actions-runner-controller \
              --set "githubWebhookServer.enabled=true"
 ```
 


### PR DESCRIPTION
Currently, some helm command examples do not work due to inconsistency between the repository name specified in the helm-repo-add and helm-upgrade commands.

`installing-arc.md` and `quickstard.md` use `actions-runner-controller` as the repo name:

```
helm repo add actions-runner-controller https://actions-runner-controller.github.io/actions-runner-controller
```

while some helm upgrade commands refers to the repo name as `actions`.

This fixes helm-upgrade command examples so that they refer to `actions-runner-controller`.

Note that we've been using `actions-runner-controller` since before the repo transfer and I assume many folks are still referring to the chart repo name as `actions-runner-controller` in their local and CI helm installation. Probably that justifies fixing helm-upgrade examples rather than fixing helm-repo-add to use `actions`.