### PR TITLE
Prevent releases on wrong tag name

### DIFF
--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -29,6 +29,10 @@ jobs:
   release-controller:
     name: Release
     runs-on: ubuntu-latest
+    # gha-runner-scale-set has its own release workflow.
+    # We don't want to publish a new actions-runner-controller image 
+    # we release gha-runner-scale-set.
+    if: ${{ !startsWith(github.event.inputs.release_tag_name, 'gha-runner-scale-set-') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Context

We want to tag & create releases for `gha-runner-scale-set` but without triggering the `publish-arc` workflow. This fixes that.