### PR TITLE
Simplify the setup of controller tests

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +35,7 @@ const (
 
 var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 	var ctx context.Context
-	var mgr manager.Manager
+	var mgr ctrl.Manager
 	var autoscalingNS *corev1.Namespace
 	var autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet
 	var configSecret *corev1.Secret
@@ -404,7 +403,7 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 var _ = Describe("Test AutoscalingController creation failures", func() {
 	Context("When autoscaling runner set creation fails on the client", func() {
 		var ctx context.Context
-		var mgr manager.Manager
+		var mgr ctrl.Manager
 		var autoscalingNS *corev1.Namespace
 
 		BeforeEach(func() {

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -34,7 +34,7 @@ const (
 	autoscalingRunnerSetTestGitHubToken = "gh_token"
 )
 
-var _ = FDescribe("Test AutoScalingRunnerSet controller", func() {
+var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 	var ctx context.Context
 	var mgr manager.Manager
 	var autoscalingNS *corev1.Namespace
@@ -401,7 +401,7 @@ var _ = FDescribe("Test AutoScalingRunnerSet controller", func() {
 	})
 })
 
-var _ = FDescribe("Test AutoscalingController creation failures", func() {
+var _ = Describe("Test AutoscalingController creation failures", func() {
 	Context("When autoscaling runner set creation fails on the client", func() {
 		var ctx context.Context
 		var mgr manager.Manager
@@ -510,7 +510,7 @@ var _ = FDescribe("Test AutoscalingController creation failures", func() {
 	})
 })
 
-var _ = FDescribe("Test Client optional configuration", func() {
+var _ = Describe("Test Client optional configuration", func() {
 	Context("When specifying a proxy", func() {
 		var ctx context.Context
 		var mgr ctrl.Manager

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -33,40 +34,17 @@ const (
 	autoscalingRunnerSetTestGitHubToken = "gh_token"
 )
 
-var _ = Describe("Test AutoScalingRunnerSet controller", func() {
+var _ = FDescribe("Test AutoScalingRunnerSet controller", func() {
 	var ctx context.Context
-	var cancel context.CancelFunc
-	autoscalingNS := new(corev1.Namespace)
-	autoscalingRunnerSet := new(v1alpha1.AutoscalingRunnerSet)
-	configSecret := new(corev1.Secret)
+	var mgr manager.Manager
+	var autoscalingNS *corev1.Namespace
+	var autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet
+	var configSecret *corev1.Secret
 
 	BeforeEach(func() {
-		ctx, cancel = context.WithCancel(context.TODO())
-		autoscalingNS = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: "testns-autoscaling" + RandStringRunes(5)},
-		}
-
-		err := k8sClient.Create(ctx, autoscalingNS)
-		Expect(err).NotTo(HaveOccurred(), "failed to create test namespace for AutoScalingRunnerSet")
-
-		configSecret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "github-config-secret",
-				Namespace: autoscalingNS.Name,
-			},
-			Data: map[string][]byte{
-				"github_token": []byte(autoscalingRunnerSetTestGitHubToken),
-			},
-		}
-
-		err = k8sClient.Create(ctx, configSecret)
-		Expect(err).NotTo(HaveOccurred(), "failed to create config secret")
-
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-			Namespace:          autoscalingNS.Name,
-			MetricsBindAddress: "0",
-		})
-		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+		ctx = context.Background()
+		autoscalingNS, mgr = createNamespace(GinkgoT(), k8sClient)
+		configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 		controller := &AutoscalingRunnerSetReconciler{
 			Client:                             mgr.GetClient(),
@@ -76,7 +54,7 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 			DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 			ActionsClient:                      fake.NewMultiClient(),
 		}
-		err = controller.SetupWithManager(mgr)
+		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
 
 		min := 1
@@ -108,19 +86,7 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 		err = k8sClient.Create(ctx, autoscalingRunnerSet)
 		Expect(err).NotTo(HaveOccurred(), "failed to create AutoScalingRunnerSet")
 
-		go func() {
-			defer GinkgoRecover()
-
-			err := mgr.Start(ctx)
-			Expect(err).NotTo(HaveOccurred(), "failed to start manager")
-		}()
-	})
-
-	AfterEach(func() {
-		defer cancel()
-
-		err := k8sClient.Delete(ctx, autoscalingNS)
-		Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace for AutoScalingRunnerSet")
+		startManagers(GinkgoT(), mgr)
 	})
 
 	Context("When creating a new AutoScalingRunnerSet", func() {
@@ -435,39 +401,15 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 	})
 })
 
-var _ = Describe("Test AutoscalingController creation failures", func() {
+var _ = FDescribe("Test AutoscalingController creation failures", func() {
 	Context("When autoscaling runner set creation fails on the client", func() {
 		var ctx context.Context
-		var cancel context.CancelFunc
-		autoscalingNS := new(corev1.Namespace)
-		configSecret := new(corev1.Secret)
+		var mgr manager.Manager
+		var autoscalingNS *corev1.Namespace
 
 		BeforeEach(func() {
-			ctx, cancel = context.WithCancel(context.TODO())
-			autoscalingNS = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: "testns-autoscaling" + RandStringRunes(5)},
-			}
-
-			err := k8sClient.Create(ctx, autoscalingNS)
-			Expect(err).NotTo(HaveOccurred(), "failed to create test namespace for AutoScalingRunnerSet")
-
-			configSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "github-config-secret",
-					Namespace: autoscalingNS.Name,
-				},
-				Data: map[string][]byte{
-					"github_token": []byte(autoscalingRunnerSetTestGitHubToken),
-				},
-			}
-
-			err = k8sClient.Create(ctx, configSecret)
-			Expect(err).NotTo(HaveOccurred(), "failed to create config secret")
-
-			mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-				MetricsBindAddress: "0",
-			})
-			Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+			ctx = context.Background()
+			autoscalingNS, mgr = createNamespace(GinkgoT(), k8sClient)
 
 			controller := &AutoscalingRunnerSetReconciler{
 				Client:                             mgr.GetClient(),
@@ -477,22 +419,10 @@ var _ = Describe("Test AutoscalingController creation failures", func() {
 				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 				ActionsClient:                      fake.NewMultiClient(),
 			}
-			err = controller.SetupWithManager(mgr)
+			err := controller.SetupWithManager(mgr)
 			Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
 
-			go func() {
-				defer GinkgoRecover()
-
-				err := mgr.Start(ctx)
-				Expect(err).NotTo(HaveOccurred(), "failed to start manager")
-			}()
-		})
-
-		AfterEach(func() {
-			defer cancel()
-
-			err := k8sClient.Delete(ctx, autoscalingNS)
-			Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace for AutoScalingRunnerSet")
+			startManagers(GinkgoT(), mgr)
 		})
 
 		It("It should be able to clean up if annotation related to scale set id does not exist", func() {
@@ -580,60 +510,20 @@ var _ = Describe("Test AutoscalingController creation failures", func() {
 	})
 })
 
-var _ = Describe("Test Client optional configuration", func() {
+var _ = FDescribe("Test Client optional configuration", func() {
 	Context("When specifying a proxy", func() {
 		var ctx context.Context
-		var cancel context.CancelFunc
-
-		autoscalingNS := new(corev1.Namespace)
-		configSecret := new(corev1.Secret)
 		var mgr ctrl.Manager
+		var autoscalingNS *corev1.Namespace
+		var configSecret *corev1.Secret
+		var controller *AutoscalingRunnerSetReconciler
 
 		BeforeEach(func() {
-			ctx, cancel = context.WithCancel(context.TODO())
-			autoscalingNS = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: "testns-autoscaling" + RandStringRunes(5)},
-			}
+			ctx = context.Background()
+			autoscalingNS, mgr = createNamespace(GinkgoT(), k8sClient)
+			configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
-			err := k8sClient.Create(ctx, autoscalingNS)
-			Expect(err).NotTo(HaveOccurred(), "failed to create test namespace for AutoScalingRunnerSet")
-
-			configSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "github-config-secret",
-					Namespace: autoscalingNS.Name,
-				},
-				Data: map[string][]byte{
-					"github_token": []byte(autoscalingRunnerSetTestGitHubToken),
-				},
-			}
-
-			err = k8sClient.Create(ctx, configSecret)
-			Expect(err).NotTo(HaveOccurred(), "failed to create config secret")
-
-			mgr, err = ctrl.NewManager(cfg, ctrl.Options{
-				Namespace:          autoscalingNS.Name,
-				MetricsBindAddress: "0",
-			})
-			Expect(err).NotTo(HaveOccurred(), "failed to create manager")
-
-			go func() {
-				defer GinkgoRecover()
-
-				err := mgr.Start(ctx)
-				Expect(err).NotTo(HaveOccurred(), "failed to start manager")
-			}()
-		})
-
-		AfterEach(func() {
-			defer cancel()
-
-			err := k8sClient.Delete(ctx, autoscalingNS)
-			Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace for AutoScalingRunnerSet")
-		})
-
-		It("should be able to make requests to a server using a proxy", func() {
-			controller := &AutoscalingRunnerSetReconciler{
+			controller = &AutoscalingRunnerSetReconciler{
 				Client:                             mgr.GetClient(),
 				Scheme:                             mgr.GetScheme(),
 				Log:                                logf.Log,
@@ -644,6 +534,10 @@ var _ = Describe("Test Client optional configuration", func() {
 			err := controller.SetupWithManager(mgr)
 			Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
 
+			startManagers(GinkgoT(), mgr)
+		})
+
+		It("should be able to make requests to a server using a proxy", func() {
 			serverSuccessfullyCalled := false
 			proxy := testserver.New(GinkgoT(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				serverSuccessfullyCalled = true
@@ -681,7 +575,7 @@ var _ = Describe("Test Client optional configuration", func() {
 				},
 			}
 
-			err = k8sClient.Create(ctx, autoscalingRunnerSet)
+			err := k8sClient.Create(ctx, autoscalingRunnerSet)
 			Expect(err).NotTo(HaveOccurred(), "failed to create AutoScalingRunnerSet")
 
 			// wait for server to be called
@@ -695,17 +589,6 @@ var _ = Describe("Test Client optional configuration", func() {
 		})
 
 		It("should be able to make requests to a server using a proxy with user info", func() {
-			controller := &AutoscalingRunnerSetReconciler{
-				Client:                             mgr.GetClient(),
-				Scheme:                             mgr.GetScheme(),
-				Log:                                logf.Log,
-				ControllerNamespace:                autoscalingNS.Name,
-				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
-				ActionsClient:                      actions.NewMultiClient("test", logr.Discard()),
-			}
-			err := controller.SetupWithManager(mgr)
-			Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
-
 			serverSuccessfullyCalled := false
 			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				header := r.Header.Get("Proxy-Authorization")
@@ -734,7 +617,7 @@ var _ = Describe("Test Client optional configuration", func() {
 				},
 			}
 
-			err = k8sClient.Create(ctx, secretCredentials)
+			err := k8sClient.Create(ctx, secretCredentials)
 			Expect(err).NotTo(HaveOccurred(), "failed to create secret credentials")
 
 			min := 1

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -22,7 +22,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -84,45 +83,19 @@ func newExampleRunner(name, namespace, configSecretName string) *v1alpha1.Epheme
 	}
 }
 
-var _ = Describe("EphemeralRunner", func() {
+var _ = FDescribe("EphemeralRunner", func() {
 	Describe("Resource manipulation", func() {
 		var ctx context.Context
-		var cancel context.CancelFunc
-
-		autoscalingNS := new(corev1.Namespace)
-		configSecret := new(corev1.Secret)
-
-		controller := new(EphemeralRunnerReconciler)
-		ephemeralRunner := new(v1alpha1.EphemeralRunner)
+		var mgr ctrl.Manager
+		var autoscalingNS *corev1.Namespace
+		var configSecret *corev1.Secret
+		var controller *EphemeralRunnerReconciler
+		var ephemeralRunner *v1alpha1.EphemeralRunner
 
 		BeforeEach(func() {
-			ctx, cancel = context.WithCancel(context.Background())
-			autoscalingNS = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testns-autoscaling-runner" + RandStringRunes(5),
-				},
-			}
-			err := k8sClient.Create(ctx, autoscalingNS)
-			Expect(err).To(BeNil(), "failed to create test namespace for EphemeralRunner")
-
-			configSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "github-config-secret",
-					Namespace: autoscalingNS.Name,
-				},
-				Data: map[string][]byte{
-					"github_token": []byte(gh_token),
-				},
-			}
-
-			err = k8sClient.Create(ctx, configSecret)
-			Expect(err).To(BeNil(), "failed to create config secret")
-
-			mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-				Namespace:          autoscalingNS.Name,
-				MetricsBindAddress: "0",
-			})
-			Expect(err).To(BeNil(), "failed to create manager")
+			ctx = context.Background()
+			autoscalingNS, mgr = createNamespace(GinkgoT(), k8sClient)
+			configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 			controller = &EphemeralRunnerReconciler{
 				Client:        mgr.GetClient(),
@@ -131,26 +104,14 @@ var _ = Describe("EphemeralRunner", func() {
 				ActionsClient: fake.NewMultiClient(),
 			}
 
-			err = controller.SetupWithManager(mgr)
+			err := controller.SetupWithManager(mgr)
 			Expect(err).To(BeNil(), "failed to setup controller")
 
 			ephemeralRunner = newExampleRunner("test-runner", autoscalingNS.Name, configSecret.Name)
 			err = k8sClient.Create(ctx, ephemeralRunner)
 			Expect(err).To(BeNil(), "failed to create ephemeral runner")
 
-			go func() {
-				defer GinkgoRecover()
-
-				err := mgr.Start(ctx)
-				Expect(err).To(BeNil(), "failed to start manager")
-			}()
-		})
-
-		AfterEach(func() {
-			defer cancel()
-
-			err := k8sClient.Delete(ctx, autoscalingNS)
-			Expect(err).To(BeNil(), "failed to delete test namespace for EphemeralRunner")
+			startManagers(GinkgoT(), mgr)
 		})
 
 		It("It should create/add all required resources for EphemeralRunner (finalizer, jit secret)", func() {
@@ -668,52 +629,17 @@ var _ = Describe("EphemeralRunner", func() {
 
 	Describe("Checking the API", func() {
 		var ctx context.Context
-		var cancel context.CancelFunc
-
-		autoscalingNS := new(corev1.Namespace)
-		configSecret := new(corev1.Secret)
-
-		var mgr manager.Manager
+		var autoscalingNS *corev1.Namespace
+		var configSecret *corev1.Secret
+		var controller *EphemeralRunnerReconciler
+		var mgr ctrl.Manager
 
 		BeforeEach(func() {
-			ctx, cancel = context.WithCancel(context.Background())
-			autoscalingNS = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testns-autoscaling-runner" + RandStringRunes(5),
-				},
-			}
-			err := k8sClient.Create(ctx, autoscalingNS)
-			Expect(err).To(BeNil(), "failed to create test namespace for EphemeralRunner")
+			ctx = context.Background()
+			autoscalingNS, mgr = createNamespace(GinkgoT(), k8sClient)
+			configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
-			configSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "github-config-secret",
-					Namespace: autoscalingNS.Name,
-				},
-				Data: map[string][]byte{
-					"github_token": []byte(gh_token),
-				},
-			}
-
-			err = k8sClient.Create(ctx, configSecret)
-			Expect(err).To(BeNil(), "failed to create config secret")
-
-			mgr, err = ctrl.NewManager(cfg, ctrl.Options{
-				Namespace:          autoscalingNS.Name,
-				MetricsBindAddress: "0",
-			})
-			Expect(err).To(BeNil(), "failed to create manager")
-		})
-
-		AfterEach(func() {
-			defer cancel()
-
-			err := k8sClient.Delete(ctx, autoscalingNS)
-			Expect(err).To(BeNil(), "failed to delete test namespace for EphemeralRunner")
-		})
-
-		It("It should set the Phase to Succeeded", func() {
-			controller := &EphemeralRunnerReconciler{
+			controller = &EphemeralRunnerReconciler{
 				Client: mgr.GetClient(),
 				Scheme: mgr.GetScheme(),
 				Log:    logf.Log,
@@ -732,20 +658,16 @@ var _ = Describe("EphemeralRunner", func() {
 					),
 				),
 			}
-
 			err := controller.SetupWithManager(mgr)
 			Expect(err).To(BeNil(), "failed to setup controller")
 
-			go func() {
-				defer GinkgoRecover()
+			startManagers(GinkgoT(), mgr)
+		})
 
-				err := mgr.Start(ctx)
-				Expect(err).To(BeNil(), "failed to start manager")
-			}()
-
+		It("It should set the Phase to Succeeded", func() {
 			ephemeralRunner := newExampleRunner("test-runner", autoscalingNS.Name, configSecret.Name)
 
-			err = k8sClient.Create(ctx, ephemeralRunner)
+			err := k8sClient.Create(ctx, ephemeralRunner)
 			Expect(err).To(BeNil())
 
 			pod := new(corev1.Pod)
@@ -780,40 +702,15 @@ var _ = Describe("EphemeralRunner", func() {
 
 	Describe("Pod proxy config", func() {
 		var ctx context.Context
-		var cancel context.CancelFunc
-
-		autoScalingNS := new(corev1.Namespace)
-		configSecret := new(corev1.Secret)
-		controller := new(EphemeralRunnerReconciler)
+		var mgr ctrl.Manager
+		var autoScalingNS *corev1.Namespace
+		var configSecret *corev1.Secret
+		var controller *EphemeralRunnerReconciler
 
 		BeforeEach(func() {
-			ctx, cancel = context.WithCancel(context.Background())
-			autoScalingNS = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testns-autoscaling-runner" + RandStringRunes(5),
-				},
-			}
-			err := k8sClient.Create(ctx, autoScalingNS)
-			Expect(err).To(BeNil(), "failed to create test namespace for EphemeralRunner")
-
-			configSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "github-config-secret",
-					Namespace: autoScalingNS.Name,
-				},
-				Data: map[string][]byte{
-					"github_token": []byte(gh_token),
-				},
-			}
-
-			err = k8sClient.Create(ctx, configSecret)
-			Expect(err).To(BeNil(), "failed to create config secret")
-
-			mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-				Namespace:          autoScalingNS.Name,
-				MetricsBindAddress: "0",
-			})
-			Expect(err).To(BeNil(), "failed to create manager")
+			ctx = context.Background()
+			autoScalingNS, mgr = createNamespace(GinkgoT(), k8sClient)
+			configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoScalingNS.Name)
 
 			controller = &EphemeralRunnerReconciler{
 				Client:        mgr.GetClient(),
@@ -821,23 +718,10 @@ var _ = Describe("EphemeralRunner", func() {
 				Log:           logf.Log,
 				ActionsClient: fake.NewMultiClient(),
 			}
-
-			err = controller.SetupWithManager(mgr)
+			err := controller.SetupWithManager(mgr)
 			Expect(err).To(BeNil(), "failed to setup controller")
 
-			go func() {
-				defer GinkgoRecover()
-
-				err := mgr.Start(ctx)
-				Expect(err).To(BeNil(), "failed to start manager")
-			}()
-		})
-
-		AfterEach(func() {
-			defer cancel()
-
-			err := k8sClient.Delete(ctx, autoScalingNS)
-			Expect(err).To(BeNil(), "failed to delete test namespace for EphemeralRunner")
+			startManagers(GinkgoT(), mgr)
 		})
 
 		It("uses an actions client with proxy transport", func() {

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	gh_token    = "gh_token"
 	timeout     = time.Second * 10
 	interval    = time.Millisecond * 250
 	runnerImage = "ghcr.io/actions/actions-runner:latest"
@@ -83,7 +82,7 @@ func newExampleRunner(name, namespace, configSecretName string) *v1alpha1.Epheme
 	}
 }
 
-var _ = FDescribe("EphemeralRunner", func() {
+var _ = Describe("EphemeralRunner", func() {
 	Describe("Resource manipulation", func() {
 		var ctx context.Context
 		var mgr ctrl.Manager

--- a/controllers/actions.github.com/helpers_test.go
+++ b/controllers/actions.github.com/helpers_test.go
@@ -15,8 +15,8 @@ import (
 
 const defaultGitHubToken = "gh_token"
 
-func startManagers(t ginkgo.GinkgoTInterface, managers ...manager.Manager) {
-	for _, mgr := range managers {
+func startManagers(t ginkgo.GinkgoTInterface, first manager.Manager, others ...manager.Manager) {
+	for _, mgr := range append([]manager.Manager{first}, others...) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		g, ctx := errgroup.WithContext(ctx)

--- a/controllers/actions.github.com/helpers_test.go
+++ b/controllers/actions.github.com/helpers_test.go
@@ -1,0 +1,71 @@
+package actionsgithubcom
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const defaultGitHubToken = "gh_token"
+
+func startManagers(t ginkgo.GinkgoTInterface, managers ...manager.Manager) {
+	for _, mgr := range managers {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		g, ctx := errgroup.WithContext(ctx)
+		g.Go(func() error {
+			return mgr.Start(ctx)
+		})
+
+		t.Cleanup(func() {
+			cancel()
+			require.NoError(t, g.Wait())
+		})
+	}
+}
+
+func createNamespace(t ginkgo.GinkgoTInterface, client client.Client) (*corev1.Namespace, manager.Manager) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "testns-autoscaling" + RandStringRunes(5)},
+	}
+
+	err := k8sClient.Create(context.Background(), ns)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := k8sClient.Delete(context.Background(), ns)
+		require.NoError(t, err)
+	})
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Namespace:          ns.Name,
+		MetricsBindAddress: "0",
+	})
+	require.NoError(t, err)
+
+	return ns, mgr
+}
+
+func createDefaultSecret(t ginkgo.GinkgoTInterface, client client.Client, namespace string) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "github-config-secret",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"github_token": []byte(defaultGitHubToken),
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), secret)
+	require.NoError(t, err)
+
+	return secret
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This introduces some helpers to simplify the setup for k8s controllers tests and avoid quite some error prone repetition