### PR TITLE
fix: case-insensitive webhook label matching

### DIFF
--- a/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook.go
@@ -609,7 +609,7 @@ HRA:
 				// TODO labels related to OS and architecture needs to be explicitly declared or the current implementation will not be able to find them.
 
 				for _, l2 := range rs.Spec.Labels {
-					if strings.ToLower(l) == strings.ToLower(l2) {
+					if strings.EqualFold(l, l2) {
 						matched = true
 						break
 					}
@@ -640,7 +640,7 @@ HRA:
 				// TODO labels related to OS and architecture needs to be explicitly declared or the current implementation will not be able to find them.
 
 				for _, l2 := range rd.Spec.Template.Spec.Labels {
-					if strings.ToLower(l) == strings.ToLower(l2) {
+					if strings.EqualFold(l, l2) {
 						matched = true
 						break
 					}

--- a/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -608,7 +609,7 @@ HRA:
 				// TODO labels related to OS and architecture needs to be explicitly declared or the current implementation will not be able to find them.
 
 				for _, l2 := range rs.Spec.Labels {
-					if l == l2 {
+					if strings.ToLower(l) == strings.ToLower(l2) {
 						matched = true
 						break
 					}
@@ -639,7 +640,7 @@ HRA:
 				// TODO labels related to OS and architecture needs to be explicitly declared or the current implementation will not be able to find them.
 
 				for _, l2 := range rd.Spec.Template.Spec.Labels {
-					if l == l2 {
+					if strings.ToLower(l) == strings.ToLower(l2) {
 						matched = true
 						break
 					}


### PR DESCRIPTION
reopen #1500

Github definitely uses case-insensitive label matching. I didn't find any info in docs, but I tested it.

I had two workflows, the one with `[self-hosted,linux]`, and the second one with `[self-hosted,Linux]` labels.
I also had configured ARC with webhook scaling and `[self-hosted,Linux]` labels. 
The first workflow didn't scale up runners, but GitHub scheduled it to runner (after second workflow).