### PR TITLE
Noting type none containerMode

### DIFF
--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -69,7 +69,7 @@ githubConfigSecret:
 #   runnerMountPath: /usr/local/share/ca-certificates/
 
 containerMode:
-  type: ""  ## type can be set to dind or kubernetes
+  type: ""  ## type can be set to none, dind, or kubernetes (defaults to "none")
   ## the following is required when containerMode.type=kubernetes
   # kubernetesModeWorkVolumeClaim:
   #   accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
When [containerMode](https://github.com/actions/actions-runner-controller/blob/f49d08e4bc6348c0041e2f0f0046058dc76a2ce7/charts/gha-runner-scale-set/tests/values_extra_containers.yaml#L46) is left blank, it defaults to `none`. 

Currently, the values file seems to indicate that it can only be `kubernetes` or `dind`, which is slightly confusing. 