### PR TITLE
Allow webhook server env to be set individually

### DIFF
--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -83,6 +83,10 @@ if [ "${tool}" == "helm" ]; then
     flags+=( --set actionsMetricsServer.secret.create=true)
     flags+=( --set actionsMetricsServer.secret.github_token=${WEBHOOK_GITHUB_TOKEN})
   fi
+  if [ -n "${GITHUB_WEBHOOK_SERVER_ENV_NAME}" ] && [ -n "${GITHUB_WEBHOOK_SERVER_ENV_VALUE}" ]; then
+    flags+=( --set githubWebhookServer.env[0].name=${GITHUB_WEBHOOK_SERVER_ENV_NAME})
+    flags+=( --set githubWebhookServer.env[0].value=${GITHUB_WEBHOOK_SERVER_ENV_VALUE})
+  fi
 
   set -vx
 

--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -117,6 +117,9 @@ spec:
               name: {{ include "actions-runner-controller.secretName" . }}
               optional: true
         {{- end }}
+        {{- if kindIs "slice" .Values.githubWebhookServer.env }}
+        {{- toYaml .Values.githubWebhookServer.env | nindent 8 }}
+        {{- else }}
         {{- range $key, $val := .Values.githubWebhookServer.env }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
+++ b/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml
@@ -124,6 +124,7 @@ spec:
         - name: {{ $key }}
           value: {{ $val | quote }}
         {{- end }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag  | default (cat "v" .Chart.AppVersion | replace " " "") }}"
         name: github-webhook-server
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -291,7 +291,7 @@ githubWebhookServer:
   #       key: GITHUB_WEBHOOK_SECRET_TOKEN
   #       name: prod-gha-controller-webhook-token
   #       optional: true
-  env: { }
+  env: {}
 
 actionsMetrics:
   serviceAnnotations: {}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -279,6 +279,19 @@ githubWebhookServer:
   # queueLimit: 100
   terminationGracePeriodSeconds: 10
   lifecycle: {}
+  # specify additional environment variables for the webhook server pod.
+  # It's possible to specify either key vale pairs e.g.:
+  # my_env_var: "some value"
+  # my_other_env_var: "other value"
+
+  # or a list of complete environment variable definitions e.g.:
+  # - name: GITHUB_WEBHOOK_SECRET_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: GITHUB_WEBHOOK_SECRET_TOKEN
+  #       name: prod-gha-controller-webhook-token
+  #       optional: true
+  env: { }
 
 actionsMetrics:
   serviceAnnotations: {}


### PR DESCRIPTION
Similar to https://github.com/actions/actions-runner-controller/pull/1565

### Problem
We are using a CSI Provder to sync secrets between AWS and EKS. The way that secrets are bound into the controller deployment doesn't really fit our workflow, so I'd be happy to specify my own environment variables from secrets, kind of the same way as I can specify additional volumes and mounts. 

This PR would allow something like this: 
```yaml
githubWebhookServer:
  env:
    - name: GITHUB_WEBHOOK_SECRET_TOKEN
      valueFrom:
        secretKeyRef:
          key: GITHUB_WEBHOOK_SECRET_TOKEN
          name: prod-gha-controller-webhook-token
          optional: true
```

The last reference in the env variables should be the one, that's taken by k8s to populate the env variable. 