### PR TITLE
Refactor main.go and introduce make run-scaleset to be able to run manager locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ run: generate fmt vet manifests
 
 run-scaleset: generate fmt vet
 	CONTROLLER_MANAGER_POD_NAMESPACE=default \
-	SCALE_SET_LISTENER_IMAGE="${DOCKER_IMAGE_NAME}:${VERSION}" \
+	CONTROLLER_MANAGER_CONTAINER_IMAGE="${DOCKER_IMAGE_NAME}:${VERSION}" \
 	go run ./main.go --auto-scaling-runner-set-only
 
 # Install CRDs into a cluster
@@ -108,7 +108,7 @@ uninstall: manifests
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
 	cd config/manager && kustomize edit set image controller=${DOCKER_IMAGE_NAME}:${VERSION}
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config/default | kubectl apply --server-side -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: manifests-gen-crds chart-crds

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ run: generate fmt vet manifests
 
 run-scaleset: generate fmt vet
 	CONTROLLER_MANAGER_POD_NAMESPACE=default \
-	SCALE_SET_LISTENER_IMAGE="${$DOCKER_USER}/actions-runner-controller:dev" \
+	SCALE_SET_LISTENER_IMAGE="${DOCKER_IMAGE_NAME}:${VERSION}" \
 	go run ./main.go --auto-scaling-runner-set-only
 
 # Install CRDs into a cluster

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,14 @@ manager: generate fmt vet
 run: generate fmt vet manifests
 	go run ./main.go
 
+run-scaleset: generate fmt vet
+	CONTROLLER_MANAGER_POD_NAMESPACE=default \
+	SCALE_SET_LISTENER_IMAGE="${$DOCKER_USER}/actions-runner-controller:dev" \
+	go run ./main.go --auto-scaling-runner-set-only
+
 # Install CRDs into a cluster
 install: manifests
-	kustomize build config/crd | kubectl apply -f -
+	kustomize build config/crd | kubectl apply --server-side -f -
 
 # Uninstall CRDs from a cluster
 uninstall: manifests

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -54,10 +54,8 @@ spec:
         command:
         - "/manager"
         env:
-        - name: CONTROLLER_MANAGER_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+        - name: CONTROLLER_MANAGER_CONTAINER_IMAGE
+          value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         - name: CONTROLLER_MANAGER_POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -261,9 +261,11 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 	assert.Nil(t, deployment.Spec.Template.Spec.Affinity)
 	assert.Len(t, deployment.Spec.Template.Spec.Tolerations, 0)
 
+	managerImage := "ghcr.io/actions/gha-runner-scale-set-controller:dev"
+
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, "manager", deployment.Spec.Template.Spec.Containers[0].Name)
-	assert.Equal(t, "ghcr.io/actions/gha-runner-scale-set-controller:dev", deployment.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, managerImage, deployment.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Command, 1)
@@ -274,8 +276,8 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 	assert.Equal(t, "--log-level=debug", deployment.Spec.Template.Spec.Containers[0].Args[1])
 
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
-	assert.Equal(t, "CONTROLLER_MANAGER_POD_NAME", deployment.Spec.Template.Spec.Containers[0].Env[0].Name)
-	assert.Equal(t, "metadata.name", deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "CONTROLLER_MANAGER_CONTAINER_IMAGE", deployment.Spec.Template.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, managerImage, deployment.Spec.Template.Spec.Containers[0].Env[0].Value)
 
 	assert.Equal(t, "CONTROLLER_MANAGER_POD_NAMESPACE", deployment.Spec.Template.Spec.Containers[0].Env[1].Name)
 	assert.Equal(t, "metadata.namespace", deployment.Spec.Template.Spec.Containers[0].Env[1].ValueFrom.FieldRef.FieldPath)
@@ -375,9 +377,11 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 	assert.Len(t, deployment.Spec.Template.Spec.Tolerations, 1)
 	assert.Equal(t, "foo", deployment.Spec.Template.Spec.Tolerations[0].Key)
 
+	managerImage := "ghcr.io/actions/gha-runner-scale-set-controller:dev"
+
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, "manager", deployment.Spec.Template.Spec.Containers[0].Name)
-	assert.Equal(t, "ghcr.io/actions/gha-runner-scale-set-controller:dev", deployment.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, managerImage, deployment.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Command, 1)
@@ -389,8 +393,8 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 	assert.Equal(t, "--log-level=debug", deployment.Spec.Template.Spec.Containers[0].Args[2])
 
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
-	assert.Equal(t, "CONTROLLER_MANAGER_POD_NAME", deployment.Spec.Template.Spec.Containers[0].Env[0].Name)
-	assert.Equal(t, "metadata.name", deployment.Spec.Template.Spec.Containers[0].Env[0].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "CONTROLLER_MANAGER_CONTAINER_IMAGE", deployment.Spec.Template.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, managerImage, deployment.Spec.Template.Spec.Containers[0].Env[0].Value)
 
 	assert.Equal(t, "CONTROLLER_MANAGER_POD_NAMESPACE", deployment.Spec.Template.Spec.Containers[0].Env[1].Name)
 	assert.Equal(t, "metadata.namespace", deployment.Spec.Template.Spec.Containers[0].Env[1].ValueFrom.FieldRef.FieldPath)

--- a/config/manager/env-replacement.yaml
+++ b/config/manager/env-replacement.yaml
@@ -1,0 +1,10 @@
+source:
+  kind: Deployment
+  name: controller-manager
+  fieldPath: spec.template.spec.containers.[name=manager].image
+targets:
+- select:
+    kind: Deployment
+    name: controller-manager
+  fieldPaths:
+  - spec.template.spec.containers.[name=manager].env.[name=CONTROLLER_MANAGER_CONTAINER_IMAGE].value

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,3 +6,6 @@ images:
 - name: controller
   newName: summerwind/actions-runner-controller
   newTag: dev
+
+replacements:
+- path: env-replacement.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,10 +50,8 @@ spec:
               optional: true
         - name: GITHUB_APP_PRIVATE_KEY
           value: /etc/actions-runner-controller/github_app_private_key
-        - name: CONTROLLER_MANAGER_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+        - name: CONTROLLER_MANAGER_CONTAINER_IMAGE
+          value: CONTROLLER_MANAGER_CONTAINER_IMAGE
         - name: CONTROLLER_MANAGER_POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/main.go
+++ b/main.go
@@ -308,9 +308,6 @@ func main() {
 				log.Error(err, "unable to create webhook", "webhook", "RunnerReplicaSet")
 				os.Exit(1)
 			}
-		}
-
-		if !disableAdmissionWebhook {
 			injector := &actionssummerwindnet.PodRunnerTokenInjector{
 				Client:       mgr.GetClient(),
 				GitHubClient: multiClient,


### PR DESCRIPTION
This change should not affect how the application operates right now.

The intention of this change is to make it easier to run the controller locally, without spinning up the cluster, so it is easier and faster to debug.