### PR TITLE
Bump arc-2 chart version and prepare 0.2.0 release

### DIFF
--- a/charts/actions-runner-controller-2/Chart.yaml
+++ b/charts/actions-runner-controller-2/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "preview"
+appVersion: "0.2.0"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/actions-runner-controller-2/tests/template_test.go
+++ b/charts/actions-runner-controller-2/tests/template_test.go
@@ -218,10 +218,10 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 
 	assert.Equal(t, namespaceName, deployment.Namespace)
 	assert.Equal(t, "test-arc-actions-runner-controller-2", deployment.Name)
-	assert.Equal(t, "actions-runner-controller-2-0.1.0", deployment.Labels["helm.sh/chart"])
+	assert.Equal(t, "actions-runner-controller-2-0.2.0", deployment.Labels["helm.sh/chart"])
 	assert.Equal(t, "actions-runner-controller-2", deployment.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "test-arc", deployment.Labels["app.kubernetes.io/instance"])
-	assert.Equal(t, "preview", deployment.Labels["app.kubernetes.io/version"])
+	assert.Equal(t, "0.2.0", deployment.Labels["app.kubernetes.io/version"])
 	assert.Equal(t, "Helm", deployment.Labels["app.kubernetes.io/managed-by"])
 
 	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
@@ -315,10 +315,10 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 
 	assert.Equal(t, namespaceName, deployment.Namespace)
 	assert.Equal(t, "actions-runner-controller-2-fullname-override", deployment.Name)
-	assert.Equal(t, "actions-runner-controller-2-0.1.0", deployment.Labels["helm.sh/chart"])
+	assert.Equal(t, "actions-runner-controller-2-0.2.0", deployment.Labels["helm.sh/chart"])
 	assert.Equal(t, "actions-runner-controller-2-override", deployment.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "test-arc", deployment.Labels["app.kubernetes.io/instance"])
-	assert.Equal(t, "preview", deployment.Labels["app.kubernetes.io/version"])
+	assert.Equal(t, "0.2.0", deployment.Labels["app.kubernetes.io/version"])
 	assert.Equal(t, "Helm", deployment.Labels["app.kubernetes.io/managed-by"])
 	assert.Equal(t, "bar", deployment.Labels["foo"])
 	assert.Equal(t, "actions", deployment.Labels["github"])

--- a/charts/actions-runner-controller-2/tests/template_test.go
+++ b/charts/actions-runner-controller-2/tests/template_test.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -208,7 +208,7 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 	helmChartPath, err := filepath.Abs("../../actions-runner-controller-2")
 	require.NoError(t, err)
 
-	chartContent, err := ioutil.ReadFile(filepath.Join(helmChartPath, "Chart.yaml"))
+	chartContent, err := os.ReadFile(filepath.Join(helmChartPath, "Chart.yaml"))
 	require.NoError(t, err)
 
 	chart := new(Chart)
@@ -294,7 +294,7 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 	helmChartPath, err := filepath.Abs("../../actions-runner-controller-2")
 	require.NoError(t, err)
 
-	chartContent, err := ioutil.ReadFile(filepath.Join(helmChartPath, "Chart.yaml"))
+	chartContent, err := os.ReadFile(filepath.Join(helmChartPath, "Chart.yaml"))
 	require.NoError(t, err)
 
 	chart := new(Chart)

--- a/charts/actions-runner-controller-2/tests/template_test.go
+++ b/charts/actions-runner-controller-2/tests/template_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,10 +11,16 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
+
+type Chart struct {
+	Version    string `yaml:"version"`
+	AppVersion string `yaml:"appVersion"`
+}
 
 func TestTemplate_CreateServiceAccount(t *testing.T) {
 	t.Parallel()
@@ -201,6 +208,13 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 	helmChartPath, err := filepath.Abs("../../actions-runner-controller-2")
 	require.NoError(t, err)
 
+	chartContent, err := ioutil.ReadFile(filepath.Join(helmChartPath, "Chart.yaml"))
+	require.NoError(t, err)
+
+	chart := new(Chart)
+	err = yaml.Unmarshal(chartContent, chart)
+	require.NoError(t, err)
+
 	releaseName := "test-arc"
 	namespaceName := "test-" + strings.ToLower(random.UniqueId())
 
@@ -218,10 +232,10 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 
 	assert.Equal(t, namespaceName, deployment.Namespace)
 	assert.Equal(t, "test-arc-actions-runner-controller-2", deployment.Name)
-	assert.Equal(t, "actions-runner-controller-2-0.2.0", deployment.Labels["helm.sh/chart"])
+	assert.Equal(t, "actions-runner-controller-2-"+chart.Version, deployment.Labels["helm.sh/chart"])
 	assert.Equal(t, "actions-runner-controller-2", deployment.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "test-arc", deployment.Labels["app.kubernetes.io/instance"])
-	assert.Equal(t, "0.2.0", deployment.Labels["app.kubernetes.io/version"])
+	assert.Equal(t, chart.AppVersion, deployment.Labels["app.kubernetes.io/version"])
 	assert.Equal(t, "Helm", deployment.Labels["app.kubernetes.io/managed-by"])
 
 	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
@@ -280,6 +294,13 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 	helmChartPath, err := filepath.Abs("../../actions-runner-controller-2")
 	require.NoError(t, err)
 
+	chartContent, err := ioutil.ReadFile(filepath.Join(helmChartPath, "Chart.yaml"))
+	require.NoError(t, err)
+
+	chart := new(Chart)
+	err = yaml.Unmarshal(chartContent, chart)
+	require.NoError(t, err)
+
 	releaseName := "test-arc"
 	namespaceName := "test-" + strings.ToLower(random.UniqueId())
 
@@ -315,10 +336,10 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 
 	assert.Equal(t, namespaceName, deployment.Namespace)
 	assert.Equal(t, "actions-runner-controller-2-fullname-override", deployment.Name)
-	assert.Equal(t, "actions-runner-controller-2-0.2.0", deployment.Labels["helm.sh/chart"])
+	assert.Equal(t, "actions-runner-controller-2-"+chart.Version, deployment.Labels["helm.sh/chart"])
 	assert.Equal(t, "actions-runner-controller-2-override", deployment.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "test-arc", deployment.Labels["app.kubernetes.io/instance"])
-	assert.Equal(t, "0.2.0", deployment.Labels["app.kubernetes.io/version"])
+	assert.Equal(t, chart.AppVersion, deployment.Labels["app.kubernetes.io/version"])
 	assert.Equal(t, "Helm", deployment.Labels["app.kubernetes.io/managed-by"])
 	assert.Equal(t, "bar", deployment.Labels["foo"])
 	assert.Equal(t, "actions", deployment.Labels["github"])

--- a/charts/auto-scaling-runner-set/Chart.yaml
+++ b/charts/auto-scaling-runner-set/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.0"
 
 home: https://github.com/actions/dev-arc
 

--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,10 @@ require (
 	github.com/teambition/rrule-go v1.8.0
 	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/net v0.6.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	gomodules.xyz/jsonpatch/v2 v2.2.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
@@ -84,7 +86,6 @@ require (
 	github.com/urfave/cli v1.22.2 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/net v0.6.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
@@ -92,7 +93,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/component-base v0.26.0 // indirect


### PR DESCRIPTION
Notable Changes (excluding test/doc):
- #2216
- #2222 
- #2219 
- #2223
- #2234
- #2237 
- #2241 
- #2239
- #2257 
- #2260
- #2262
- #2255
- #2291
- #2292
- #2252 
- #2303 
- #2286 