### PR TITLE
Make CT test to install charts in the right order.

### DIFF
--- a/charts/.ci/ct-config.yaml
+++ b/charts/.ci/ct-config.yaml
@@ -1,6 +1,9 @@
 # This file defines the config for "ct" (chart tester) used by the helm linting GitHub workflow
-all: true
 lint-conf: charts/.ci/lint-config.yaml
 chart-repos:
   - jetstack=https://charts.jetstack.io
 check-version-increment: false # Disable checking that the chart version has been bumped
+charts:
+- charts/actions-runner-controller
+- charts/gha-runner-scale-set-controller
+- charts/gha-runner-scale-set


### PR DESCRIPTION
Due to the recent chart rename, the order of the chart installs during `ct install --config charts/.ci/ct-config.yaml` changed from:
```
actions-runner-controller => (version: "0.[22](https://github.com/actions/actions-runner-controller/actions/runs/4227858128/jobs/7342715259#step:12:23).0", path: "charts/actions-runner-controller")
actions-runner-controller-2 => (version: "0.1.0", path: "charts/actions-runner-controller-2")
auto-scaling-runner-set => (version: "0.1.0", path: "charts/auto-scaling-runner-set")
```
to
```
actions-runner-controller => (version: "0.[22](https://github.com/actions/actions-runner-controller/actions/runs/4307597864/jobs/7512857307#step:12:23).0", path: "charts/actions-runner-controller")
gha-runner-scale-set => (version: "0.2.0", path: "charts/gha-runner-scale-set")
gha-runner-scale-set-controller => (version: "0.2.0", path: "charts/gha-runner-scale-set-controller")
```

Since `gha-runner-scale-set(aka auto-scaling-runner-set)` depends on `gha-runner-scale-set-controller(aka actions-runner-controller-2)`, the order change breaks the test.

I am updating the `ct-config.yaml` file to declare the orders we want. 🙇 
