### PR TITLE
Matrix jobs workflow path update

### DIFF
--- a/test_e2e_arc/arc_jobs_test.go
+++ b/test_e2e_arc/arc_jobs_test.go
@@ -95,8 +95,8 @@ func TestARCJobs(t *testing.T) {
 		dateTime := os.Getenv("DATE_TIME")
 		// We are triggering manually a workflow that already exists in the repo.
 		// This workflow is expected to spin up a number of runner pods matching the runners value set in podCountsByType.
-		url := "https://api.github.com/repos/actions/actions-runner-controller/actions/workflows/e2e-test-dispatch-workflow.yaml/dispatches"
-		jsonStr := []byte(fmt.Sprintf(`{"ref":"master", "inputs":{"date_time":"%s"}}`, dateTime))
+		url := "https://api.github.com/repos/actions-runner-controller/arc_e2e_test_dummy/actions/workflows/e2e-test-dispatch-workflow.yaml/dispatches"
+		jsonStr := []byte(fmt.Sprintf(`{"ref":"main", "inputs":{"date_time":"%s"}}`, dateTime))
 
 		req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 		if err != nil {


### PR DESCRIPTION
We will be triggering a workflow to test the auto scaling of the runners with ARC. This will use an access token for a Github App installed on the actions-runner-controller org, having access to the arc_e2e_test_dummy repo. The workflow we trigger should live in that repo.