### PR TITLE
Fix GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/update-runners.yaml
+++ b/.github/workflows/update-runners.yaml
@@ -77,6 +77,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+      actions: write
     env:
       GH_TOKEN: ${{ github.token }}
       CURRENT_VERSION: ${{ needs.check_versions.outputs.current_version }}


### PR DESCRIPTION
### Context

The workflow is failing with this error:

```
[update-runner-2.303.0 243913c] Update runner to version 2.303.0
 5 files changed, 5 insertions(+), 5 deletions(-)
To https://github.com/actions/actions-runner-controller
 ! [remote rejected] HEAD -> update-runner-2.303.0 (refusing to allow a GitHub App to create or update workflow `.github/workflows/e2e-test-linux-vm.yaml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/actions/actions-runner-controller'
Error: Process completed with exit code 1.
```

This added permission is an attempt to solve the problem.