### PR TITLE
Allow customization of admission webhook timeout

### DIFF
--- a/acceptance/deploy.sh
+++ b/acceptance/deploy.sh
@@ -69,6 +69,9 @@ if [ "${tool}" == "helm" ]; then
     flags+=( --set githubWebhookServer.logFormat=${LOG_FORMAT})
     flags+=( --set actionsMetricsServer.logFormat=${LOG_FORMAT})
   fi
+  if [ "${ADMISSION_WEBHOOKS_TIMEOUT}" != "" ]; then
+    flags+=( --set admissionWebHooks.timeoutSeconds=${ADMISSION_WEBHOOKS_TIMEOUT})
+  fi
   if [ -n "${CREATE_SECRETS_USING_HELM}" ]; then
     if [ -z "${WEBHOOK_GITHUB_TOKEN}" ]; then
       echo 'Failed deploying secret "actions-metrics-server" using helm. Set WEBHOOK_GITHUB_TOKEN to deploy.' 1>&2

--- a/charts/actions-runner-controller/templates/webhook_configs.yaml
+++ b/charts/actions-runner-controller/templates/webhook_configs.yaml
@@ -44,6 +44,7 @@ webhooks:
     resources:
     - runners
   sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebHooks.timeoutSeconds | default 10}}
 - admissionReviewVersions:
   - v1beta1
   {{- if .Values.scope.singleNamespace }}
@@ -74,6 +75,7 @@ webhooks:
     resources:
     - runnerdeployments
   sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebHooks.timeoutSeconds | default 10}}
 - admissionReviewVersions:
   - v1beta1
   {{- if .Values.scope.singleNamespace }}
@@ -104,6 +106,7 @@ webhooks:
     resources:
     - runnerreplicasets
   sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebHooks.timeoutSeconds | default 10}}
 - admissionReviewVersions:
   - v1beta1
   {{- if .Values.scope.singleNamespace }}
@@ -136,6 +139,7 @@ webhooks:
   objectSelector:
     matchLabels:
       "actions-runner-controller/inject-registration-token": "true"
+  timeoutSeconds: {{ .Values.admissionWebHooks.timeoutSeconds | default 10}}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -177,6 +181,7 @@ webhooks:
     resources:
     - runners
   sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebHooks.timeoutSeconds | default 10}}
 - admissionReviewVersions:
   - v1beta1
   {{- if .Values.scope.singleNamespace }}
@@ -207,6 +212,7 @@ webhooks:
     resources:
     - runnerdeployments
   sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebHooks.timeoutSeconds | default 10}}
 - admissionReviewVersions:
   - v1beta1
   {{- if .Values.scope.singleNamespace }}
@@ -238,6 +244,7 @@ webhooks:
     - runnerreplicasets
   sideEffects: None
 {{ if not (or (hasKey .Values.admissionWebHooks "caBundle") .Values.certManagerEnabled) }}
+  timeoutSeconds: {{ .Values.admissionWebHooks.timeoutSeconds | default 10}}
 ---
 apiVersion: v1
 kind: Secret

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -413,6 +413,7 @@ type env struct {
 	runnerNamespace                             string
 	logFormat                                   string
 	remoteKubeconfig                            string
+	admissionWebhooksTimeout                    string
 	imagePullSecretName                         string
 	imagePullPolicy                             string
 
@@ -547,6 +548,7 @@ func initTestEnv(t *testing.T, k8sMinorVer string, vars vars) *env {
 	e.runnerNamespace = testing.Getenv(t, "TEST_RUNNER_NAMESPACE", "default")
 	e.logFormat = testing.Getenv(t, "ARC_E2E_LOG_FORMAT", "")
 	e.remoteKubeconfig = testing.Getenv(t, "ARC_E2E_REMOTE_KUBECONFIG", "")
+	e.admissionWebhooksTimeout = testing.Getenv(t, "ARC_E2E_ADMISSION_WEBHOOKS_TIMEOUT", "")
 	e.imagePullSecretName = testing.Getenv(t, "ARC_E2E_IMAGE_PULL_SECRET_NAME", "")
 	e.vars = vars
 
@@ -724,6 +726,7 @@ func (e *env) installActionsRunnerController(t *testing.T, repo, tag, testID, ch
 		"TEST_ID=" + testID,
 		"NAME=" + repo,
 		"VERSION=" + tag,
+		"ADMISSION_WEBHOOKS_TIMEOUT=" + e.admissionWebhooksTimeout,
 		"IMAGE_PULL_SECRET=" + e.imagePullSecretName,
 		"IMAGE_PULL_POLICY=" + e.imagePullPolicy,
 	}


### PR DESCRIPTION
This allows users to specify the timeout for the admission webhooks, while defaulting to the normal Kubernetes default of 10s if not set.

I've run into this issue a few times while attempting to deploy, 10s sometimes seems a bit too short and the deploy fails.