### PR TITLE
Upgrading & pinning action versions

### DIFF
--- a/.github/workflows/publish-runner-scale-set.yaml
+++ b/.github/workflows/publish-runner-scale-set.yaml
@@ -129,7 +129,8 @@ jobs:
           echo "repository_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT 
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3.3
+        # Using https://github.com/Azure/setup-helm/releases/tag/v3.5
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
         with:
           version: ${{ env.HELM_VERSION }}
 
@@ -176,7 +177,8 @@ jobs:
           echo "repository_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT 
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3.3
+        # Using https://github.com/Azure/setup-helm/releases/tag/v3.5
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
         with:
           version: ${{ env.HELM_VERSION }}
 


### PR DESCRIPTION
Upgrading setup-helm action to remove the set-output deprecation notice & pinning the version for added security.