### PR TITLE
Allow custom graceful termination and loadBalancerSourceRanges for the githubwebhook service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN --mount=target=. \
   go build -trimpath -ldflags="-s -w -X 'github.com/actions/actions-runner-controller/build.Version=${VERSION}'" -o /out/manager main.go && \
   go build -trimpath -ldflags="-s -w" -o /out/github-runnerscaleset-listener ./cmd/githubrunnerscalesetlistener && \
   go build -trimpath -ldflags="-s -w" -o /out/github-webhook-server ./cmd/githubwebhookserver && \
-  go build -trimpath -ldflags="-s -w" -o /out/actions-metrics-server ./cmd/actionsmetricsserver
+  go build -trimpath -ldflags="-s -w" -o /out/actions-metrics-server ./cmd/actionsmetricsserver && \
+  go build -trimpath -ldflags="-s -w" -o /out/sleep ./cmd/sleep
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -51,6 +52,7 @@ COPY --from=builder /out/manager .
 COPY --from=builder /out/github-webhook-server .
 COPY --from=builder /out/actions-metrics-server .
 COPY --from=builder /out/github-runnerscaleset-listener .
+COPY --from=builder /out/sleep .
 
 USER 65532:65532
 

--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -56,6 +56,12 @@ spec:
         {{- end }}
         command:
         - "/github-webhook-server"
+        {{- if .Values.githubWebhookServer.lifecycle }}
+        {{- with .Values.githubWebhookServer.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
         env:
         - name: GITHUB_WEBHOOK_SECRET_TOKEN
           valueFrom:
@@ -148,7 +154,7 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
       {{- end }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.githubWebhookServer.terminationGracePeriodSeconds }}
       {{- with .Values.githubWebhookServer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/actions-runner-controller/templates/githubwebhook.service.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.service.yaml
@@ -23,4 +23,10 @@ spec:
     {{- end }}
   selector:
     {{- include "actions-runner-controller-github-webhook-server.selectorLabels" . | nindent 4 }}
+  {{- if .Values.githubWebhookServer.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $ip := .Values.githubWebhookServer.service.loadBalancerSourceRanges }}
+    - {{ $ip -}}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -276,6 +276,8 @@ githubWebhookServer:
     # minAvailable: 1
     # maxUnavailable: 3
   # queueLimit: 100
+  terminationGracePeriodSeconds: 10
+  lifecycle: {}
 
 actionsMetrics:
   serviceAnnotations: {}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -240,6 +240,7 @@ githubWebhookServer:
         protocol: TCP
         name: http
         #nodePort: someFixedPortForUseWithTerraformCdkCfnEtc
+    loadBalancerSourceRanges: []
   ingress:
     enabled: false
     ingressClassName: ""

--- a/cmd/sleep/main.go
+++ b/cmd/sleep/main.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The actions-runner-controller authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+var Seconds int
+
+func main() {
+	fmt.Printf("sleeping for %d seconds\n", Seconds)
+	time.Sleep(time.Duration(Seconds) * time.Second)
+	fmt.Println("done sleeping")
+}
+
+func init() {
+	flag.IntVar(&Seconds, "seconds", 60, "Number of seconds to sleep")
+	flag.Parse()
+}


### PR DESCRIPTION
## Changes
- Adds a sleep command as part of the image. This will allow us to do graceful shutdown with lifecycle preStop hook.
- Updates the githubwebhook service to allow us to define `loadBalancerSourceRanges`.  This will allow for restriction access to the service when using and NLB in front of it. [1]
- Updates the githubwebhook deployment to allow us to customise the `terminationGracePeriodSeconds` of the pod. It keeps the default behaviour of 10 seconds.
- Updates the githubwebhook deployment to allow us to specify a lifecycle hook as part of the `github-webhook-server` container.

Ref:
[1] https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support
