### PR TITLE
Split listener pod label to avoid long names issue

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -48,10 +48,6 @@ const (
 	autoscalingRunnerSetFinalizerName = "autoscalingrunnerset.actions.github.com/finalizer"
 	runnerScaleSetIdKey               = "runner-scale-set-id"
 	runnerScaleSetRunnerGroupNameKey  = "runner-scale-set-runner-group-name"
-
-	// scaleSetListenerLabel is the key of pod.meta.labels to label
-	// that the pod is a listener application
-	scaleSetListenerLabel = "runner-scale-set-listener"
 )
 
 // AutoscalingRunnerSetReconciler reconciles a AutoscalingRunnerSet object

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -44,7 +44,6 @@ const (
 	// TODO: Replace with shared image.
 	autoscalingRunnerSetOwnerKey      = ".metadata.controller"
 	LabelKeyRunnerSpecHash            = "runner-spec-hash"
-	LabelKeyAutoScaleRunnerSetName    = "auto-scale-runner-set-name"
 	autoscalingRunnerSetFinalizerName = "autoscalingrunnerset.actions.github.com/finalizer"
 	runnerScaleSetIdKey               = "runner-scale-set-id"
 	runnerScaleSetRunnerGroupNameKey  = "runner-scale-set-runner-group-name"

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -14,8 +14,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// secret constants
 const (
 	jitTokenKey = "jitToken"
+)
+
+// labels applied to resources
+const (
+	LabelKeyAutoScaleRunnerSetName      = "auto-scale-runner-set-name"
+	LabelKeyAutoScaleRunnerSetNamespace = "auto-scale-runner-set-namespace"
 )
 
 type resourceBuilder struct{}
@@ -131,8 +138,8 @@ func (b *resourceBuilder) newScaleSetListenerPod(autoscalingListener *v1alpha1.A
 			Name:      autoscalingListener.Name,
 			Namespace: autoscalingListener.Namespace,
 			Labels: map[string]string{
-				"auto-scaling-runner-set-namespace": autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				"auto-scaling-runner-set-name":      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				LabelKeyAutoScaleRunnerSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyAutoScaleRunnerSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 			},
 		},
 		Spec: podSpec,
@@ -180,8 +187,8 @@ func (b *resourceBuilder) newScaleSetListenerServiceAccount(autoscalingListener 
 			Name:      scaleSetListenerServiceAccountName(autoscalingListener),
 			Namespace: autoscalingListener.Namespace,
 			Labels: map[string]string{
-				"auto-scaling-runner-set-namespace": autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				"auto-scaling-runner-set-name":      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				LabelKeyAutoScaleRunnerSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyAutoScaleRunnerSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 			},
 		},
 	}
@@ -195,8 +202,8 @@ func (b *resourceBuilder) newScaleSetListenerRole(autoscalingListener *v1alpha1.
 			Name:      scaleSetListenerRoleName(autoscalingListener),
 			Namespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
 			Labels: map[string]string{
-				"auto-scaling-runner-set-namespace": autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				"auto-scaling-runner-set-name":      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				LabelKeyAutoScaleRunnerSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyAutoScaleRunnerSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 				"auto-scaling-listener-namespace":   autoscalingListener.Namespace,
 				"auto-scaling-listener-name":        autoscalingListener.Name,
 				"role-policy-rules-hash":            rulesHash,
@@ -229,8 +236,8 @@ func (b *resourceBuilder) newScaleSetListenerRoleBinding(autoscalingListener *v1
 			Name:      scaleSetListenerRoleName(autoscalingListener),
 			Namespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
 			Labels: map[string]string{
-				"auto-scaling-runner-set-namespace": autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				"auto-scaling-runner-set-name":      autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyAutoScaleRunnerSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyAutoScaleRunnerSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 				"auto-scaling-listener-namespace":   autoscalingListener.Namespace,
 				"auto-scaling-listener-name":        autoscalingListener.Name,
 				"role-binding-role-ref-hash":        roleRefHash,
@@ -252,8 +259,8 @@ func (b *resourceBuilder) newScaleSetListenerSecretMirror(autoscalingListener *v
 			Name:      scaleSetListenerSecretMirrorName(autoscalingListener),
 			Namespace: autoscalingListener.Namespace,
 			Labels: map[string]string{
-				"auto-scaling-runner-set-namespace": autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				"auto-scaling-runner-set-name":      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				LabelKeyAutoScaleRunnerSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyAutoScaleRunnerSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 				"secret-data-hash":                  dataHash,
 			},
 		},
@@ -283,8 +290,8 @@ func (b *resourceBuilder) newAutoScalingListener(autoscalingRunnerSet *v1alpha1.
 			Name:      scaleSetListenerName(autoscalingRunnerSet),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"auto-scaling-runner-set-namespace": autoscalingRunnerSet.Namespace,
-				"auto-scaling-runner-set-name":      autoscalingRunnerSet.Name,
+				LabelKeyAutoScaleRunnerSetNamespace: autoscalingRunnerSet.Namespace,
+				LabelKeyAutoScaleRunnerSetName:      autoscalingRunnerSet.Name,
 				LabelKeyRunnerSpecHash:              autoscalingRunnerSet.ListenerSpecHash(),
 			},
 		},

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -21,9 +21,6 @@ const (
 type resourceBuilder struct{}
 
 func (b *resourceBuilder) newScaleSetListenerPod(autoscalingListener *v1alpha1.AutoscalingListener, serviceAccount *corev1.ServiceAccount, secret *corev1.Secret, envs ...corev1.EnvVar) *corev1.Pod {
-	newLabels := map[string]string{}
-	newLabels[scaleSetListenerLabel] = fmt.Sprintf("%v-%v", autoscalingListener.Spec.AutoscalingRunnerSetNamespace, autoscalingListener.Spec.AutoscalingRunnerSetName)
-
 	listenerEnv := []corev1.EnvVar{
 		{
 			Name:  "GITHUB_CONFIGURE_URL",
@@ -133,7 +130,10 @@ func (b *resourceBuilder) newScaleSetListenerPod(autoscalingListener *v1alpha1.A
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      autoscalingListener.Name,
 			Namespace: autoscalingListener.Namespace,
-			Labels:    newLabels,
+			Labels: map[string]string{
+				"auto-scaling-runner-set-namespace": autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				"auto-scaling-runner-set-name":      autoscalingListener.Spec.AutoscalingRunnerSetName,
+			},
 		},
 		Spec: podSpec,
 	}

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -21,8 +21,8 @@ const (
 
 // labels applied to resources
 const (
-	LabelKeyAutoScaleRunnerSetName      = "auto-scale-runner-set-name"
-	LabelKeyAutoScaleRunnerSetNamespace = "auto-scale-runner-set-namespace"
+	LabelKeyAutoScaleRunnerSetName      = "auto-scaling-runner-set-name"
+	LabelKeyAutoScaleRunnerSetNamespace = "auto-scaling-runner-set-namespace"
 )
 
 type resourceBuilder struct{}

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -50,7 +50,7 @@ https://user-images.githubusercontent.com/568794/212668313-8946ddc5-60c1-461f-a7
 
     ```bash
     # Using a Personal Access Token (PAT)
-    INSTALLATION_NAME="arc-runner-set" 
+    INSTALLATION_NAME="arc-runner-set"
     NAMESPACE="arc-runners"
     GITHUB_CONFIG_URL="https://github.com/<your_enterprise/org/repo>"
     GITHUB_PAT="<PAT>"
@@ -64,9 +64,9 @@ https://user-images.githubusercontent.com/568794/212668313-8946ddc5-60c1-461f-a7
 
     ```bash
     # Using a GitHub App
-    INSTALLATION_NAME="arc-runner-set" 
+    INSTALLATION_NAME="arc-runner-set"
     NAMESPACE="arc-runners"
-    GITHUB_CONFIG_URL="https://github.com/<your_enterprise/org/repo>" 
+    GITHUB_CONFIG_URL="https://github.com/<your_enterprise/org/repo>"
     GITHUB_APP_ID="<GITHUB_APP_ID>"
     GITHUB_APP_INSTALLATION_ID="<GITHUB_APP_INSTALLATION_ID>"
     GITHUB_APP_PRIVATE_KEY="<GITHUB_APP_PRIVATE_KEY>"
@@ -86,8 +86,8 @@ https://user-images.githubusercontent.com/568794/212668313-8946ddc5-60c1-461f-a7
     $ helm list -n "${NAMESPACE}"
 
     NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                    APP VERSION
-    arc             arc-systems     1               2023-01-18 10:03:36.610534934 +0000 UTC deployed        gha-runner-scale-set-controller-0.2.0        preview    
-    arc-runner-set  arc-systems     1               2023-01-18 10:20:14.795285645 +0000 UTC deployed        gha-runner-scale-set-0.2.0            0.2.0 
+    arc             arc-systems     1               2023-01-18 10:03:36.610534934 +0000 UTC deployed        gha-runner-scale-set-controller-0.2.0        preview
+    arc-runner-set  arc-systems     1               2023-01-18 10:20:14.795285645 +0000 UTC deployed        gha-runner-scale-set-0.2.0            0.2.0
     ```
 
     ```bash
@@ -135,8 +135,9 @@ You can check the logs of the controller pod using the following command:
 $ kubectl logs -n "${NAMESPACE}" -l app.kubernetes.io/name=gha-runner-scale-set-controller
 
 # Runner set listener logs
-kubectl logs -n "${NAMESPACE}" -l runner-scale-set-listener=arc-systems-arc-runner-set
+kubectl logs -n "${NAMESPACE}" -l auto-scaling-runner-set-namespace=arc-systems -l auto-scaling-runner-set-name=arc-runner-set
 ```
+
 
 ### If you installed the autoscaling runner set, but the listener pod is not created
 


### PR DESCRIPTION
All other resources are having labels split on namespace and the name.

Split for the listener pod will allow for the longer autoscaling runner set `NamespacedName` combination (Label restriction is 63 characters, so right now, the combination of the namespace and the name must be < 63)