### PR TITLE
Support the controller to watching a single namespace.

### DIFF
--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -124,3 +124,105 @@ jobs:
         if: always() && steps.install_arc_controller.outcome == 'success'
         run: |
           kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems
+
+  single-namespace-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Resolve inputs
+        id: resolved_inputs
+        run: |
+          TARGET_ORG="${{env.TARGET_ORG}}"
+          TARGET_REPO="${{env.TARGET_REPO}}"
+          if [ ! -z "${{inputs.target_org}}" ]; then
+            TARGET_ORG="${{inputs.target_org}}"
+          fi
+          if [ ! -z "${{inputs.target_repo}}" ]; then
+            TARGET_REPO="${{inputs.target_repo}}"
+          fi
+          echo "TARGET_ORG=$TARGET_ORG" >> $GITHUB_OUTPUT
+          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_OUTPUT
+
+      - uses: ./.github/actions/setup-arc-e2e
+        id: setup
+        with:
+          github-app-id: ${{secrets.ACTIONS_ACCESS_APP_ID}}
+          github-app-pk: ${{secrets.ACTIONS_ACCESS_PK}}
+          github-app-org: ${{steps.resolved_inputs.outputs.TARGET_ORG}}
+          docker-image-name: ${{env.IMAGE_NAME}}
+          docker-image-tag: ${{env.IMAGE_VERSION}}
+
+      - name: Install gha-runner-scale-set-controller
+        id: install_arc_controller
+        run: |
+          kubectl create namespace arc-runners
+          helm install arc \
+          --namespace "arc-systems" \
+          --create-namespace \
+          --set image.repository=${{ env.IMAGE_NAME }} \
+          --set image.tag=${{ env.IMAGE_VERSION }} \
+          --set flags.watchSingleNamespace=arc-runners \
+          ./charts/gha-runner-scale-set-controller \
+          --debug
+          count=0
+          while true; do
+            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-runner-scale-set-controller -o name)
+            if [ -n "$POD_NAME" ]; then
+              echo "Pod found: $POD_NAME"
+              break
+            fi
+            if [ "$count" -ge 10 ]; then
+              echo "Timeout waiting for controller pod with label app.kubernetes.io/name=gha-runner-scale-set-controller"
+              exit 1
+            fi
+            sleep 1
+          done
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-runner-scale-set-controller
+          kubectl get pod -n arc-systems
+          kubectl describe deployment arc-gha-runner-scale-set-controller -n arc-systems
+
+      - name: Install gha-runner-scale-set
+        id: install_arc
+        run: |
+          ARC_NAME=arc-runner-${{github.job}}-$(date +'%M-%S')-$(($RANDOM % 100 + 1))
+          helm install "$ARC_NAME" \
+          --namespace "arc-runners" \
+          --create-namespace \
+          --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
+          --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
+          ./charts/gha-runner-scale-set \
+          --debug
+          echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
+          count=0
+          while true; do
+            POD_NAME=$(kubectl get pods -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME -o name)
+            if [ -n "$POD_NAME" ]; then
+              echo "Pod found: $POD_NAME"
+              break
+            fi
+            if [ "$count" -ge 10 ]; then
+              echo "Timeout waiting for listener pod with label auto-scaling-runner-set-name=$ARC_NAME"
+              exit 1
+            fi
+            sleep 1
+          done
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
+          kubectl get pod -n arc-systems
+
+      - name: Test ARC scales pods up and down
+        run: |
+          export GITHUB_TOKEN="${{ steps.setup.outputs.token }}"
+          export ARC_NAME="${{ steps.install_arc.outputs.ARC_NAME }}"
+          go test ./test_e2e_arc -v
+
+      - name: Uninstall gha-runner-scale-set
+        if: always() && steps.install_arc.outcome == 'success'
+        run: |
+          helm uninstall ${{ steps.install_arc.outputs.ARC_NAME }} --namespace arc-runners
+          kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n demo -l app.kubernetes.io/instance=${{ steps.install_arc.outputs.ARC_NAME }}
+
+      - name: Dump gha-runner-scale-set-controller logs
+        if: always() && steps.install_arc_controller.outcome == 'success'
+        run: |
+          kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems

--- a/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
@@ -80,6 +80,14 @@ Create the name of the service account to use
 {{- include "gha-runner-scale-set-controller.fullname" . }}-manager-cluster-rolebinding
 {{- end }}
 
+{{- define "gha-runner-scale-set-controller.managerSingleNamespaceRoleName" -}}
+{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-single-namespace-role
+{{- end }}
+
+{{- define "gha-runner-scale-set-controller.managerSingleNamespaceRoleBinding" -}}
+{{- include "gha-runner-scale-set-controller.fullname" . }}-manager-single-namespace-rolebinding
+{{- end }}
+
 {{- define "gha-runner-scale-set-controller.managerListenerRoleName" -}}
 {{- include "gha-runner-scale-set-controller.fullname" . }}-manager-listener-role
 {{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "gha-runner-scale-set-controller.labels" . | nindent 4 }}
     actions.github.com/controller-service-account-namespace: {{ .Release.Namespace }}
     actions.github.com/controller-service-account-name: {{ include "gha-runner-scale-set-controller.serviceAccountName" . }}
+    {{- if .Values.flags.watchSingleNamespace }}
+    actions.github.com/controller-watch-single-namespace: {{ .Values.flags.watchSingleNamespace }}
+    {{- end }}
 spec:
   replicas: {{ default 1 .Values.replicaCount }}
   selector:
@@ -52,6 +55,9 @@ spec:
         {{- end }}
         {{- with .Values.flags.logLevel }}
         - "--log-level={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.watchSingleNamespace }}
+        - "--watch-single-namespace={{ . }}"
         {{- end }}
         command:
         - "/manager"

--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role_binding.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if empty .Values.flags.watchSingleNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "gha-runner-scale-set-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.flags.watchSingleNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gha-runner-scale-set-controller.managerSingleNamespaceRoleName" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - actions.github.com
+  resources:
+  - autoscalinglisteners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - actions.github.com
+  resources:
+  - autoscalinglisteners/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - actions.github.com
+  resources:
+  - autoscalinglisteners/finalizers
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - actions.github.com
+  resources:
+  - autoscalingrunnersets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - actions.github.com
+  resources:
+  - ephemeralrunnersets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - actions.github.com
+  resources:
+  - ephemeralrunners
+  verbs:
+  - list
+  - watch
+{{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role_binding.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role_binding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.flags.watchSingleNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gha-runner-scale-set-controller.managerSingleNamespaceRoleBinding" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gha-runner-scale-set-controller.managerSingleNamespaceRoleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gha-runner-scale-set-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
@@ -1,8 +1,9 @@
-{{- if empty .Values.flags.watchSingleNamespace }}
+{{- if .Values.flags.watchSingleNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: {{ include "gha-runner-scale-set-controller.managerClusterRoleName" . }}
+  name: {{ include "gha-runner-scale-set-controller.managerSingleNamespaceRoleName" . }}
+  namespace: {{ .Values.flags.watchSingleNamespace }}
 rules:
 - apiGroups:
   - actions.github.com
@@ -29,33 +30,6 @@ rules:
   - autoscalingrunnersets/status
   verbs:
   - get
-  - patch
-  - update
-- apiGroups:
-  - actions.github.com
-  resources:
-  - autoscalinglisteners
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - actions.github.com
-  resources:
-  - autoscalinglisteners/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - actions.github.com
-  resources:
-  - autoscalinglisteners/finalizers
-  verbs:
   - patch
   - update
 - apiGroups:
@@ -105,6 +79,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - actions.github.com
+  resources:
+  - autoscalinglisteners
+  verbs:
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role_binding.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role_binding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.flags.watchSingleNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gha-runner-scale-set-controller.managerSingleNamespaceRoleBinding" . }}
+  namespace: {{ .Values.flags.watchSingleNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gha-runner-scale-set-controller.managerSingleNamespaceRoleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gha-runner-scale-set-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -68,3 +68,7 @@ flags:
   # Log level can be set here with one of the following values: "debug", "info", "warn", "error".
   # Defaults to "debug".
   logLevel: "debug"
+
+  # Restricts the controller to only watch resources in the desired namespace.
+  # Defaults to watch all namespaces when unset.
+  # watchSingleNamespace: ""

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -155,7 +155,7 @@ containerMode:
   ## the following is required when containerMode.type=kubernetes
   kubernetesModeWorkVolumeClaim:
     accessModes: ["ReadWriteOnce"]
-    # For testing, use https://github.com/rancher/local-path-provisioner to provide dynamic provision volume
+    # For local testing, use https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md to provide dynamic provision volume with storageClassName: openebs-hostpath
     # TODO: remove before release
     storageClassName: "dynamic-blob-storage"
     resources:


### PR DESCRIPTION
Part 3 of https://github.com/actions/actions-runner-controller/pull/2275

- Introduce `watchSingleName` to `gha-runner-scale-set-controller` to allow the controller only watch resources in a single namespace.