### PR TITLE
Ignore extra dind container when contaerinMode.type=dind.

### DIFF
--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -439,7 +439,9 @@ jobs:
           --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
           --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
           --set containerMode.type="kubernetes" \
+          --set containerMode.kubernetesModeWorkVolumeClaim.accessModes={"ReadWriteOnce"} \
           --set containerMode.kubernetesModeWorkVolumeClaim.storageClassName="openebs-hostpath" \
+          --set containerMode.kubernetesModeWorkVolumeClaim.resources.requests.storage="1Gi" \
           ./charts/gha-runner-scale-set \
           --debug
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT

--- a/apis/actions.github.com/v1alpha1/autoscalingrunnerset_types.go
+++ b/apis/actions.github.com/v1alpha1/autoscalingrunnerset_types.go
@@ -248,7 +248,6 @@ type AutoscalingRunnerSetStatus struct {
 }
 
 func (ars *AutoscalingRunnerSet) ListenerSpecHash() string {
-	type listenerSpec = AutoscalingRunnerSetSpec
 	arsSpec := ars.Spec.DeepCopy()
 	spec := arsSpec
 	return hash.ComputeTemplateHash(&spec)

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -163,6 +163,14 @@ volumeMounts:
   {{- end }}
 {{- end }}
 
+{{- define "gha-runner-scale-set.non-runner-non-dind-containers" -}}
+  {{- range $i, $container := .Values.template.spec.containers }}
+    {{- if and (ne $container.name "runner") (ne $container.name "dind") }}
+- {{ $container | toYaml | nindent 2 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- define "gha-runner-scale-set.dind-runner-container" -}}
 {{- $tlsConfig := (default (dict) .Values.githubServerTLS) }}
 {{- range $i, $container := .Values.template.spec.containers }}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -111,7 +111,7 @@ spec:
         {{- include "gha-runner-scale-set.dind-runner-container" . | nindent 8 }}
       - name: dind
         {{- include "gha-runner-scale-set.dind-container" . | nindent 8 }}
-      {{- include "gha-runner-scale-set.non-runner-containers" . | nindent 6 }}
+      {{- include "gha-runner-scale-set.non-runner-non-dind-containers" . | nindent 6 }}
       {{- else if eq .Values.containerMode.type "kubernetes" }}
       - name: runner
         {{- include "gha-runner-scale-set.kubernetes-mode-runner-container" . | nindent 8 }}

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -86,11 +86,11 @@ template:
   ## template:
   ##   spec:
   ##     initContainers:
-  ##     - name: initExternalsInternalVolume
+  ##     - name: init-dind-externals
   ##       image: ghcr.io/actions/actions-runner:latest
   ##       command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
   ##       volumeMounts:
-  ##         - name: externalsInternal
+  ##         - name: dind-externals
   ##           mountPath: /home/runner/tmpDir
   ##     containers:
   ##     - name: runner
@@ -103,9 +103,9 @@ template:
   ##         - name: DOCKER_CERT_PATH
   ##           value: /certs/client
   ##       volumeMounts:
-  ##         - name: workingDirectoryInternal
+  ##         - name: work
   ##           mountPath: /home/runner/_work
-  ##         - name: dinDInternal
+  ##         - name: dind-cert
   ##           mountPath: /certs/client
   ##           readOnly: true
   ##     - name: dind
@@ -113,18 +113,18 @@ template:
   ##       securityContext:
   ##         privileged: true
   ##       volumeMounts:
-  ##         - mountPath: /certs/client
-  ##           name: dinDInternal
-  ##         - mountPath: /home/runner/_work
-  ##           name: workingDirectoryInternal
-  ##         - mountPath: /home/runner/externals
-  ##           name: externalsInternal
+  ##         - name: work
+  ##           mountPath: /home/runner/_work
+  ##         - name: dind-cert
+  ##           mountPath: /certs/client
+  ##         - name: dind-externals
+  ##           mountPath: /home/runner/externals
   ##     volumes:
-  ##     - name: dinDInternal
+  ##     - name: work
   ##       emptyDir: {}
-  ##     - name: workingDirectoryInternal
+  ##     - name: dind-cert
   ##       emptyDir: {}
-  ##     - name: externalsInternal
+  ##     - name: dind-externals
   ##       emptyDir: {}
   ######################################################################################################
   ## with containerMode.type=kubernetes, we will populate the template.spec with following pod spec


### PR DESCRIPTION
When customers provide `contaerinMode.type=dind`, we will skip any container named `dind`.