### PR TITLE
Add enterprise, organization, repository, and runner labels to runnerdeployments print columns

### DIFF
--- a/apis/actions.summerwind.net/v1alpha1/runnerdeployment_types.go
+++ b/apis/actions.summerwind.net/v1alpha1/runnerdeployment_types.go
@@ -77,6 +77,11 @@ type RunnerDeploymentStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=rdeploy
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".spec.template.spec.enterprise",name=Enterprise,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.template.spec.organization",name=Organization,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.template.spec.repository",name=Repository,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.template.spec.group",name=Group,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.template.spec.labels",name=Labels,type=string
 // +kubebuilder:printcolumn:JSONPath=".spec.replicas",name=Desired,type=number
 // +kubebuilder:printcolumn:JSONPath=".status.replicas",name=Current,type=number
 // +kubebuilder:printcolumn:JSONPath=".status.updatedReplicas",name=Up-To-Date,type=number

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -32,6 +32,10 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+        - jsonPath: .spec.template.spec.labels
+          name: Labels
+          type: string
+          priority: 1
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -17,6 +17,21 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.enterprise
+          name: Enterprise
+          type: string
+        - jsonPath: .spec.template.spec.organization
+          name: Organization
+          type: string
+        - jsonPath: .spec.template.spec.repository
+          name: Repository
+          type: string
+        - jsonPath: .spec.template.spec.group
+          name: Group
+          type: string
+        - jsonPath: .spec.template.spec.labels
+          name: Labels
+          type: string
         - jsonPath: .spec.replicas
           name: Desired
           type: number
@@ -32,10 +47,6 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-        - jsonPath: .spec.template.spec.labels
-          name: Labels
-          type: string
-          priority: 1
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -17,6 +17,21 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.enterprise
+          name: Enterprise
+          type: string
+        - jsonPath: .spec.template.spec.organization
+          name: Organization
+          type: string
+        - jsonPath: .spec.template.spec.repository
+          name: Repository
+          type: string
+        - jsonPath: .spec.template.spec.group
+          name: Group
+          type: string
+        - jsonPath: .spec.template.spec.labels
+          name: Labels
+          type: string
         - jsonPath: .spec.replicas
           name: Desired
           type: number


### PR DESCRIPTION
Using `kubectl get runnerdeployments -o wide` will now show the labels associated with the runners.

See https://github.com/actions/actions-runner-controller/issues/2308