### PR TITLE
Fix helm chart rendering errors.

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -20,4 +20,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           only-new-issues: true
-          version: v1.49.0
+          version: v1.51.1

--- a/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
@@ -59,16 +59,16 @@ Create the name of the service account to use
 */}}
 {{- define "gha-runner-scale-set-controller.serviceAccountName" -}}
 {{- if eq .Values.serviceAccount.name "default"}}
-{{- fail "serviceAccount.name cannot be set to 'default'" }}
+  {{- fail "serviceAccount.name cannot be set to 'default'" }}
 {{- end }}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "gha-runner-scale-set-controller.fullname" .) .Values.serviceAccount.name }}
+  {{- default (include "gha-runner-scale-set-controller.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-    {{- if not .Values.serviceAccount.name }}
-{{- fail "serviceAccount.name must be set if serviceAccount.create is false" }}
-    {{- else }}
-{{- .Values.serviceAccount.name }}
-    {{- end }}
+  {{- if not .Values.serviceAccount.name }}
+    {{- fail "serviceAccount.name must be set if serviceAccount.create is false" }}
+  {{- else }}
+    {{- .Values.serviceAccount.name }}
+  {{- end }}
 {{- end }}
 {{- end }}
 
@@ -107,7 +107,7 @@ Create the name of the service account to use
 {{- define "gha-runner-scale-set-controller.imagePullSecretsNames" -}}
 {{- $names := list }}
 {{- range $k, $v := . }}
-{{- $names = append $names $v.name }}
+  {{- $names = append $names $v.name }}
 {{- end }}
 {{- $names | join ","}}
 {{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/leader_election_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/leader_election_role.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int (default 1 .Values.replicaCount)) 1 -}}
+{{- if gt (int (default 1 .Values.replicaCount)) 1 }}
 # permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/gha-runner-scale-set-controller/templates/leader_election_role_binding.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/leader_election_role_binding.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int (default 1 .Values.replicaCount)) 1 -}}
+{{- if gt (int (default 1 .Values.replicaCount)) 1 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/gha-runner-scale-set-controller/templates/serviceaccount.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -75,19 +75,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-init-container" -}}
-{{- range $i, $val := .Values.template.spec.containers -}}
-{{- if eq $val.name "runner" -}}
+{{- range $i, $val := .Values.template.spec.containers }}
+  {{- if eq $val.name "runner" }}
 image: {{ $val.image }}
-{{- if $val.imagePullSecrets }}
-imagePullSecrets:
-  {{ $val.imagePullSecrets | toYaml -}}
-{{- end }}
 command: ["cp"]
 args: ["-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
 volumeMounts:
   - name: dind-externals
     mountPath: /home/runner/tmpDir
-{{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 
@@ -124,7 +120,7 @@ volumeMounts:
 {{- $createWorkVolume := 1 }}
   {{- range $i, $volume := .Values.template.spec.volumes }}
     {{- if eq $volume.name "work" }}
-      {{- $createWorkVolume = 0 -}}
+      {{- $createWorkVolume = 0 }}
 - {{ $volume | toYaml | nindent 2 }}
     {{- end }}
   {{- end }}
@@ -138,7 +134,7 @@ volumeMounts:
 {{- $createWorkVolume := 1 }}
   {{- range $i, $volume := .Values.template.spec.volumes }}
     {{- if eq $volume.name "work" }}
-      {{- $createWorkVolume = 0 -}}
+      {{- $createWorkVolume = 0 }}
 - {{ $volume | toYaml | nindent 2 }}
     {{- end }}
   {{- end }}
@@ -160,25 +156,20 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.non-runner-containers" -}}
-  {{- range $i, $container := .Values.template.spec.containers -}}
-    {{- if ne $container.name "runner" -}}
-- name: {{ $container.name }}
-      {{- range $key, $val := $container }}
-        {{- if ne $key "name" }}
-  {{ $key }}: {{ $val }}
-        {{- end }}
-      {{- end }}
+  {{- range $i, $container := .Values.template.spec.containers }}
+    {{- if ne $container.name "runner" }}
+- {{ $container | toYaml | nindent 2 }}
     {{- end }}
   {{- end }}
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-runner-container" -}}
 {{- $tlsConfig := (default (dict) .Values.githubServerTLS) }}
-{{- range $i, $container := .Values.template.spec.containers -}}
-  {{- if eq $container.name "runner" -}}
+{{- range $i, $container := .Values.template.spec.containers }}
+  {{- if eq $container.name "runner" }}
     {{- range $key, $val := $container }}
       {{- if and (ne $key "env") (ne $key "volumeMounts") (ne $key "name") }}
-{{ $key }}: {{ $val }}
+{{ $key }}: {{ $val | toYaml | nindent 2 }}
       {{- end }}
     {{- end }}
     {{- $setDockerHost := 1 }}
@@ -195,29 +186,24 @@ env:
     {{- with $container.env }}
       {{- range $i, $env := . }}
         {{- if eq $env.name "DOCKER_HOST" }}
-          {{- $setDockerHost = 0 -}}
+          {{- $setDockerHost = 0 }}
         {{- end }}
         {{- if eq $env.name "DOCKER_TLS_VERIFY" }}
-          {{- $setDockerTlsVerify = 0 -}}
+          {{- $setDockerTlsVerify = 0 }}
         {{- end }}
         {{- if eq $env.name "DOCKER_CERT_PATH" }}
-          {{- $setDockerCertPath = 0 -}}
+          {{- $setDockerCertPath = 0 }}
         {{- end }}
         {{- if eq $env.name "RUNNER_WAIT_FOR_DOCKER_IN_SECONDS" }}
-          {{- $setRunnerWaitDocker = 0 -}}
+          {{- $setRunnerWaitDocker = 0 }}
         {{- end }}
         {{- if eq $env.name "NODE_EXTRA_CA_CERTS" }}
-          {{- $setNodeExtraCaCerts = 0 -}}
+          {{- $setNodeExtraCaCerts = 0 }}
         {{- end }}
         {{- if eq $env.name "RUNNER_UPDATE_CA_CERTS" }}
-          {{- $setRunnerUpdateCaCerts = 0 -}}
+          {{- $setRunnerUpdateCaCerts = 0 }}
         {{- end }}
-  - name: {{ $env.name }}
-        {{- range $envKey, $envVal := $env }}
-          {{- if ne $envKey "name" }}
-    {{ $envKey }}: {{ $envVal | toYaml | nindent 8 }}
-          {{- end }}
-        {{- end }}
+  - {{ $env | toYaml | nindent 4 }}
       {{- end }}
     {{- end }}
     {{- if $setDockerHost }}
@@ -254,20 +240,15 @@ volumeMounts:
     {{- with $container.volumeMounts }}
       {{- range $i, $volMount := . }}
         {{- if eq $volMount.name "work" }}
-          {{- $mountWork = 0 -}}
+          {{- $mountWork = 0 }}
         {{- end }}
         {{- if eq $volMount.name "dind-cert" }}
-          {{- $mountDindCert = 0 -}}
+          {{- $mountDindCert = 0 }}
         {{- end }}
         {{- if eq $volMount.name "github-server-tls-cert" }}
-          {{- $mountGitHubServerTLS = 0 -}}
+          {{- $mountGitHubServerTLS = 0 }}
         {{- end }}
-  - name: {{ $volMount.name }}
-        {{- range $mountKey, $mountVal := $volMount }}
-          {{- if ne $mountKey "name" }}
-    {{ $mountKey }}: {{ $mountVal | toYaml | nindent 8 }}
-          {{- end }}
-        {{- end }}
+  - {{ $volMount | toYaml | nindent 4 }}
       {{- end }}
     {{- end }}
     {{- if $mountWork }}
@@ -290,11 +271,11 @@ volumeMounts:
 
 {{- define "gha-runner-scale-set.kubernetes-mode-runner-container" -}}
 {{- $tlsConfig := (default (dict) .Values.githubServerTLS) }}
-{{- range $i, $container := .Values.template.spec.containers -}}
-  {{- if eq $container.name "runner" -}}
+{{- range $i, $container := .Values.template.spec.containers }}
+  {{- if eq $container.name "runner" }}
     {{- range $key, $val := $container }}
       {{- if and (ne $key "env") (ne $key "volumeMounts") (ne $key "name") }}
-{{ $key }}: {{ $val }}
+{{ $key }}: {{ $val | toYaml | nindent 2 }}
       {{- end }}
     {{- end }}
     {{- $setContainerHooks := 1 }}
@@ -310,26 +291,21 @@ env:
     {{- with $container.env }}
       {{- range $i, $env := . }}
         {{- if eq $env.name "ACTIONS_RUNNER_CONTAINER_HOOKS" }}
-          {{- $setContainerHooks = 0 -}}
+          {{- $setContainerHooks = 0 }}
         {{- end }}
         {{- if eq $env.name "ACTIONS_RUNNER_POD_NAME" }}
-          {{- $setPodName = 0 -}}
+          {{- $setPodName = 0 }}
         {{- end }}
         {{- if eq $env.name "ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER" }}
-          {{- $setRequireJobContainer = 0 -}}
+          {{- $setRequireJobContainer = 0 }}
         {{- end }}
         {{- if eq $env.name "NODE_EXTRA_CA_CERTS" }}
-          {{- $setNodeExtraCaCerts = 0 -}}
+          {{- $setNodeExtraCaCerts = 0 }}
         {{- end }}
         {{- if eq $env.name "RUNNER_UPDATE_CA_CERTS" }}
-          {{- $setRunnerUpdateCaCerts = 0 -}}
+          {{- $setRunnerUpdateCaCerts = 0 }}
         {{- end }}
-  - name: {{ $env.name }}
-        {{- range $envKey, $envVal := $env }}
-          {{- if ne $envKey "name" }}
-    {{ $envKey }}: {{ $envVal | toYaml | nindent 8 }}
-          {{- end }}
-        {{- end }}
+  - {{ $env | toYaml | nindent 4 }}
       {{- end }}
     {{- end }}
     {{- if $setContainerHooks }}
@@ -363,17 +339,12 @@ volumeMounts:
     {{- with $container.volumeMounts }}
       {{- range $i, $volMount := . }}
         {{- if eq $volMount.name "work" }}
-          {{- $mountWork = 0 -}}
+          {{- $mountWork = 0 }}
         {{- end }}
         {{- if eq $volMount.name "github-server-tls-cert" }}
-          {{- $mountGitHubServerTLS = 0 -}}
+          {{- $mountGitHubServerTLS = 0 }}
         {{- end }}
-  - name: {{ $volMount.name }}
-        {{- range $mountKey, $mountVal := $volMount }}
-          {{- if ne $mountKey "name" }}
-    {{ $mountKey }}: {{ $mountVal | toYaml | nindent 8 }}
-          {{- end }}
-        {{- end }}
+  - {{ $volMount | toYaml | nindent 4 }}
       {{- end }}
     {{- end }}
     {{- if $mountWork }}
@@ -391,14 +362,14 @@ volumeMounts:
 
 {{- define "gha-runner-scale-set.default-mode-runner-containers" -}}
 {{- $tlsConfig := (default (dict) .Values.githubServerTLS) }}
-{{- range $i, $container := .Values.template.spec.containers -}}
-{{- if ne $container.name "runner" -}}
+{{- range $i, $container := .Values.template.spec.containers }}
+{{- if ne $container.name "runner" }}
 - {{ $container | toYaml | nindent 2 }}
 {{- else }}
 - name: {{ $container.name }}
   {{- range $key, $val := $container }}
     {{- if and (ne $key "env") (ne $key "volumeMounts") (ne $key "name") }}
-  {{ $key }}: {{ $val }}
+  {{ $key }}: {{ $val | toYaml | nindent 4 }}
     {{- end }}
   {{- end }}
   {{- $setNodeExtraCaCerts := 0 }}
@@ -411,17 +382,12 @@ volumeMounts:
     {{- with $container.env }}
       {{- range $i, $env := . }}
         {{- if eq $env.name "NODE_EXTRA_CA_CERTS" }}
-          {{- $setNodeExtraCaCerts = 0 -}}
+          {{- $setNodeExtraCaCerts = 0 }}
         {{- end }}
         {{- if eq $env.name "RUNNER_UPDATE_CA_CERTS" }}
-          {{- $setRunnerUpdateCaCerts = 0 -}}
+          {{- $setRunnerUpdateCaCerts = 0 }}
         {{- end }}
-    - name: {{ $env.name }}
-        {{- range $envKey, $envVal := $env }}
-          {{- if ne $envKey "name" }}
-      {{ $envKey }}: {{ $envVal | toYaml | nindent 10 }}
-          {{- end }}
-        {{- end }}
+    - {{ $env | toYaml | nindent 6 }}
       {{- end }}
     {{- end }}
     {{- if $setNodeExtraCaCerts }}
@@ -440,14 +406,9 @@ volumeMounts:
     {{- with $container.volumeMounts }}
       {{- range $i, $volMount := . }}
         {{- if eq $volMount.name "github-server-tls-cert" }}
-          {{- $mountGitHubServerTLS = 0 -}}
+          {{- $mountGitHubServerTLS = 0 }}
         {{- end }}
-    - name: {{ $volMount.name }}
-        {{- range $mountKey, $mountVal := $volMount }}
-          {{- if ne $mountKey "name" }}
-      {{ $mountKey }}: {{ $mountVal | toYaml | nindent 10 }}
-          {{- end }}
-        {{- end }}
+    - {{ $volMount | toYaml | nindent 6 }}
       {{- end }}
     {{- end }}
     {{- if $mountGitHubServerTLS }}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -36,17 +36,21 @@ spec:
     {{- if .Values.proxy.http }}
     http:
       url: {{ .Values.proxy.http.url }}
+      {{- if .Values.proxy.http.credentialSecretRef }}
       credentialSecretRef: {{ .Values.proxy.http.credentialSecretRef }}
-    {{ end }}
+      {{- end }}
+    {{- end }}
     {{- if .Values.proxy.https }}
     https:
       url: {{ .Values.proxy.https.url }}
+      {{- if .Values.proxy.https.credentialSecretRef }}
       credentialSecretRef: {{ .Values.proxy.https.credentialSecretRef }}
-    {{ end }}
+      {{- end }}
+    {{- end }}
     {{- if and .Values.proxy.noProxy (kindIs "slice" .Values.proxy.noProxy) }}
     noProxy: {{ .Values.proxy.noProxy | toYaml | nindent 6}}
-    {{ end }}
-  {{ end }}
+    {{- end }}
+  {{- end }}
 
   {{- if and (or (kindIs "int64" .Values.minRunners) (kindIs "float64" .Values.minRunners)) (or (kindIs "int64" .Values.maxRunners) (kindIs "float64" .Values.maxRunners)) }}
     {{- if gt .Values.minRunners .Values.maxRunners }}

--- a/charts/gha-runner-scale-set/tests/values_dind_merge_spec.yaml
+++ b/charts/gha-runner-scale-set/tests/values_dind_merge_spec.yaml
@@ -1,0 +1,31 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+template:
+  spec:
+    containers:
+    - name: runner
+      image: runner-image:latest
+      env:
+      - name: DOCKER_HOST
+        value: tcp://localhost:9999
+      - name: MY_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      volumeMounts:
+      - name: work
+        mountPath: /work
+      - name: others
+        mountPath: /others
+      resources:
+        limits:
+          memory: "64Mi"
+          cpu: "250m"
+    volumes:
+    - name: work
+      hostPath:
+        path: /data
+        type: Directory
+containerMode:
+  type: dind

--- a/charts/gha-runner-scale-set/tests/values_extra_containers.yaml
+++ b/charts/gha-runner-scale-set/tests/values_extra_containers.yaml
@@ -1,0 +1,46 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+template:
+  spec:
+    containers:
+    - name: runner
+      image: runner-image:latest
+      env:
+      - name: SOME_ENV
+        value: SOME_VALUE
+      - name: MY_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      volumeMounts:
+      - name: work
+        mountPath: /work
+      - name: others
+        mountPath: /others
+      resources:
+        limits:
+          memory: "64Mi"
+          cpu: "250m"
+    - name: other
+      image: other-image:latest
+      volumeMounts:
+      - name: work
+        mountPath: /work
+      - name: others
+        mountPath: /others
+      resources:
+        limits:
+          memory: "64Mi"
+          cpu: "250m"
+    volumes:
+    - name: work
+      hostPath:
+        path: /data
+        type: Directory
+    dnsPolicy: "None"
+    dnsConfig:
+      nameservers:
+        - 192.0.2.1
+containerMode:
+  type: none

--- a/charts/gha-runner-scale-set/tests/values_extra_pod_spec.yaml
+++ b/charts/gha-runner-scale-set/tests/values_extra_pod_spec.yaml
@@ -1,0 +1,12 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+template:
+  spec:
+    containers:
+    - name: runner
+      image: runner-image:latest
+    dnsPolicy: "None"
+    dnsConfig:
+      nameservers:
+        - 192.0.2.1

--- a/charts/gha-runner-scale-set/tests/values_k8s_merge_spec.yaml
+++ b/charts/gha-runner-scale-set/tests/values_k8s_merge_spec.yaml
@@ -1,0 +1,31 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+template:
+  spec:
+    containers:
+    - name: runner
+      image: runner-image:latest
+      env:
+      - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+        value: /k8s/index.js
+      - name: MY_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      volumeMounts:
+      - name: work
+        mountPath: /work
+      - name: others
+        mountPath: /others
+      resources:
+        limits:
+          memory: "64Mi"
+          cpu: "250m"
+    volumes:
+    - name: work
+      hostPath:
+        path: /data
+        type: Directory
+containerMode:
+  type: kubernetes


### PR DESCRIPTION
Fixes:
- Replace `-}}` with `}}` in the place where trimming trailing whitespace doesn't make sense.
- Make sure to have `toYaml` when rewriting the object back to YAML.
- Adding L0 tests to cover more scenarios.