### PR TITLE
Change e2e config url

### DIFF
--- a/.github/actions/e2e-arc-test/action.yaml
+++ b/.github/actions/e2e-arc-test/action.yaml
@@ -5,6 +5,9 @@ inputs:
   github-token:
     description: 'JWT generated with Github App inputs'
     required: true
+  config-url:
+    description: "Url of repo or org where runners will be installed"
+    required: true
 
 runs:
   using: "composite"
@@ -22,7 +25,7 @@ runs:
           helm install "arc-runner-${{ env.DATE_TIME }}" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/actions-runner-controller/arc_e2e_test_dummy" \
+          --set githubConfigUrl="${{ inputs.config-url }}"\
           --set githubConfigSecret.github_token="${{ inputs.github-token }}" \
           ./charts/auto-scaling-runner-set \
           --debug

--- a/.github/actions/e2e-arc-test/action.yaml
+++ b/.github/actions/e2e-arc-test/action.yaml
@@ -22,7 +22,7 @@ runs:
           helm install "arc-runner-${{ env.DATE_TIME }}" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/actions/actions-runner-controller" \
+          --set githubConfigUrl="https://github.com/actions-runner-controller/arc_e2e_test_dummy" \
           --set githubConfigSecret.github_token="${{ inputs.github-token }}" \
           ./charts/auto-scaling-runner-set \
           --debug

--- a/.github/actions/e2e-arc-test/action.yaml
+++ b/.github/actions/e2e-arc-test/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: 'JWT generated with Github App inputs'
     required: true
   config-url:
-    description: "Url of repo or org where runners will be installed"
+    description: "URL of the repo, org or enterprise where the runner scale sets will be registered"
     required: true
 
 runs:

--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -25,3 +25,4 @@ jobs:
       - uses: ./.github/actions/e2e-arc-test
         with:
           github-token: ${{ steps.get_workflow_token.outputs.token }}
+          config-url: "https://github.com/actions-runner-controller/arc_e2e_test_dummy"


### PR DESCRIPTION
Since we are using the old actions-runner-controller org Github App for JWT generation, the config url for arc runner registration should be a repo in the old org.
The custom action was also built with the scope of being reusable, so the url will be passed via the workflow that calls it, to make this customizable too. 