### PR TITLE
Add labels to autoscaling runner set subresources to allow easier inspection

### DIFF
--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -79,20 +79,20 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
             fi
             if [ "$count" -ge 10 ]; then
-              echo "Timeout waiting for listener pod with label auto-scaling-runner-set-name=$ARC_NAME"
+              echo "Timeout waiting for listener pod with label actions.github.com/scale-set-name=$ARC_NAME"
               exit 1
             fi
             sleep 1
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
-      
+
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
         timeout-minutes: 10
@@ -167,18 +167,18 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
             fi
             if [ "$count" -ge 10 ]; then
-              echo "Timeout waiting for listener pod with label auto-scaling-runner-set-name=$ARC_NAME"
+              echo "Timeout waiting for listener pod with label actions.github.com/scale-set-name=$ARC_NAME"
               exit 1
             fi
             sleep 1
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
       - name: Test ARC E2E
@@ -254,18 +254,18 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
             fi
             if [ "$count" -ge 10 ]; then
-              echo "Timeout waiting for listener pod with label auto-scaling-runner-set-name=$ARC_NAME"
+              echo "Timeout waiting for listener pod with label actions.github.com/scale-set-name=$ARC_NAME"
               exit 1
             fi
             sleep 1
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
       - name: Test ARC E2E
@@ -350,18 +350,18 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
             fi
             if [ "$count" -ge 10 ]; then
-              echo "Timeout waiting for listener pod with label auto-scaling-runner-set-name=$ARC_NAME"
+              echo "Timeout waiting for listener pod with label actions.github.com/scale-set-name=$ARC_NAME"
               exit 1
             fi
             sleep 1
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
       - name: Test ARC E2E
@@ -448,18 +448,18 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
             fi
             if [ "$count" -ge 10 ]; then
-              echo "Timeout waiting for listener pod with label auto-scaling-runner-set-name=$ARC_NAME"
+              echo "Timeout waiting for listener pod with label actions.github.com/scale-set-name=$ARC_NAME"
               exit 1
             fi
             sleep 1
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
       - name: Test ARC E2E
@@ -540,18 +540,18 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
             fi
             if [ "$count" -ge 10 ]; then
-              echo "Timeout waiting for listener pod with label auto-scaling-runner-set-name=$ARC_NAME"
+              echo "Timeout waiting for listener pod with label actions.github.com/scale-set-name=$ARC_NAME"
               exit 1
             fi
             sleep 1
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
       - name: Test ARC E2E

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -40,7 +40,7 @@ helm.sh/chart: {{ include "gha-runner-scale-set.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: gha-runner-scale-set-controller
+app.kubernetes.io/part-of: gha-runner-scale-set
 {{- end }}
 
 {{/*

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "gha-runner-scale-set.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: gha-runner-scale-set-controller
 {{- end }}
 
 {{/*

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -10,6 +10,7 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: "autoscaling-runner-set"
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
 spec:
   githubConfigUrl: {{ required ".Values.githubConfigUrl is required" (trimSuffix "/" .Values.githubConfigUrl) }}

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -311,6 +311,10 @@ func TestTemplateRenderedAutoScalingRunnerSet(t *testing.T) {
 
 	assert.Equal(t, "gha-runner-scale-set", ars.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "test-runners", ars.Labels["app.kubernetes.io/instance"])
+	assert.Equal(t, "gha-runner-scale-set-controller", ars.Labels["app.kubernetes.io/part-of"])
+	assert.Equal(t, "autoscaling-runner-set", ars.Labels["app.kubernetes.io/component"])
+	assert.NotEmpty(t, ars.Labels["app.kubernetes.io/version"])
+
 	assert.Equal(t, "https://github.com/actions", ars.Spec.GitHubConfigUrl)
 	assert.Equal(t, "test-runners-gha-runner-scale-set-github-secret", ars.Spec.GitHubConfigSecret)
 

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -311,7 +311,7 @@ func TestTemplateRenderedAutoScalingRunnerSet(t *testing.T) {
 
 	assert.Equal(t, "gha-runner-scale-set", ars.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "test-runners", ars.Labels["app.kubernetes.io/instance"])
-	assert.Equal(t, "gha-runner-scale-set-controller", ars.Labels["app.kubernetes.io/part-of"])
+	assert.Equal(t, "gha-runner-scale-set", ars.Labels["app.kubernetes.io/part-of"])
 	assert.Equal(t, "autoscaling-runner-set", ars.Labels["app.kubernetes.io/component"])
 	assert.NotEmpty(t, ars.Labels["app.kubernetes.io/version"])
 

--- a/controllers/actions.github.com/autoscalinglistener_controller.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller.go
@@ -523,8 +523,8 @@ func (r *AutoscalingListenerReconciler) createProxySecret(ctx context.Context, a
 			Name:      proxyListenerSecretName(autoscalingListener),
 			Namespace: autoscalingListener.Namespace,
 			Labels: map[string]string{
-				"auto-scaling-runner-set-namespace": autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				"auto-scaling-runner-set-name":      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				LabelKeyGithubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				LabelKeyGithubScaleSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
 			},
 		},
 		Data: data,

--- a/controllers/actions.github.com/autoscalinglistener_controller.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller.go
@@ -523,8 +523,8 @@ func (r *AutoscalingListenerReconciler) createProxySecret(ctx context.Context, a
 			Name:      proxyListenerSecretName(autoscalingListener),
 			Namespace: autoscalingListener.Namespace,
 			Labels: map[string]string{
-				LabelKeyGithubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 				LabelKeyGithubScaleSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyGithubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 			},
 		},
 		Data: data,

--- a/controllers/actions.github.com/autoscalinglistener_controller.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller.go
@@ -523,8 +523,8 @@ func (r *AutoscalingListenerReconciler) createProxySecret(ctx context.Context, a
 			Name:      proxyListenerSecretName(autoscalingListener),
 			Namespace: autoscalingListener.Namespace,
 			Labels: map[string]string{
-				LabelKeyGithubScaleSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				LabelKeyGithubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				LabelKeyGitHubScaleSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyGitHubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 			},
 		},
 		Data: data,

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -364,12 +364,16 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 	if autoscalingRunnerSet.Annotations == nil {
 		autoscalingRunnerSet.Annotations = map[string]string{}
 	}
+	if autoscalingRunnerSet.Labels == nil {
+		autoscalingRunnerSet.Labels = map[string]string{}
+	}
 
-	logger.Info("Adding runner scale set ID, name and runner group name as an annotation")
+	logger.Info("Adding runner scale set ID, name and runner group name as an annotation and url labels")
 	if err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
 		obj.Annotations[runnerScaleSetNameAnnotationKey] = runnerScaleSet.Name
 		obj.Annotations[runnerScaleSetIdAnnotationKey] = strconv.Itoa(runnerScaleSet.Id)
 		obj.Annotations[AnnotationKeyGitHubRunnerGroupName] = runnerScaleSet.RunnerGroupName
+		applyGitHubURLLabels(obj.Spec.GitHubConfigUrl, obj.Labels)
 	}); err != nil {
 		logger.Error(err, "Failed to add runner scale set ID, name and runner group name as an annotation")
 		return ctrl.Result{}, err

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -153,7 +153,7 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	// Make sure the runner group of the scale set is up to date
-	currentRunnerGroupName, ok := autoscalingRunnerSet.Annotations[LabelKeyGithubRunnerGroupName]
+	currentRunnerGroupName, ok := autoscalingRunnerSet.Annotations[LabelKeyGitHubRunnerGroupName]
 	if !ok || (len(autoscalingRunnerSet.Spec.RunnerGroup) > 0 && !strings.EqualFold(currentRunnerGroupName, autoscalingRunnerSet.Spec.RunnerGroup)) {
 		log.Info("AutoScalingRunnerSet runner group changed. Updating the runner scale set.")
 		return r.updateRunnerScaleSetRunnerGroup(ctx, autoscalingRunnerSet, log)
@@ -369,7 +369,7 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 	if err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
 		obj.Annotations[runnerScaleSetNameKey] = runnerScaleSet.Name
 		obj.Annotations[runnerScaleSetIdKey] = strconv.Itoa(runnerScaleSet.Id)
-		obj.Annotations[LabelKeyGithubRunnerGroupName] = runnerScaleSet.RunnerGroupName
+		obj.Annotations[LabelKeyGitHubRunnerGroupName] = runnerScaleSet.RunnerGroupName
 	}); err != nil {
 		logger.Error(err, "Failed to add runner scale set ID, name and runner group name as an annotation")
 		return ctrl.Result{}, err
@@ -414,7 +414,7 @@ func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetRunnerGroup(ctx con
 
 	logger.Info("Updating runner scale set runner group name as an annotation")
 	if err := patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
-		obj.Annotations[LabelKeyGithubRunnerGroupName] = updatedRunnerScaleSet.RunnerGroupName
+		obj.Annotations[LabelKeyGitHubRunnerGroupName] = updatedRunnerScaleSet.RunnerGroupName
 	}); err != nil {
 		logger.Error(err, "Failed to update runner group name annotation")
 		return ctrl.Result{}, err

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -45,8 +45,8 @@ const (
 	autoscalingRunnerSetOwnerKey      = ".metadata.controller"
 	LabelKeyRunnerSpecHash            = "runner-spec-hash"
 	autoscalingRunnerSetFinalizerName = "autoscalingrunnerset.actions.github.com/finalizer"
-	runnerScaleSetIdKey               = "runner-scale-set-id"
-	runnerScaleSetNameKey             = "runner-scale-set-name"
+	runnerScaleSetIdAnnotationKey     = "runner-scale-set-id"
+	runnerScaleSetNameAnnotationKey   = "runner-scale-set-name"
 )
 
 // AutoscalingRunnerSetReconciler reconciles a AutoscalingRunnerSet object
@@ -139,7 +139,7 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, nil
 	}
 
-	scaleSetIdRaw, ok := autoscalingRunnerSet.Annotations[runnerScaleSetIdKey]
+	scaleSetIdRaw, ok := autoscalingRunnerSet.Annotations[runnerScaleSetIdAnnotationKey]
 	if !ok {
 		// Need to create a new runner scale set on Actions service
 		log.Info("Runner scale set id annotation does not exist. Creating a new runner scale set.")
@@ -160,7 +160,7 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	// Make sure the runner scale set name is up to date
-	currentRunnerScaleSetName, ok := autoscalingRunnerSet.Annotations[runnerScaleSetNameKey]
+	currentRunnerScaleSetName, ok := autoscalingRunnerSet.Annotations[runnerScaleSetNameAnnotationKey]
 	if !ok || (len(autoscalingRunnerSet.Spec.RunnerScaleSetName) > 0 && !strings.EqualFold(currentRunnerScaleSetName, autoscalingRunnerSet.Spec.RunnerScaleSetName)) {
 		log.Info("AutoScalingRunnerSet runner scale set name changed. Updating the runner scale set.")
 		return r.updateRunnerScaleSetName(ctx, autoscalingRunnerSet, log)
@@ -367,8 +367,8 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 
 	logger.Info("Adding runner scale set ID, name and runner group name as an annotation")
 	if err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
-		obj.Annotations[runnerScaleSetNameKey] = runnerScaleSet.Name
-		obj.Annotations[runnerScaleSetIdKey] = strconv.Itoa(runnerScaleSet.Id)
+		obj.Annotations[runnerScaleSetNameAnnotationKey] = runnerScaleSet.Name
+		obj.Annotations[runnerScaleSetIdAnnotationKey] = strconv.Itoa(runnerScaleSet.Id)
 		obj.Annotations[LabelKeyGitHubRunnerGroupName] = runnerScaleSet.RunnerGroupName
 	}); err != nil {
 		logger.Error(err, "Failed to add runner scale set ID, name and runner group name as an annotation")
@@ -383,7 +383,7 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 }
 
 func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetRunnerGroup(ctx context.Context, autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet, logger logr.Logger) (ctrl.Result, error) {
-	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdKey])
+	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdAnnotationKey])
 	if err != nil {
 		logger.Error(err, "Failed to parse runner scale set ID")
 		return ctrl.Result{}, err
@@ -425,7 +425,7 @@ func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetRunnerGroup(ctx con
 }
 
 func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetName(ctx context.Context, autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet, logger logr.Logger) (ctrl.Result, error) {
-	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdKey])
+	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdAnnotationKey])
 	if err != nil {
 		logger.Error(err, "Failed to parse runner scale set ID")
 		return ctrl.Result{}, err
@@ -450,7 +450,7 @@ func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetName(ctx context.Co
 
 	logger.Info("Updating runner scale set name as an annotation")
 	if err := patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
-		obj.Annotations[runnerScaleSetNameKey] = updatedRunnerScaleSet.Name
+		obj.Annotations[runnerScaleSetNameAnnotationKey] = updatedRunnerScaleSet.Name
 	}); err != nil {
 		logger.Error(err, "Failed to update runner scale set name annotation")
 		return ctrl.Result{}, err
@@ -462,7 +462,7 @@ func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetName(ctx context.Co
 
 func (r *AutoscalingRunnerSetReconciler) deleteRunnerScaleSet(ctx context.Context, autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet, logger logr.Logger) error {
 	logger.Info("Deleting the runner scale set from Actions service")
-	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdKey])
+	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdAnnotationKey])
 	if err != nil {
 		// If the annotation is not set correctly, or if it does not exist, we are going to get stuck in a loop trying to parse the scale set id.
 		// If the configuration is invalid (secret does not exist for example), we never get to the point to create runner set. But then, manual cleanup

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -153,7 +153,7 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	// Make sure the runner group of the scale set is up to date
-	currentRunnerGroupName, ok := autoscalingRunnerSet.Annotations[LabelKeyGitHubRunnerGroupName]
+	currentRunnerGroupName, ok := autoscalingRunnerSet.Annotations[AnnotationKeyGitHubRunnerGroupName]
 	if !ok || (len(autoscalingRunnerSet.Spec.RunnerGroup) > 0 && !strings.EqualFold(currentRunnerGroupName, autoscalingRunnerSet.Spec.RunnerGroup)) {
 		log.Info("AutoScalingRunnerSet runner group changed. Updating the runner scale set.")
 		return r.updateRunnerScaleSetRunnerGroup(ctx, autoscalingRunnerSet, log)
@@ -369,7 +369,7 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 	if err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
 		obj.Annotations[runnerScaleSetNameAnnotationKey] = runnerScaleSet.Name
 		obj.Annotations[runnerScaleSetIdAnnotationKey] = strconv.Itoa(runnerScaleSet.Id)
-		obj.Annotations[LabelKeyGitHubRunnerGroupName] = runnerScaleSet.RunnerGroupName
+		obj.Annotations[AnnotationKeyGitHubRunnerGroupName] = runnerScaleSet.RunnerGroupName
 	}); err != nil {
 		logger.Error(err, "Failed to add runner scale set ID, name and runner group name as an annotation")
 		return ctrl.Result{}, err
@@ -414,7 +414,7 @@ func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetRunnerGroup(ctx con
 
 	logger.Info("Updating runner scale set runner group name as an annotation")
 	if err := patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
-		obj.Annotations[LabelKeyGitHubRunnerGroupName] = updatedRunnerScaleSet.RunnerGroupName
+		obj.Annotations[AnnotationKeyGitHubRunnerGroupName] = updatedRunnerScaleSet.RunnerGroupName
 	}); err != nil {
 		logger.Error(err, "Failed to update runner group name annotation")
 		return ctrl.Result{}, err

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -47,7 +47,6 @@ const (
 	autoscalingRunnerSetFinalizerName = "autoscalingrunnerset.actions.github.com/finalizer"
 	runnerScaleSetIdKey               = "runner-scale-set-id"
 	runnerScaleSetNameKey             = "runner-scale-set-name"
-	runnerScaleSetRunnerGroupNameKey  = "runner-scale-set-runner-group-name"
 )
 
 // AutoscalingRunnerSetReconciler reconciles a AutoscalingRunnerSet object
@@ -154,7 +153,7 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	// Make sure the runner group of the scale set is up to date
-	currentRunnerGroupName, ok := autoscalingRunnerSet.Annotations[runnerScaleSetRunnerGroupNameKey]
+	currentRunnerGroupName, ok := autoscalingRunnerSet.Annotations[LabelKeyGithubRunnerGroupName]
 	if !ok || (len(autoscalingRunnerSet.Spec.RunnerGroup) > 0 && !strings.EqualFold(currentRunnerGroupName, autoscalingRunnerSet.Spec.RunnerGroup)) {
 		log.Info("AutoScalingRunnerSet runner group changed. Updating the runner scale set.")
 		return r.updateRunnerScaleSetRunnerGroup(ctx, autoscalingRunnerSet, log)
@@ -370,7 +369,7 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 	if err = patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
 		obj.Annotations[runnerScaleSetNameKey] = runnerScaleSet.Name
 		obj.Annotations[runnerScaleSetIdKey] = strconv.Itoa(runnerScaleSet.Id)
-		obj.Annotations[runnerScaleSetRunnerGroupNameKey] = runnerScaleSet.RunnerGroupName
+		obj.Annotations[LabelKeyGithubRunnerGroupName] = runnerScaleSet.RunnerGroupName
 	}); err != nil {
 		logger.Error(err, "Failed to add runner scale set ID, name and runner group name as an annotation")
 		return ctrl.Result{}, err
@@ -415,7 +414,7 @@ func (r *AutoscalingRunnerSetReconciler) updateRunnerScaleSetRunnerGroup(ctx con
 
 	logger.Info("Updating runner scale set runner group name as an annotation")
 	if err := patch(ctx, r.Client, autoscalingRunnerSet, func(obj *v1alpha1.AutoscalingRunnerSet) {
-		obj.Annotations[runnerScaleSetRunnerGroupNameKey] = updatedRunnerScaleSet.RunnerGroupName
+		obj.Annotations[LabelKeyGithubRunnerGroupName] = updatedRunnerScaleSet.RunnerGroupName
 	}); err != nil {
 		logger.Error(err, "Failed to update runner group name annotation")
 		return ctrl.Result{}, err

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -373,7 +373,9 @@ func (r *AutoscalingRunnerSetReconciler) createRunnerScaleSet(ctx context.Contex
 		obj.Annotations[runnerScaleSetNameAnnotationKey] = runnerScaleSet.Name
 		obj.Annotations[runnerScaleSetIdAnnotationKey] = strconv.Itoa(runnerScaleSet.Id)
 		obj.Annotations[AnnotationKeyGitHubRunnerGroupName] = runnerScaleSet.RunnerGroupName
-		applyGitHubURLLabels(obj.Spec.GitHubConfigUrl, obj.Labels)
+		if err := applyGitHubURLLabels(obj.Spec.GitHubConfigUrl, obj.Labels); err != nil { // should never happen
+			logger.Error(err, "Failed to apply GitHub URL labels")
+		}
 	}); err != nil {
 		logger.Error(err, "Failed to add runner scale set ID, name and runner group name as an annotation")
 		return ctrl.Result{}, err

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -130,6 +130,26 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("1_testgroup"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's annotation")
 
+			Eventually(
+				func() (string, error) {
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: autoscalingRunnerSet.Name, Namespace: autoscalingRunnerSet.Namespace}, created)
+					if err != nil {
+						return "", err
+					}
+
+					if _, ok := created.Labels[LabelKeyGitHubOrganization]; !ok {
+						return "", nil
+					}
+
+					if _, ok := created.Labels[LabelKeyGitHubRepository]; !ok {
+						return "", nil
+					}
+
+					return fmt.Sprintf("%s/%s", created.Labels[LabelKeyGitHubOrganization], created.Labels[LabelKeyGitHubRepository]), nil
+				},
+				autoscalingRunnerSetTestTimeout,
+				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("owner/repo"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's label")
+
 			// Check if ephemeral runner set is created
 			Eventually(
 				func() (int, error) {

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", err
 					}
 
-					if _, ok := created.Annotations[runnerScaleSetIdKey]; !ok {
+					if _, ok := created.Annotations[runnerScaleSetIdAnnotationKey]; !ok {
 						return "", nil
 					}
 
@@ -125,7 +125,7 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", nil
 					}
 
-					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdKey], created.Annotations[LabelKeyGitHubRunnerGroupName]), nil
+					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdAnnotationKey], created.Annotations[LabelKeyGitHubRunnerGroupName]), nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("1_testgroup"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's annotation")
@@ -539,7 +539,7 @@ var _ = Describe("Test AutoScalingController updates", func() {
 						return "", err
 					}
 
-					if val, ok := ars.Annotations[runnerScaleSetNameKey]; ok {
+					if val, ok := ars.Annotations[runnerScaleSetNameAnnotationKey]; ok {
 						return val, nil
 					}
 
@@ -562,7 +562,7 @@ var _ = Describe("Test AutoScalingController updates", func() {
 						return "", err
 					}
 
-					if val, ok := ars.Annotations[runnerScaleSetNameKey]; ok {
+					if val, ok := ars.Annotations[runnerScaleSetNameAnnotationKey]; ok {
 						return val, nil
 					}
 

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -121,11 +121,11 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", nil
 					}
 
-					if _, ok := created.Annotations[LabelKeyGithubRunnerGroupName]; !ok {
+					if _, ok := created.Annotations[LabelKeyGitHubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdKey], created.Annotations[LabelKeyGithubRunnerGroupName]), nil
+					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdKey], created.Annotations[LabelKeyGitHubRunnerGroupName]), nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("1_testgroup"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's annotation")
@@ -351,18 +351,18 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", err
 					}
 
-					if _, ok := updated.Annotations[LabelKeyGithubRunnerGroupName]; !ok {
+					if _, ok := updated.Annotations[LabelKeyGitHubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return updated.Annotations[LabelKeyGithubRunnerGroupName], nil
+					return updated.Annotations[LabelKeyGitHubRunnerGroupName], nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("testgroup2"), "AutoScalingRunnerSet should have the new runner group in its annotation")
 
 			// delete the annotation and it should be re-added
 			patched = autoscalingRunnerSet.DeepCopy()
-			delete(patched.Annotations, LabelKeyGithubRunnerGroupName)
+			delete(patched.Annotations, LabelKeyGitHubRunnerGroupName)
 			err = k8sClient.Patch(ctx, patched, client.MergeFrom(autoscalingRunnerSet))
 			Expect(err).NotTo(HaveOccurred(), "failed to patch AutoScalingRunnerSet")
 
@@ -374,11 +374,11 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", err
 					}
 
-					if _, ok := updated.Annotations[LabelKeyGithubRunnerGroupName]; !ok {
+					if _, ok := updated.Annotations[LabelKeyGitHubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return updated.Annotations[LabelKeyGithubRunnerGroupName], nil
+					return updated.Annotations[LabelKeyGitHubRunnerGroupName], nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval,

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -121,11 +121,11 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", nil
 					}
 
-					if _, ok := created.Annotations[runnerScaleSetRunnerGroupNameKey]; !ok {
+					if _, ok := created.Annotations[LabelKeyGithubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdKey], created.Annotations[runnerScaleSetRunnerGroupNameKey]), nil
+					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdKey], created.Annotations[LabelKeyGithubRunnerGroupName]), nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("1_testgroup"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's annotation")
@@ -351,18 +351,18 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", err
 					}
 
-					if _, ok := updated.Annotations[runnerScaleSetRunnerGroupNameKey]; !ok {
+					if _, ok := updated.Annotations[LabelKeyGithubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return updated.Annotations[runnerScaleSetRunnerGroupNameKey], nil
+					return updated.Annotations[LabelKeyGithubRunnerGroupName], nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("testgroup2"), "AutoScalingRunnerSet should have the new runner group in its annotation")
 
 			// delete the annotation and it should be re-added
 			patched = autoscalingRunnerSet.DeepCopy()
-			delete(patched.Annotations, runnerScaleSetRunnerGroupNameKey)
+			delete(patched.Annotations, LabelKeyGithubRunnerGroupName)
 			err = k8sClient.Patch(ctx, patched, client.MergeFrom(autoscalingRunnerSet))
 			Expect(err).NotTo(HaveOccurred(), "failed to patch AutoScalingRunnerSet")
 
@@ -374,11 +374,11 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", err
 					}
 
-					if _, ok := updated.Annotations[runnerScaleSetRunnerGroupNameKey]; !ok {
+					if _, ok := updated.Annotations[LabelKeyGithubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return updated.Annotations[runnerScaleSetRunnerGroupNameKey], nil
+					return updated.Annotations[LabelKeyGithubRunnerGroupName], nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval,

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -121,11 +121,11 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", nil
 					}
 
-					if _, ok := created.Annotations[LabelKeyGitHubRunnerGroupName]; !ok {
+					if _, ok := created.Annotations[AnnotationKeyGitHubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdAnnotationKey], created.Annotations[LabelKeyGitHubRunnerGroupName]), nil
+					return fmt.Sprintf("%s_%s", created.Annotations[runnerScaleSetIdAnnotationKey], created.Annotations[AnnotationKeyGitHubRunnerGroupName]), nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("1_testgroup"), "RunnerScaleSet should be created/fetched and update the AutoScalingRunnerSet's annotation")
@@ -351,18 +351,18 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", err
 					}
 
-					if _, ok := updated.Annotations[LabelKeyGitHubRunnerGroupName]; !ok {
+					if _, ok := updated.Annotations[AnnotationKeyGitHubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return updated.Annotations[LabelKeyGitHubRunnerGroupName], nil
+					return updated.Annotations[AnnotationKeyGitHubRunnerGroupName], nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval).Should(BeEquivalentTo("testgroup2"), "AutoScalingRunnerSet should have the new runner group in its annotation")
 
 			// delete the annotation and it should be re-added
 			patched = autoscalingRunnerSet.DeepCopy()
-			delete(patched.Annotations, LabelKeyGitHubRunnerGroupName)
+			delete(patched.Annotations, AnnotationKeyGitHubRunnerGroupName)
 			err = k8sClient.Patch(ctx, patched, client.MergeFrom(autoscalingRunnerSet))
 			Expect(err).NotTo(HaveOccurred(), "failed to patch AutoScalingRunnerSet")
 
@@ -374,11 +374,11 @@ var _ = Describe("Test AutoScalingRunnerSet controller", func() {
 						return "", err
 					}
 
-					if _, ok := updated.Annotations[LabelKeyGitHubRunnerGroupName]; !ok {
+					if _, ok := updated.Annotations[AnnotationKeyGitHubRunnerGroupName]; !ok {
 						return "", nil
 					}
 
-					return updated.Annotations[LabelKeyGitHubRunnerGroupName], nil
+					return updated.Annotations[AnnotationKeyGitHubRunnerGroupName], nil
 				},
 				autoscalingRunnerSetTestTimeout,
 				autoscalingRunnerSetTestInterval,

--- a/controllers/actions.github.com/ephemeralrunnerset_controller.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller.go
@@ -356,10 +356,9 @@ func (r *EphemeralRunnerSetReconciler) createProxySecret(ctx context.Context, ep
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      proxyEphemeralRunnerSetSecretName(ephemeralRunnerSet),
 			Namespace: ephemeralRunnerSet.Namespace,
-			Labels:    map[string]string{
-				// TODO: figure out autoScalingRunnerSet name and set it as a label for this secret
-				// "auto-scaling-runner-set-namespace": ephemeralRunnerSet.Namespace,
-				// "auto-scaling-runner-set-name": ephemeralRunnerSet.Name,
+			Labels: map[string]string{
+				LabelKeyGitHubScaleSetName:      ephemeralRunnerSet.Labels[LabelKeyGitHubScaleSetName],
+				LabelKeyGitHubScaleSetNamespace: ephemeralRunnerSet.Labels[LabelKeyGitHubScaleSetNamespace],
 			},
 		},
 		Data: proxySecretData,

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -181,7 +181,7 @@ func (b *resourceBuilder) newScaleSetListenerPod(autoscalingListener *v1alpha1.A
 }
 
 func (b *resourceBuilder) newEphemeralRunnerSet(autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet) (*v1alpha1.EphemeralRunnerSet, error) {
-	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdKey])
+	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdAnnotationKey])
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +318,7 @@ func (b *resourceBuilder) newScaleSetListenerSecretMirror(autoscalingListener *v
 }
 
 func (b *resourceBuilder) newAutoScalingListener(autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet, ephemeralRunnerSet *v1alpha1.EphemeralRunnerSet, namespace, image string, imagePullSecrets []corev1.LocalObjectReference) (*v1alpha1.AutoscalingListener, error) {
-	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdKey])
+	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdAnnotationKey])
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -28,7 +28,7 @@ const (
 	LabelKeyKubernetesVersion   = "app.kubernetes.io/version"
 
 	// Github labels
-	LabelKeyGithubScaleSetName      = "actions.github.com/scale-set-name" //"auto-scaling-runner-set-name"
+	LabelKeyGithubScaleSetName      = "actions.github.com/scale-set-name"
 	LabelKeyGithubScaleSetNamespace = "actions.github.com/scale-set-namespace"
 	LabelKeyGithubEnterprise        = "actions.github.com/enterprise"
 	LabelKeyGithubOrganization      = "actions.github.com/organization"

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -36,6 +36,12 @@ const (
 	LabelKeyGitHubRunnerGroupName   = "actions.github.com/runner-group-name"
 )
 
+// Labels applied to listener roles
+const (
+	labelKeyListenerName      = "auto-scaling-listener-name"
+	labelKeyListenerNamespace = "auto-scaling-listener-namespace"
+)
+
 var commonLabelKeys = [...]string{
 	LabelKeyKubernetesPartOf,
 	LabelKeyKubernetesComponent,
@@ -243,11 +249,11 @@ func (b *resourceBuilder) newScaleSetListenerRole(autoscalingListener *v1alpha1.
 			Name:      scaleSetListenerRoleName(autoscalingListener),
 			Namespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
 			Labels: map[string]string{
-				LabelKeyGitHubScaleSetNamespace:   autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				LabelKeyGitHubScaleSetName:        autoscalingListener.Spec.AutoscalingRunnerSetName,
-				"auto-scaling-listener-namespace": autoscalingListener.Namespace,
-				"auto-scaling-listener-name":      autoscalingListener.Name,
-				"role-policy-rules-hash":          rulesHash,
+				LabelKeyGitHubScaleSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyGitHubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				labelKeyListenerNamespace:       autoscalingListener.Namespace,
+				labelKeyListenerName:            autoscalingListener.Name,
+				"role-policy-rules-hash":        rulesHash,
 			},
 		},
 		Rules: rules,
@@ -277,12 +283,12 @@ func (b *resourceBuilder) newScaleSetListenerRoleBinding(autoscalingListener *v1
 			Name:      scaleSetListenerRoleName(autoscalingListener),
 			Namespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
 			Labels: map[string]string{
-				LabelKeyGitHubScaleSetNamespace:   autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
-				LabelKeyGitHubScaleSetName:        autoscalingListener.Spec.AutoscalingRunnerSetName,
-				"auto-scaling-listener-namespace": autoscalingListener.Namespace,
-				"auto-scaling-listener-name":      autoscalingListener.Name,
-				"role-binding-role-ref-hash":      roleRefHash,
-				"role-binding-subject-hash":       subjectHash,
+				LabelKeyGitHubScaleSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
+				LabelKeyGitHubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
+				labelKeyListenerNamespace:       autoscalingListener.Namespace,
+				labelKeyListenerName:            autoscalingListener.Name,
+				"role-binding-role-ref-hash":    roleRefHash,
+				"role-binding-subject-hash":     subjectHash,
 			},
 		},
 		RoleRef:  roleRef,

--- a/controllers/actions.github.com/resourcebuilder_test.go
+++ b/controllers/actions.github.com/resourcebuilder_test.go
@@ -1,0 +1,92 @@
+package actionsgithubcom
+
+import (
+	"context"
+	"testing"
+
+	"github.com/actions/actions-runner-controller/apis/actions.github.com/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLabelPropagation(t *testing.T) {
+	autoscalingRunnerSet := v1alpha1.AutoscalingRunnerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-scale-set",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				LabelKeyKubernetesPartOf:      labelValueKubernetesPartOf,
+				LabelKeyKubernetesVersion:     "0.2.0",
+				LabelKeyGithubRunnerGroupName: "test-group",
+			},
+			Annotations: map[string]string{
+				runnerScaleSetIdKey: "1",
+			},
+		},
+		Spec: v1alpha1.AutoscalingRunnerSetSpec{
+			GitHubConfigUrl: "https://github.com/org/repo",
+		},
+	}
+
+	var b resourceBuilder
+	ephemeralRunnerSet, err := b.newEphemeralRunnerSet(&autoscalingRunnerSet)
+	require.NoError(t, err)
+	assert.Equal(t, labelValueKubernetesPartOf, ephemeralRunnerSet.Labels[LabelKeyKubernetesPartOf])
+	assert.Equal(t, "runner-set", ephemeralRunnerSet.Labels[LabelKeyKubernetesComponent])
+	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion], ephemeralRunnerSet.Labels[LabelKeyKubernetesVersion])
+	assert.NotEmpty(t, ephemeralRunnerSet.Labels[LabelKeyRunnerSpecHash])
+	assert.Equal(t, autoscalingRunnerSet.Name, ephemeralRunnerSet.Labels[LabelKeyGithubScaleSetName])
+	assert.Equal(t, autoscalingRunnerSet.Namespace, ephemeralRunnerSet.Labels[LabelKeyGithubScaleSetNamespace])
+	assert.Equal(t, "", ephemeralRunnerSet.Labels[LabelKeyGithubEnterprise])
+	assert.Equal(t, "org", ephemeralRunnerSet.Labels[LabelKeyGithubOrganization])
+	assert.Equal(t, "repo", ephemeralRunnerSet.Labels[LabelKeyGithubRepository])
+	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyGithubRunnerGroupName], ephemeralRunnerSet.Labels[LabelKeyGithubRunnerGroupName])
+
+	listener, err := b.newAutoScalingListener(&autoscalingRunnerSet, ephemeralRunnerSet, autoscalingRunnerSet.Namespace, "test:latest", nil)
+	require.NoError(t, err)
+	assert.Equal(t, labelValueKubernetesPartOf, listener.Labels[LabelKeyKubernetesPartOf])
+	assert.Equal(t, "runner-scale-set-listener", listener.Labels[LabelKeyKubernetesComponent])
+	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion], listener.Labels[LabelKeyKubernetesVersion])
+	assert.NotEmpty(t, ephemeralRunnerSet.Labels[LabelKeyRunnerSpecHash])
+	assert.Equal(t, autoscalingRunnerSet.Name, listener.Labels[LabelKeyGithubScaleSetName])
+	assert.Equal(t, autoscalingRunnerSet.Namespace, listener.Labels[LabelKeyGithubScaleSetNamespace])
+	assert.Equal(t, "", listener.Labels[LabelKeyGithubEnterprise])
+	assert.Equal(t, "org", listener.Labels[LabelKeyGithubOrganization])
+	assert.Equal(t, "repo", listener.Labels[LabelKeyGithubRepository])
+
+	listenerServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+	listenerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+	listenerPod := b.newScaleSetListenerPod(listener, listenerServiceAccount, listenerSecret)
+	assert.Equal(t, listenerPod.Labels, listener.Labels)
+
+	ephemeralRunner := b.newEphemeralRunner(ephemeralRunnerSet)
+	require.NoError(t, err)
+
+	for _, key := range append(commonLabelKeys[:], LabelKeyGithubRunnerGroupName) {
+		if key == LabelKeyKubernetesComponent {
+			continue
+		}
+		assert.Equal(t, ephemeralRunnerSet.Labels[key], ephemeralRunner.Labels[key])
+	}
+	assert.Equal(t, "runner", ephemeralRunner.Labels[LabelKeyKubernetesComponent])
+
+	runnerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+	pod := b.newEphemeralRunnerPod(context.TODO(), ephemeralRunner, runnerSecret)
+	for key := range ephemeralRunner.Labels {
+		assert.Equal(t, ephemeralRunner.Labels[key], pod.Labels[key])
+	}
+}

--- a/controllers/actions.github.com/resourcebuilder_test.go
+++ b/controllers/actions.github.com/resourcebuilder_test.go
@@ -17,12 +17,12 @@ func TestLabelPropagation(t *testing.T) {
 			Name:      "test-scale-set",
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				LabelKeyKubernetesPartOf:      labelValueKubernetesPartOf,
-				LabelKeyKubernetesVersion:     "0.2.0",
-				LabelKeyGitHubRunnerGroupName: "test-group",
+				LabelKeyKubernetesPartOf:  labelValueKubernetesPartOf,
+				LabelKeyKubernetesVersion: "0.2.0",
 			},
 			Annotations: map[string]string{
-				runnerScaleSetIdAnnotationKey: "1",
+				runnerScaleSetIdAnnotationKey:      "1",
+				AnnotationKeyGitHubRunnerGroupName: "test-group",
 			},
 		},
 		Spec: v1alpha1.AutoscalingRunnerSetSpec{
@@ -42,7 +42,7 @@ func TestLabelPropagation(t *testing.T) {
 	assert.Equal(t, "", ephemeralRunnerSet.Labels[LabelKeyGitHubEnterprise])
 	assert.Equal(t, "org", ephemeralRunnerSet.Labels[LabelKeyGitHubOrganization])
 	assert.Equal(t, "repo", ephemeralRunnerSet.Labels[LabelKeyGitHubRepository])
-	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyGitHubRunnerGroupName], ephemeralRunnerSet.Labels[LabelKeyGitHubRunnerGroupName])
+	assert.Equal(t, autoscalingRunnerSet.Annotations[AnnotationKeyGitHubRunnerGroupName], ephemeralRunnerSet.Annotations[AnnotationKeyGitHubRunnerGroupName])
 
 	listener, err := b.newAutoScalingListener(&autoscalingRunnerSet, ephemeralRunnerSet, autoscalingRunnerSet.Namespace, "test:latest", nil)
 	require.NoError(t, err)
@@ -72,13 +72,14 @@ func TestLabelPropagation(t *testing.T) {
 	ephemeralRunner := b.newEphemeralRunner(ephemeralRunnerSet)
 	require.NoError(t, err)
 
-	for _, key := range append(commonLabelKeys[:], LabelKeyGitHubRunnerGroupName) {
+	for _, key := range commonLabelKeys {
 		if key == LabelKeyKubernetesComponent {
 			continue
 		}
 		assert.Equal(t, ephemeralRunnerSet.Labels[key], ephemeralRunner.Labels[key])
 	}
 	assert.Equal(t, "runner", ephemeralRunner.Labels[LabelKeyKubernetesComponent])
+	assert.Equal(t, autoscalingRunnerSet.Annotations[AnnotationKeyGitHubRunnerGroupName], ephemeralRunner.Annotations[AnnotationKeyGitHubRunnerGroupName])
 
 	runnerSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/actions.github.com/resourcebuilder_test.go
+++ b/controllers/actions.github.com/resourcebuilder_test.go
@@ -22,7 +22,7 @@ func TestLabelPropagation(t *testing.T) {
 				LabelKeyGitHubRunnerGroupName: "test-group",
 			},
 			Annotations: map[string]string{
-				runnerScaleSetIdKey: "1",
+				runnerScaleSetIdAnnotationKey: "1",
 			},
 		},
 		Spec: v1alpha1.AutoscalingRunnerSetSpec{

--- a/controllers/actions.github.com/resourcebuilder_test.go
+++ b/controllers/actions.github.com/resourcebuilder_test.go
@@ -19,7 +19,7 @@ func TestLabelPropagation(t *testing.T) {
 			Labels: map[string]string{
 				LabelKeyKubernetesPartOf:      labelValueKubernetesPartOf,
 				LabelKeyKubernetesVersion:     "0.2.0",
-				LabelKeyGithubRunnerGroupName: "test-group",
+				LabelKeyGitHubRunnerGroupName: "test-group",
 			},
 			Annotations: map[string]string{
 				runnerScaleSetIdKey: "1",
@@ -37,12 +37,12 @@ func TestLabelPropagation(t *testing.T) {
 	assert.Equal(t, "runner-set", ephemeralRunnerSet.Labels[LabelKeyKubernetesComponent])
 	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion], ephemeralRunnerSet.Labels[LabelKeyKubernetesVersion])
 	assert.NotEmpty(t, ephemeralRunnerSet.Labels[LabelKeyRunnerSpecHash])
-	assert.Equal(t, autoscalingRunnerSet.Name, ephemeralRunnerSet.Labels[LabelKeyGithubScaleSetName])
-	assert.Equal(t, autoscalingRunnerSet.Namespace, ephemeralRunnerSet.Labels[LabelKeyGithubScaleSetNamespace])
-	assert.Equal(t, "", ephemeralRunnerSet.Labels[LabelKeyGithubEnterprise])
-	assert.Equal(t, "org", ephemeralRunnerSet.Labels[LabelKeyGithubOrganization])
-	assert.Equal(t, "repo", ephemeralRunnerSet.Labels[LabelKeyGithubRepository])
-	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyGithubRunnerGroupName], ephemeralRunnerSet.Labels[LabelKeyGithubRunnerGroupName])
+	assert.Equal(t, autoscalingRunnerSet.Name, ephemeralRunnerSet.Labels[LabelKeyGitHubScaleSetName])
+	assert.Equal(t, autoscalingRunnerSet.Namespace, ephemeralRunnerSet.Labels[LabelKeyGitHubScaleSetNamespace])
+	assert.Equal(t, "", ephemeralRunnerSet.Labels[LabelKeyGitHubEnterprise])
+	assert.Equal(t, "org", ephemeralRunnerSet.Labels[LabelKeyGitHubOrganization])
+	assert.Equal(t, "repo", ephemeralRunnerSet.Labels[LabelKeyGitHubRepository])
+	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyGitHubRunnerGroupName], ephemeralRunnerSet.Labels[LabelKeyGitHubRunnerGroupName])
 
 	listener, err := b.newAutoScalingListener(&autoscalingRunnerSet, ephemeralRunnerSet, autoscalingRunnerSet.Namespace, "test:latest", nil)
 	require.NoError(t, err)
@@ -50,11 +50,11 @@ func TestLabelPropagation(t *testing.T) {
 	assert.Equal(t, "runner-scale-set-listener", listener.Labels[LabelKeyKubernetesComponent])
 	assert.Equal(t, autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion], listener.Labels[LabelKeyKubernetesVersion])
 	assert.NotEmpty(t, ephemeralRunnerSet.Labels[LabelKeyRunnerSpecHash])
-	assert.Equal(t, autoscalingRunnerSet.Name, listener.Labels[LabelKeyGithubScaleSetName])
-	assert.Equal(t, autoscalingRunnerSet.Namespace, listener.Labels[LabelKeyGithubScaleSetNamespace])
-	assert.Equal(t, "", listener.Labels[LabelKeyGithubEnterprise])
-	assert.Equal(t, "org", listener.Labels[LabelKeyGithubOrganization])
-	assert.Equal(t, "repo", listener.Labels[LabelKeyGithubRepository])
+	assert.Equal(t, autoscalingRunnerSet.Name, listener.Labels[LabelKeyGitHubScaleSetName])
+	assert.Equal(t, autoscalingRunnerSet.Namespace, listener.Labels[LabelKeyGitHubScaleSetNamespace])
+	assert.Equal(t, "", listener.Labels[LabelKeyGitHubEnterprise])
+	assert.Equal(t, "org", listener.Labels[LabelKeyGitHubOrganization])
+	assert.Equal(t, "repo", listener.Labels[LabelKeyGitHubRepository])
 
 	listenerServiceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -72,7 +72,7 @@ func TestLabelPropagation(t *testing.T) {
 	ephemeralRunner := b.newEphemeralRunner(ephemeralRunnerSet)
 	require.NoError(t, err)
 
-	for _, key := range append(commonLabelKeys[:], LabelKeyGithubRunnerGroupName) {
+	for _, key := range append(commonLabelKeys[:], LabelKeyGitHubRunnerGroupName) {
 		if key == LabelKeyKubernetesComponent {
 			continue
 		}

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -160,7 +160,7 @@ You can check the logs of the controller pod using the following command:
 $ kubectl logs -n "${NAMESPACE}" -l app.kubernetes.io/name=gha-runner-scale-set-controller
 
 # Runner set listener logs
-kubectl logs -n "${NAMESPACE}" -l auto-scaling-runner-set-namespace=arc-systems -l auto-scaling-runner-set-name=arc-runner-set
+kubectl logs -n "${NAMESPACE}" -l actions.github.com/scale-set-namespace=arc-systems -l actions.github.com/scale-set-name=arc-runner-set
 ```
 
 ### Naming error: `Name must have up to characters`


### PR DESCRIPTION
Fixes https://github.com/github/c2c-actions-runtime/issues/2175

Addressing ADR: https://github.com/actions/actions-runner-controller/blob/master/adrs/2022-12-05-adding-labels-k8s-resources.md