### PR TITLE
Delay role/rolebinding creation to gha-runner-scale-set installation time

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
@@ -72,12 +72,20 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "gha-runner-scale-set-controller.managerRoleName" -}}
-{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-role
+{{- define "gha-runner-scale-set-controller.managerClusterRoleName" -}}
+{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-cluster-role
 {{- end }}
 
-{{- define "gha-runner-scale-set-controller.managerRoleBinding" -}}
-{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-rolebinding
+{{- define "gha-runner-scale-set-controller.managerClusterRoleBinding" -}}
+{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-cluster-rolebinding
+{{- end }}
+
+{{- define "gha-runner-scale-set-controller.managerListenerRoleName" -}}
+{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-listener-role
+{{- end }}
+
+{{- define "gha-runner-scale-set-controller.managerListenerRoleBinding" -}}
+{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-listener-rolebinding
 {{- end }}
 
 {{- define "gha-runner-scale-set-controller.leaderElectionRoleName" -}}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gha-runner-scale-set-controller.labels" . | nindent 4 }}
+    actions.github.com/controller-service-account-namespace: {{ .Release.Namespace }}
+    actions.github.com/controller-service-account-name: {{ include "gha-runner-scale-set-controller.serviceAccountName" . }}
 spec:
   replicas: {{ default 1 .Values.replicaCount }}
   selector:

--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "gha-runner-scale-set-controller.managerRoleName" . }}
+  name: {{ include "gha-runner-scale-set-controller.managerClusterRoleName" . }}
 rules:
 - apiGroups:
   - actions.github.com
@@ -112,42 +112,12 @@ rules:
   resources:
   - pods
   verbs:
-  - create
-  - delete
-  - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/status
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - update
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
   verbs:
   - list
   - watch
@@ -156,10 +126,6 @@ rules:
   resources:
   - rolebindings
   verbs:
-  - create
-  - delete
-  - get
-  - update
   - list
   - watch
 - apiGroups:
@@ -167,9 +133,5 @@ rules:
   resources:
   - roles
   verbs:
-  - create
-  - delete
-  - get
-  - update
   - list
   - watch

--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role_binding.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "gha-runner-scale-set-controller.managerRoleBinding" . }}
+  name: {{ include "gha-runner-scale-set-controller.managerClusterRoleBinding" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "gha-runner-scale-set-controller.managerRoleName" . }}
+  name: {{ include "gha-runner-scale-set-controller.managerClusterRoleName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "gha-runner-scale-set-controller.serviceAccountName" . }}

--- a/charts/gha-runner-scale-set-controller/templates/manager_listener_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_listener_role.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gha-runner-scale-set-controller.managerListenerRoleName" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update

--- a/charts/gha-runner-scale-set-controller/templates/manager_listener_role_binding.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_listener_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gha-runner-scale-set-controller.managerListenerRoleBinding" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gha-runner-scale-set-controller.managerListenerRoleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gha-runner-scale-set-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/gha-runner-scale-set/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gha-runner-scale-set.managerRoleName" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+{{- if .Values.githubServerTLS }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+{{- end }}

--- a/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gha-runner-scale-set.managerRoleBinding" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gha-runner-scale-set.managerRoleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gha-runner-scale-set.managerServiceAccountName" . | nindent 4 }}
+  namespace: {{ include "gha-runner-scale-set.managerServiceAccountNamespace" . | nindent 4 }}

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -27,8 +27,10 @@ func TestTemplateRenderedGitHubSecretWithGitHubToken(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -60,6 +62,8 @@ func TestTemplateRenderedGitHubSecretWithGitHubApp(t *testing.T) {
 			"githubConfigSecret.github_app_id":              "10",
 			"githubConfigSecret.github_app_installation_id": "100",
 			"githubConfigSecret.github_app_private_key":     "private_key",
+			"controllerServiceAccount.name":                 "arc",
+			"controllerServiceAccount.namespace":            "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -87,9 +91,11 @@ func TestTemplateRenderedGitHubSecretErrorWithMissingAuthInput(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                  "https://github.com/actions",
-			"githubConfigSecret.github_app_id": "",
-			"githubConfigSecret.github_token":  "",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_app_id":   "",
+			"githubConfigSecret.github_token":    "",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -112,8 +118,10 @@ func TestTemplateRenderedGitHubSecretErrorWithMissingAppInput(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                  "https://github.com/actions",
-			"githubConfigSecret.github_app_id": "10",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_app_id":   "10",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -136,8 +144,10 @@ func TestTemplateNotRenderedGitHubSecretWithPredefinedSecret(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":    "https://github.com/actions",
-			"githubConfigSecret": "pre-defined-secret",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret":                 "pre-defined-secret",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -158,8 +168,10 @@ func TestTemplateRenderedSetServiceAccountToNoPermission(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -190,9 +202,11 @@ func TestTemplateRenderedSetServiceAccountToKubeMode(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"containerMode.type":              "kubernetes",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"containerMode.type":                 "kubernetes",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -248,9 +262,11 @@ func TestTemplateRenderedUserProvideSetServiceAccount(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                  "https://github.com/actions",
-			"githubConfigSecret.github_token":  "gh_token12345",
-			"template.spec.serviceAccountName": "test-service-account",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"template.spec.serviceAccountName":   "test-service-account",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -277,8 +293,10 @@ func TestTemplateRenderedAutoScalingRunnerSet(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -322,9 +340,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_RunnerScaleSetName(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"runnerScaleSetName":              "test-runner-scale-set-name",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"runnerScaleSetName":                 "test-runner-scale-set-name",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -375,6 +395,8 @@ func TestTemplateRenderedAutoScalingRunnerSet_ProvideMetadata(t *testing.T) {
 			"template.metadata.labels.test2":      "test2",
 			"template.metadata.annotations.test3": "test3",
 			"template.metadata.annotations.test4": "test4",
+			"controllerServiceAccount.name":       "arc",
+			"controllerServiceAccount.namespace":  "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -414,9 +436,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_MaxRunnersValidationError(t *testi
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"maxRunners":                      "-1",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"maxRunners":                         "-1",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -439,10 +463,12 @@ func TestTemplateRenderedAutoScalingRunnerSet_MinRunnersValidationError(t *testi
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"maxRunners":                      "1",
-			"minRunners":                      "-1",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"maxRunners":                         "1",
+			"minRunners":                         "-1",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -465,10 +491,12 @@ func TestTemplateRenderedAutoScalingRunnerSet_MinMaxRunnersValidationError(t *te
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"maxRunners":                      "0",
-			"minRunners":                      "1",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"maxRunners":                         "0",
+			"minRunners":                         "1",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -491,10 +519,12 @@ func TestTemplateRenderedAutoScalingRunnerSet_MinMaxRunnersValidationSameValue(t
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"maxRunners":                      "0",
-			"minRunners":                      "0",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"maxRunners":                         "0",
+			"minRunners":                         "0",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -520,9 +550,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_MinMaxRunnersValidation_OnlyMin(t 
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"minRunners":                      "5",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"minRunners":                         "5",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -548,9 +580,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_MinMaxRunnersValidation_OnlyMax(t 
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"maxRunners":                      "5",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"maxRunners":                         "5",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -605,6 +639,10 @@ func TestTemplateRenderedAutoScalingRunnerSet_ExtraVolumes(t *testing.T) {
 	namespaceName := "test-" + strings.ToLower(random.UniqueId())
 
 	options := &helm.Options{
+		SetValues: map[string]string{
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
 		ValuesFiles:    []string{testValuesPath},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -635,6 +673,10 @@ func TestTemplateRenderedAutoScalingRunnerSet_DinD_ExtraVolumes(t *testing.T) {
 	namespaceName := "test-" + strings.ToLower(random.UniqueId())
 
 	options := &helm.Options{
+		SetValues: map[string]string{
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
 		ValuesFiles:    []string{testValuesPath},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -667,6 +709,10 @@ func TestTemplateRenderedAutoScalingRunnerSet_K8S_ExtraVolumes(t *testing.T) {
 	namespaceName := "test-" + strings.ToLower(random.UniqueId())
 
 	options := &helm.Options{
+		SetValues: map[string]string{
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
 		ValuesFiles:    []string{testValuesPath},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -695,9 +741,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_EnableDinD(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"containerMode.type":              "dind",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"containerMode.type":                 "dind",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -784,9 +832,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_EnableKubernetesMode(t *testing.T)
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret.github_token": "gh_token12345",
-			"containerMode.type":              "kubernetes",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"containerMode.type":                 "kubernetes",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -839,8 +889,10 @@ func TestTemplateRenderedAutoScalingRunnerSet_UsePredefinedSecret(t *testing.T) 
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":    "https://github.com/actions",
-			"githubConfigSecret": "pre-defined-secrets",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret":                 "pre-defined-secrets",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -871,8 +923,10 @@ func TestTemplateRenderedAutoScalingRunnerSet_ErrorOnEmptyPredefinedSecret(t *te
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":    "https://github.com/actions",
-			"githubConfigSecret": "",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret":                 "",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -895,13 +949,15 @@ func TestTemplateRenderedWithProxy(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions",
-			"githubConfigSecret":              "pre-defined-secrets",
-			"proxy.http.url":                  "http://proxy.example.com",
-			"proxy.http.credentialSecretRef":  "http-secret",
-			"proxy.https.url":                 "https://proxy.example.com",
-			"proxy.https.credentialSecretRef": "https-secret",
-			"proxy.noProxy":                   "{example.com,example.org}",
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret":                 "pre-defined-secrets",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+			"proxy.http.url":                     "http://proxy.example.com",
+			"proxy.http.credentialSecretRef":     "http-secret",
+			"proxy.https.url":                    "https://proxy.example.com",
+			"proxy.https.credentialSecretRef":    "https-secret",
+			"proxy.noProxy":                      "{example.com,example.org}",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -961,6 +1017,8 @@ func TestTemplateRenderedWithTLS(t *testing.T) {
 					"githubServerTLS.certificateFrom.configMapKeyRef.name": "certs-configmap",
 					"githubServerTLS.certificateFrom.configMapKeyRef.key":  "cert.pem",
 					"githubServerTLS.runnerMountPath":                      "/runner/mount/path",
+					"controllerServiceAccount.name":                        "arc",
+					"controllerServiceAccount.namespace":                   "arc-system",
 				},
 				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 			}
@@ -1018,6 +1076,8 @@ func TestTemplateRenderedWithTLS(t *testing.T) {
 					"githubServerTLS.certificateFrom.configMapKeyRef.key":  "cert.pem",
 					"githubServerTLS.runnerMountPath":                      "/runner/mount/path/",
 					"containerMode.type":                                   "dind",
+					"controllerServiceAccount.name":                        "arc",
+					"controllerServiceAccount.namespace":                   "arc-system",
 				},
 				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 			}
@@ -1075,6 +1135,8 @@ func TestTemplateRenderedWithTLS(t *testing.T) {
 					"githubServerTLS.certificateFrom.configMapKeyRef.key":  "cert.pem",
 					"githubServerTLS.runnerMountPath":                      "/runner/mount/path",
 					"containerMode.type":                                   "kubernetes",
+					"controllerServiceAccount.name":                        "arc",
+					"controllerServiceAccount.namespace":                   "arc-system",
 				},
 				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 			}
@@ -1132,6 +1194,8 @@ func TestTemplateRenderedWithTLS(t *testing.T) {
 					"githubConfigSecret": "pre-defined-secrets",
 					"githubServerTLS.certificateFrom.configMapKeyRef.name": "certs-configmap",
 					"githubServerTLS.certificateFrom.configMapKeyRef.key":  "cert.pem",
+					"controllerServiceAccount.name":                        "arc",
+					"controllerServiceAccount.namespace":                   "arc-system",
 				},
 				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 			}
@@ -1184,7 +1248,9 @@ func TestTemplateRenderedWithTLS(t *testing.T) {
 					"githubConfigSecret": "pre-defined-secrets",
 					"githubServerTLS.certificateFrom.configMapKeyRef.name": "certs-configmap",
 					"githubServerTLS.certificateFrom.configMapKeyRef.key":  "cert.pem",
-					"containerMode.type": "dind",
+					"containerMode.type":                 "dind",
+					"controllerServiceAccount.name":      "arc",
+					"controllerServiceAccount.namespace": "arc-system",
 				},
 				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 			}
@@ -1237,7 +1303,9 @@ func TestTemplateRenderedWithTLS(t *testing.T) {
 					"githubConfigSecret": "pre-defined-secrets",
 					"githubServerTLS.certificateFrom.configMapKeyRef.name": "certs-configmap",
 					"githubServerTLS.certificateFrom.configMapKeyRef.key":  "cert.pem",
-					"containerMode.type": "kubernetes",
+					"containerMode.type":                 "kubernetes",
+					"controllerServiceAccount.name":      "arc",
+					"controllerServiceAccount.namespace": "arc-system",
 				},
 				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 			}
@@ -1293,8 +1361,10 @@ func TestTemplateNamingConstraints(t *testing.T) {
 	require.NoError(t, err)
 
 	setValues := map[string]string{
-		"githubConfigUrl":    "https://github.com/actions",
-		"githubConfigSecret": "",
+		"githubConfigUrl":                    "https://github.com/actions",
+		"githubConfigSecret":                 "",
+		"controllerServiceAccount.name":      "arc",
+		"controllerServiceAccount.namespace": "arc-system",
 	}
 
 	tt := map[string]struct {
@@ -1339,8 +1409,10 @@ func TestTemplateRenderedGitHubConfigUrlEndsWIthSlash(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"githubConfigUrl":                 "https://github.com/actions/",
-			"githubConfigSecret.github_token": "gh_token12345",
+			"githubConfigUrl":                    "https://github.com/actions/",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -1353,4 +1425,98 @@ func TestTemplateRenderedGitHubConfigUrlEndsWIthSlash(t *testing.T) {
 	assert.Equal(t, namespaceName, ars.Namespace)
 	assert.Equal(t, "test-runners", ars.Name)
 	assert.Equal(t, "https://github.com/actions", ars.Spec.GitHubConfigUrl)
+}
+
+func TestTemplate_CreateManagerRole(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueId())
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/manager_role.yaml"})
+
+	var managerRole rbacv1.Role
+	helm.UnmarshalK8SYaml(t, output, &managerRole)
+
+	assert.Equal(t, namespaceName, managerRole.Namespace, "namespace should match the namespace of the Helm release")
+	assert.Equal(t, "test-runners-gha-runner-scale-set-manager-role", managerRole.Name)
+	assert.Equal(t, 5, len(managerRole.Rules))
+}
+
+func TestTemplate_CreateManagerRole_UseConfigMaps(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueId())
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"githubConfigUrl":                                      "https://github.com/actions",
+			"githubConfigSecret.github_token":                      "gh_token12345",
+			"controllerServiceAccount.name":                        "arc",
+			"controllerServiceAccount.namespace":                   "arc-system",
+			"githubServerTLS.certificateFrom.configMapKeyRef.name": "test",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/manager_role.yaml"})
+
+	var managerRole rbacv1.Role
+	helm.UnmarshalK8SYaml(t, output, &managerRole)
+
+	assert.Equal(t, namespaceName, managerRole.Namespace, "namespace should match the namespace of the Helm release")
+	assert.Equal(t, "test-runners-gha-runner-scale-set-manager-role", managerRole.Name)
+	assert.Equal(t, 6, len(managerRole.Rules))
+	assert.Equal(t, "configmaps", managerRole.Rules[5].Resources[0])
+}
+
+func TestTemplate_CreateManagerRoleBinding(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueId())
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/manager_role_binding.yaml"})
+
+	var managerRoleBinding rbacv1.RoleBinding
+	helm.UnmarshalK8SYaml(t, output, &managerRoleBinding)
+
+	assert.Equal(t, namespaceName, managerRoleBinding.Namespace, "namespace should match the namespace of the Helm release")
+	assert.Equal(t, "test-runners-gha-runner-scale-set-manager-role-binding", managerRoleBinding.Name)
+	assert.Equal(t, "test-runners-gha-runner-scale-set-manager-role", managerRoleBinding.RoleRef.Name)
+	assert.Equal(t, "arc", managerRoleBinding.Subjects[0].Name)
+	assert.Equal(t, "arc-system", managerRoleBinding.Subjects[0].Namespace)
 }

--- a/charts/gha-runner-scale-set/tests/values.yaml
+++ b/charts/gha-runner-scale-set/tests/values.yaml
@@ -3,3 +3,6 @@ githubConfigSecret:
   github_token: test
 maxRunners: 10
 minRunners: 5
+controllerServiceAccount:
+  name: "arc"
+  namespace: "arc-system"

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -161,3 +161,13 @@ containerMode:
     resources:
       requests:
         storage: 1Gi
+
+## Optional controller service account that needs to have required Role and RoleBinding 
+## to operate this gha-runner-scale-set installation.
+## The helm chart will try to find the controller deployment and its service account at installation time.
+## In case the helm chart can't find the right service account, you can explicitly pass in the following value
+## to help it finish RoleBinding with the right service account.
+## Note: if your controller is installed to only watch a single namespace, you have to pass these values explicitly.
+# controllerServiceAccount:
+#   namespace: arc-system
+#   name: test-arc-gha-runner-scale-set-controller


### PR DESCRIPTION
Part 2 of https://github.com/actions/actions-runner-controller/pull/2275

- Keep `ClusterRole/ClusterRoleBinding` to manage CRD and `List/Watch` low-risk resources.
- New `Role/RoleBinding` to make sure the manager has permission to create an `AutoScalingListener` in the controller installed namespace.
- New `Role/RoleBinding` to make sure the manager has permission to do everything in the namespace where the `gha-runner-scale-set` is installed.