### PR TITLE
Update e2e workflow

### DIFF
--- a/.github/actions/execute-assert-arc-e2e/action.yaml
+++ b/.github/actions/execute-assert-arc-e2e/action.yaml
@@ -1,0 +1,160 @@
+name: 'Execute and Assert ARC E2E Test Action'
+description: 'Queue E2E test workflow and assert workflow run result to be succeed'
+
+inputs:
+  auth-token:
+    description: 'GitHub access token to queue workflow run'
+    required: true
+  repo-owner:
+    description: "The repository owner name that has the test workflow file, ex: actions"
+    required: true
+  repo-name:
+    description: "The repository name that has the test workflow file, ex: test"
+    required: true
+  workflow-file:
+    description: 'The file name of the workflow yaml, ex: test.yml'
+    required: true
+  arc-name:
+    description: 'The name of the configured gha-runner-scale-set'
+    required: true
+  arc-namespace:
+    description: 'The namespace of the configured gha-runner-scale-set'
+    required: true
+  arc-controller-namespace:
+    description: 'The namespace of the configured gha-runner-scale-set-controller'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Queue test workflow
+      shell: bash
+      id: queue_workflow
+      run: |
+        queue_time=`date +%FT%TZ`
+        echo "queue_time=$queue_time" >> $GITHUB_OUTPUT
+        curl -X POST https://api.github.com/repos/${{inputs.repo-owner}}/${{inputs.repo-name}}/actions/workflows/${{inputs.workflow-file}}/dispatches \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token ${{inputs.auth-token}}" \
+        -d '{"ref": "main", "inputs": { "arc_name": "${{inputs.arc-name}}" } }'
+
+    - name: Fetch workflow run & job ids
+      uses: actions/github-script@v6
+      id: query_workflow
+      with:
+        script: |
+          // Try to find the workflow run triggered by the previous step using the workflow_dispatch event.
+          // - Find recently create workflow runs in the test repository
+          // - For each workflow run, list its workflow job and see if the job's labels contain `inputs.arc-name`
+          // - Since the inputs.arc-name should be unique per e2e workflow run, once we find the job with the label, we find the workflow that we just triggered.
+          function sleep(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms))
+          }
+          const owner = '${{inputs.repo-owner}}'
+          const repo = '${{inputs.repo-name}}'
+          const workflow_id = '${{inputs.workflow-file}}'
+          let workflow_run_id = 0
+          let workflow_job_id = 0
+          let workflow_run_html_url = ""
+          let count = 0
+          while (count++<12) {
+            await sleep(10 * 1000);
+            let listRunResponse = await github.rest.actions.listWorkflowRuns({
+              owner: owner,
+              repo: repo,
+              workflow_id: workflow_id,
+              created: '>${{steps.queue_workflow.outputs.queue_time}}'
+            })
+            if (listRunResponse.data.total_count > 0) {
+              console.log(`Found some new workflow runs for ${workflow_id}`)
+              for (let i = 0; i<listRunResponse.data.total_count; i++) {
+                let workflowRun = listRunResponse.data.workflow_runs[i]
+                console.log(`Check if workflow run ${workflowRun.id} is triggered by us.`)
+                let listJobResponse = await github.rest.actions.listJobsForWorkflowRun({
+                  owner: owner,
+                  repo: repo,
+                  run_id: workflowRun.id
+                })
+                console.log(`Workflow run ${workflowRun.id} has ${listJobResponse.data.total_count} jobs.`)
+                if (listJobResponse.data.total_count > 0) {
+                  for (let j = 0; j<listJobResponse.data.total_count; j++) {
+                    let workflowJob = listJobResponse.data.jobs[j]
+                    console.log(`Check if workflow job ${workflowJob.id} is triggered by us.`)
+                    console.log(JSON.stringify(workflowJob.labels));
+                    if (workflowJob.labels.includes('${{inputs.arc-name}}')) {
+                      console.log(`Workflow job ${workflowJob.id} (Run id: ${workflowJob.run_id}) is triggered by us.`)
+                      workflow_run_id = workflowJob.run_id
+                      workflow_job_id = workflowJob.id
+                      workflow_run_html_url = workflowRun.html_url
+                      break
+                    }
+                  }
+                }
+
+                if (workflow_job_id > 0) {
+                  break;
+                }
+              }
+            }
+
+            if (workflow_job_id > 0) {
+              break;
+            }
+          }
+          if (workflow_job_id == 0) {
+            core.setFailed(`Can't find workflow run and workflow job triggered to 'runs-on ${{inputs.arc-name}}'`)
+          } else {
+            core.setOutput('workflow_run', workflow_run_id);
+            core.setOutput('workflow_job', workflow_job_id);
+            core.setOutput('workflow_run_url', workflow_run_html_url);
+          }
+
+    - name: Generate summary about the triggered workflow run
+      shell: bash
+      run: | 
+        cat <<-EOF > $GITHUB_STEP_SUMMARY
+        | **Triggered workflow run** |
+        |:--------------------------:|
+        | ${{steps.query_workflow.outputs.workflow_run_url}} |
+        EOF
+
+    - name: Wait for workflow to finish successfully
+      uses: actions/github-script@v6
+      with:
+        script: |
+          // Wait 5 minutes and make sure the workflow run we triggered completed with result 'success'
+          function sleep(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms))
+          }
+          const owner = '${{inputs.repo-owner}}'
+          const repo = '${{inputs.repo-name}}'
+          const workflow_run_id = ${{steps.query_workflow.outputs.workflow_run}}
+          const workflow_job_id = ${{steps.query_workflow.outputs.workflow_job}}
+          let count = 0
+          while (count++<10) {
+            await sleep(30 * 1000);
+            let getRunResponse = await github.rest.actions.getWorkflowRun({
+              owner: owner,
+              repo: repo,
+              run_id: workflow_run_id
+            })
+            console.log(`${getRunResponse.data.html_url}: ${getRunResponse.data.status} (${getRunResponse.data.conclusion})`);
+            if (getRunResponse.data.status == 'completed') {
+              if ( getRunResponse.data.conclusion == 'success') {
+                console.log(`Workflow run finished properly.`)
+                return
+              } else {
+                core.setFailed(`The triggered workflow run finish with result ${getRunResponse.data.conclusion}`)
+                return
+              }
+            }
+          }
+          core.setFailed(`The triggered workflow run didn't finish properly using ${{inputs.arc-name}}`)
+
+    - name: Gather logs and cleanup
+      shell: bash
+      if: always()
+      run: |
+        helm uninstall ${{ inputs.arc-name }} --namespace ${{inputs.arc-namespace}} --debug
+        kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n ${{inputs.arc-name}} -l app.kubernetes.io/instance=${{ inputs.arc-name }}
+        kubectl logs deployment/arc-gha-runner-scale-set-controller -n ${{inputs.arc-controller-namespace}}

--- a/.github/actions/setup-arc-e2e/action.yaml
+++ b/.github/actions/setup-arc-e2e/action.yaml
@@ -2,20 +2,20 @@ name: 'Setup ARC E2E Test Action'
 description: 'Build controller image, create kind cluster, load the image, and exchange ARC configure token.'
 
 inputs:
-  github-app-id:
+  app-id:
     description: 'GitHub App Id for exchange access token'
     required: true
-  github-app-pk:
+  app-pk:
     description: "GitHub App private key for exchange access token"
     required: true
-  github-app-org:
-    description: 'The organization the GitHub App has installed on'
-    required: true
-  docker-image-name:
+  image-name:
     description: "Local docker image name for building"
     required: true
-  docker-image-tag:
+  image-tag:
     description: "Tag of ARC Docker image for building"
+    required: true
+  target-org:
+    description: "The test organization for ARC e2e test"
     required: true
 
 outputs:
@@ -42,23 +42,22 @@ runs:
         platforms: linux/amd64
         load: true
         build-args: |
-          DOCKER_IMAGE_NAME=${{inputs.docker-image-name}}
-          VERSION=${{inputs.docker-image-tag}} 
+          DOCKER_IMAGE_NAME=${{inputs.image-name}}
+          VERSION=${{inputs.image-tag}} 
         tags: |
-          ${{inputs.docker-image-name}}:${{inputs.docker-image-tag}}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+          ${{inputs.image-name}}:${{inputs.image-tag}}
+        no-cache: true
 
     - name: Create minikube cluster and load image
       shell: bash
       run: |
         minikube start
-        minikube image load ${{inputs.docker-image-name}}:${{inputs.docker-image-tag}}
+        minikube image load ${{inputs.image-name}}:${{inputs.image-tag}}
 
     - name: Get configure token
       id: config-token
       uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db
       with:
-        application_id: ${{ inputs.github-app-id }}
-        application_private_key: ${{ inputs.github-app-pk }}
-        organization: ${{ inputs.github-app-org }}
+        application_id: ${{ inputs.app-id }}
+        application_private_key: ${{ inputs.app-pk }}
+        organization: ${{ inputs.target-org}}

--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -4,26 +4,20 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
       branches:
       - master
   workflow_dispatch:
-    inputs:
-      target_org:
-        description: The org of the test repository.
-        required: true
-        default: actions-runner-controller
-      target_repo:
-        description: The repository to install the ARC.
-        required: true
-        default: arc_e2e_test_dummy
+
+permissions:
+  contents: read
 
 env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: arc_e2e_test_dummy
   IMAGE_NAME: "arc-test-image"
   IMAGE_VERSION: "dev"
-  
+
 jobs:
   default-setup:
     runs-on: ubuntu-latest
@@ -31,29 +25,17 @@ jobs:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
       - uses: actions/checkout@v3
-
-      - name: Resolve inputs
-        id: resolved_inputs
-        run: |
-          TARGET_ORG="${{env.TARGET_ORG}}"
-          TARGET_REPO="${{env.TARGET_REPO}}"
-          if [ ! -z "${{inputs.target_org}}" ]; then
-            TARGET_ORG="${{inputs.target_org}}"
-          fi
-          if [ ! -z "${{inputs.target_repo}}" ]; then
-            TARGET_REPO="${{inputs.target_repo}}"
-          fi
-          echo "TARGET_ORG=$TARGET_ORG" >> $GITHUB_OUTPUT
-          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_OUTPUT
+        with:
+          ref: ${{github.head_ref}}
 
       - uses: ./.github/actions/setup-arc-e2e
         id: setup
         with:
-          github-app-id: ${{secrets.ACTIONS_ACCESS_APP_ID}}
-          github-app-pk: ${{secrets.ACTIONS_ACCESS_PK}}
-          github-app-org: ${{steps.resolved_inputs.outputs.TARGET_ORG}}
-          docker-image-name: ${{env.IMAGE_NAME}}
-          docker-image-tag: ${{env.IMAGE_VERSION}}
+          app-id: ${{secrets.E2E_TESTS_ACCESS_APP_ID}}
+          app-pk: ${{secrets.E2E_TESTS_ACCESS_PK}}
+          image-name: ${{env.IMAGE_NAME}}
+          image-tag: ${{env.IMAGE_VERSION}}
+          target-org: ${{env.TARGET_ORG}}
 
       - name: Install gha-runner-scale-set-controller
         id: install_arc_controller
@@ -85,11 +67,11 @@ jobs:
       - name: Install gha-runner-scale-set
         id: install_arc
         run: |
-          ARC_NAME=arc-runner-${{github.job}}-$(date +'%M-%S')-$(($RANDOM % 100 + 1))
+          ARC_NAME=${{github.job}}-$(date +'%M%S')$((($RANDOM + 100) % 100 + 1))
           helm install "$ARC_NAME" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
+          --set githubConfigUrl="https://github.com/${{ env.TARGET_ORG }}/${{env.TARGET_REPO}}" \
           --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
           ./charts/gha-runner-scale-set \
           --debug
@@ -109,34 +91,18 @@ jobs:
           done
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
-
-      - name: Test ARC scales pods up and down
-        id: test
-        run: |
-          export GITHUB_TOKEN="${{ steps.setup.outputs.token }}"
-          export ARC_NAME="${{ steps.install_arc.outputs.ARC_NAME }}"
-          export WORKFLOW_FILE="${{env.WORKFLOW_FILE}}"
-          go test ./test_e2e_arc -v
-
-      - name: Uninstall gha-runner-scale-set
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          helm uninstall ${{ steps.install_arc.outputs.ARC_NAME }} --namespace arc-runners
-          kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n demo -l app.kubernetes.io/instance=${{ steps.install_arc.outputs.ARC_NAME }}
-
-      - name: Dump gha-runner-scale-set-controller logs
-        if: always() && steps.install_arc_controller.outcome == 'success'
-        run: |
-          kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems
-
-      - name: Job summary
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          cat <<-EOF > $GITHUB_STEP_SUMMARY
-          | **Outcome**    | ${{ steps.test.outcome }}  |
-          |----------------|--------------------------------------------- |
-          | **References** | [Test workflow runs](https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}/actions/workflows/${{ env.WORKFLOW_FILE }}) |
-          EOF
+      
+      - name: Test ARC E2E
+        uses: ./.github/actions/execute-assert-arc-e2e
+        timeout-minutes: 10
+        with:
+          auth-token: ${{ steps.setup.outputs.token }}
+          repo-owner: ${{ env.TARGET_ORG }}
+          repo-name: ${{env.TARGET_REPO}}
+          workflow-file: ${{env.WORKFLOW_FILE}}
+          arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
+          arc-namespace: "arc-runners"
+          arc-controller-namespace: "arc-systems"
 
   single-namespace-setup:
     runs-on: ubuntu-latest
@@ -144,29 +110,17 @@ jobs:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
       - uses: actions/checkout@v3
-
-      - name: Resolve inputs
-        id: resolved_inputs
-        run: |
-          TARGET_ORG="${{env.TARGET_ORG}}"
-          TARGET_REPO="${{env.TARGET_REPO}}"
-          if [ ! -z "${{inputs.target_org}}" ]; then
-            TARGET_ORG="${{inputs.target_org}}"
-          fi
-          if [ ! -z "${{inputs.target_repo}}" ]; then
-            TARGET_REPO="${{inputs.target_repo}}"
-          fi
-          echo "TARGET_ORG=$TARGET_ORG" >> $GITHUB_OUTPUT
-          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_OUTPUT
+        with:
+          ref: ${{github.head_ref}}
 
       - uses: ./.github/actions/setup-arc-e2e
         id: setup
         with:
-          github-app-id: ${{secrets.ACTIONS_ACCESS_APP_ID}}
-          github-app-pk: ${{secrets.ACTIONS_ACCESS_PK}}
-          github-app-org: ${{steps.resolved_inputs.outputs.TARGET_ORG}}
-          docker-image-name: ${{env.IMAGE_NAME}}
-          docker-image-tag: ${{env.IMAGE_VERSION}}
+          app-id: ${{secrets.E2E_TESTS_ACCESS_APP_ID}}
+          app-pk: ${{secrets.E2E_TESTS_ACCESS_PK}}
+          image-name: ${{env.IMAGE_NAME}}
+          image-tag: ${{env.IMAGE_VERSION}}
+          target-org: ${{env.TARGET_ORG}}
 
       - name: Install gha-runner-scale-set-controller
         id: install_arc_controller
@@ -200,11 +154,11 @@ jobs:
       - name: Install gha-runner-scale-set
         id: install_arc
         run: |
-          ARC_NAME=arc-runner-${{github.job}}-$(date +'%M-%S')-$(($RANDOM % 100 + 1))
+          ARC_NAME=${{github.job}}-$(date +'%M%S')$((($RANDOM + 100) % 100 + 1))
           helm install "$ARC_NAME" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
+          --set githubConfigUrl="https://github.com/${{ env.TARGET_ORG }}/${{env.TARGET_REPO}}" \
           --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
           ./charts/gha-runner-scale-set \
           --debug
@@ -225,33 +179,17 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
-      - name: Test ARC scales pods up and down
-        id: test
-        run: |
-          export GITHUB_TOKEN="${{ steps.setup.outputs.token }}"
-          export ARC_NAME="${{ steps.install_arc.outputs.ARC_NAME }}"
-          export WORKFLOW_FILE="${{env.WORKFLOW_FILE}}"
-          go test ./test_e2e_arc -v
-
-      - name: Uninstall gha-runner-scale-set
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          helm uninstall ${{ steps.install_arc.outputs.ARC_NAME }} --namespace arc-runners
-          kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n demo -l app.kubernetes.io/instance=${{ steps.install_arc.outputs.ARC_NAME }}
-
-      - name: Dump gha-runner-scale-set-controller logs
-        if: always() && steps.install_arc_controller.outcome == 'success'
-        run: |
-          kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems
-
-      - name: Job summary
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          cat <<-EOF > $GITHUB_STEP_SUMMARY
-          | **Outcome**    | ${{ steps.test.outcome }}  |
-          |----------------|--------------------------------------------- |
-          | **References** | [Test workflow runs](https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}/actions/workflows/${{ env.WORKFLOW_FILE }}) |
-          EOF
+      - name: Test ARC E2E
+        uses: ./.github/actions/execute-assert-arc-e2e
+        timeout-minutes: 10
+        with:
+          auth-token: ${{ steps.setup.outputs.token }}
+          repo-owner: ${{ env.TARGET_ORG }}
+          repo-name: ${{env.TARGET_REPO}}
+          workflow-file: ${{env.WORKFLOW_FILE}}
+          arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
+          arc-namespace: "arc-runners"
+          arc-controller-namespace: "arc-systems"
 
   dind-mode-setup:
     runs-on: ubuntu-latest
@@ -259,29 +197,17 @@ jobs:
       WORKFLOW_FILE: arc-test-dind-workflow.yaml
     steps:
       - uses: actions/checkout@v3
-
-      - name: Resolve inputs
-        id: resolved_inputs
-        run: |
-          TARGET_ORG="${{env.TARGET_ORG}}"
-          TARGET_REPO="${{env.TARGET_REPO}}"
-          if [ ! -z "${{inputs.target_org}}" ]; then
-            TARGET_ORG="${{inputs.target_org}}"
-          fi
-          if [ ! -z "${{inputs.target_repo}}" ]; then
-            TARGET_REPO="${{inputs.target_repo}}"
-          fi
-          echo "TARGET_ORG=$TARGET_ORG" >> $GITHUB_OUTPUT
-          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_OUTPUT
+        with:
+          ref: ${{github.head_ref}}
 
       - uses: ./.github/actions/setup-arc-e2e
         id: setup
         with:
-          github-app-id: ${{secrets.ACTIONS_ACCESS_APP_ID}}
-          github-app-pk: ${{secrets.ACTIONS_ACCESS_PK}}
-          github-app-org: ${{steps.resolved_inputs.outputs.TARGET_ORG}}
-          docker-image-name: ${{env.IMAGE_NAME}}
-          docker-image-tag: ${{env.IMAGE_VERSION}}
+          app-id: ${{secrets.E2E_TESTS_ACCESS_APP_ID}}
+          app-pk: ${{secrets.E2E_TESTS_ACCESS_PK}}
+          image-name: ${{env.IMAGE_NAME}}
+          image-tag: ${{env.IMAGE_VERSION}}
+          target-org: ${{env.TARGET_ORG}}
 
       - name: Install gha-runner-scale-set-controller
         id: install_arc_controller
@@ -313,11 +239,11 @@ jobs:
       - name: Install gha-runner-scale-set
         id: install_arc
         run: |
-          ARC_NAME=arc-runner-${{github.job}}-$(date +'%M-%S')-$(($RANDOM % 100 + 1))
+          ARC_NAME=${{github.job}}-$(date +'%M%S')$((($RANDOM + 100) % 100 + 1))
           helm install "$ARC_NAME" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
+          --set githubConfigUrl="https://github.com/${{ env.TARGET_ORG }}/${{env.TARGET_REPO}}" \
           --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
           --set containerMode.type="dind" \
           ./charts/gha-runner-scale-set \
@@ -339,33 +265,17 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
-      - name: Test ARC scales pods up and down
-        id: test
-        run: |
-          export GITHUB_TOKEN="${{ steps.setup.outputs.token }}"
-          export ARC_NAME="${{ steps.install_arc.outputs.ARC_NAME }}"
-          export WORKFLOW_FILE="${{env.WORKFLOW_FILE}}"
-          go test ./test_e2e_arc -v
-
-      - name: Uninstall gha-runner-scale-set
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          helm uninstall ${{ steps.install_arc.outputs.ARC_NAME }} --namespace arc-runners
-          kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n demo -l app.kubernetes.io/instance=${{ steps.install_arc.outputs.ARC_NAME }}
-
-      - name: Dump gha-runner-scale-set-controller logs
-        if: always() && steps.install_arc_controller.outcome == 'success'
-        run: |
-          kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems
-
-      - name: Job summary
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          cat <<-EOF > $GITHUB_STEP_SUMMARY
-          | **Outcome**    | ${{ steps.test.outcome }}  |
-          |----------------|--------------------------------------------- |
-          | **References** | [Test workflow runs](https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}/actions/workflows/${{ env.WORKFLOW_FILE }}) |
-          EOF
+      - name: Test ARC E2E
+        uses: ./.github/actions/execute-assert-arc-e2e
+        timeout-minutes: 10
+        with:
+          auth-token: ${{ steps.setup.outputs.token }}
+          repo-owner: ${{ env.TARGET_ORG }}
+          repo-name: ${{env.TARGET_REPO}}
+          workflow-file: ${{env.WORKFLOW_FILE}}
+          arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
+          arc-namespace: "arc-runners"
+          arc-controller-namespace: "arc-systems"
 
   kubernetes-mode-setup:
     runs-on: ubuntu-latest
@@ -373,33 +283,26 @@ jobs:
       WORKFLOW_FILE: "arc-test-kubernetes-workflow.yaml"
     steps:
       - uses: actions/checkout@v3
-
-      - name: Resolve inputs
-        id: resolved_inputs
-        run: |
-          TARGET_ORG="${{env.TARGET_ORG}}"
-          TARGET_REPO="${{env.TARGET_REPO}}"
-          if [ ! -z "${{inputs.target_org}}" ]; then
-            TARGET_ORG="${{inputs.target_org}}"
-          fi
-          if [ ! -z "${{inputs.target_repo}}" ]; then
-            TARGET_REPO="${{inputs.target_repo}}"
-          fi
-          echo "TARGET_ORG=$TARGET_ORG" >> $GITHUB_OUTPUT
-          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_OUTPUT
+        with:
+          ref: ${{github.head_ref}}
 
       - uses: ./.github/actions/setup-arc-e2e
         id: setup
         with:
-          github-app-id: ${{secrets.ACTIONS_ACCESS_APP_ID}}
-          github-app-pk: ${{secrets.ACTIONS_ACCESS_PK}}
-          github-app-org: ${{steps.resolved_inputs.outputs.TARGET_ORG}}
-          docker-image-name: ${{env.IMAGE_NAME}}
-          docker-image-tag: ${{env.IMAGE_VERSION}}
+          app-id: ${{secrets.E2E_TESTS_ACCESS_APP_ID}}
+          app-pk: ${{secrets.E2E_TESTS_ACCESS_PK}}
+          image-name: ${{env.IMAGE_NAME}}
+          image-tag: ${{env.IMAGE_VERSION}}
+          target-org: ${{env.TARGET_ORG}}
 
       - name: Install gha-runner-scale-set-controller
         id: install_arc_controller
         run: |
+          echo "Install openebs/dynamic-localpv-provisioner"
+          helm repo add openebs https://openebs.github.io/charts
+          helm repo update
+          helm install openebs openebs/openebs -n openebs --create-namespace
+
           helm install arc \
           --namespace "arc-systems" \
           --create-namespace \
@@ -423,20 +326,16 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-runner-scale-set-controller
           kubectl get pod -n arc-systems
           kubectl describe deployment arc-gha-runner-scale-set-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n openebs -l name=openebs-localpv-provisioner
 
       - name: Install gha-runner-scale-set
         id: install_arc
         run: |
-          echo "Install openebs/dynamic-localpv-provisioner"
-          helm repo add openebs https://openebs.github.io/charts
-          helm repo update
-          helm install openebs openebs/openebs -n openebs --create-namespace
-
-          ARC_NAME=arc-runner-${{github.job}}-$(date +'%M-%S')-$(($RANDOM % 100 + 1))
+          ARC_NAME=${{github.job}}-$(date +'%M%S')$((($RANDOM + 100) % 100 + 1))
           helm install "$ARC_NAME" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
+          --set githubConfigUrl="https://github.com/${{ env.TARGET_ORG }}/${{env.TARGET_REPO}}" \
           --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
           --set containerMode.type="kubernetes" \
           --set containerMode.kubernetesModeWorkVolumeClaim.accessModes={"ReadWriteOnce"} \
@@ -461,33 +360,17 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
-      - name: Test ARC scales pods up and down
-        id: test
-        run: |
-          export GITHUB_TOKEN="${{ steps.setup.outputs.token }}"
-          export ARC_NAME="${{ steps.install_arc.outputs.ARC_NAME }}"
-          export WORKFLOW_FILE="${{env.WORKFLOW_FILE}}"
-          go test ./test_e2e_arc -v
-
-      - name: Uninstall gha-runner-scale-set
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          helm uninstall ${{ steps.install_arc.outputs.ARC_NAME }} --namespace arc-runners
-          kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n demo -l app.kubernetes.io/instance=${{ steps.install_arc.outputs.ARC_NAME }}
-
-      - name: Dump gha-runner-scale-set-controller logs
-        if: always() && steps.install_arc_controller.outcome == 'success'
-        run: |
-          kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems
-
-      - name: Job summary
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          cat <<-EOF > $GITHUB_STEP_SUMMARY
-          | **Outcome**    | ${{ steps.test.outcome }}  |
-          |----------------|--------------------------------------------- |
-          | **References** | [Test workflow runs](https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}/actions/workflows/${{ env.WORKFLOW_FILE }}) |
-          EOF
+      - name: Test ARC E2E
+        uses: ./.github/actions/execute-assert-arc-e2e
+        timeout-minutes: 10
+        with:
+          auth-token: ${{ steps.setup.outputs.token }}
+          repo-owner: ${{ env.TARGET_ORG }}
+          repo-name: ${{env.TARGET_REPO}}
+          workflow-file: ${{env.WORKFLOW_FILE}}
+          arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
+          arc-namespace: "arc-runners"
+          arc-controller-namespace: "arc-systems"
 
   auth-proxy-setup:
     runs-on: ubuntu-latest
@@ -495,29 +378,17 @@ jobs:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
       - uses: actions/checkout@v3
-
-      - name: Resolve inputs
-        id: resolved_inputs
-        run: |
-          TARGET_ORG="${{env.TARGET_ORG}}"
-          TARGET_REPO="${{env.TARGET_REPO}}"
-          if [ ! -z "${{inputs.target_org}}" ]; then
-            TARGET_ORG="${{inputs.target_org}}"
-          fi
-          if [ ! -z "${{inputs.target_repo}}" ]; then
-            TARGET_REPO="${{inputs.target_repo}}"
-          fi
-          echo "TARGET_ORG=$TARGET_ORG" >> $GITHUB_OUTPUT
-          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_OUTPUT
+        with:
+          ref: ${{github.head_ref}}
 
       - uses: ./.github/actions/setup-arc-e2e
         id: setup
         with:
-          github-app-id: ${{secrets.ACTIONS_ACCESS_APP_ID}}
-          github-app-pk: ${{secrets.ACTIONS_ACCESS_PK}}
-          github-app-org: ${{steps.resolved_inputs.outputs.TARGET_ORG}}
-          docker-image-name: ${{env.IMAGE_NAME}}
-          docker-image-tag: ${{env.IMAGE_VERSION}}
+          app-id: ${{secrets.E2E_TESTS_ACCESS_APP_ID}}
+          app-pk: ${{secrets.E2E_TESTS_ACCESS_PK}}
+          image-name: ${{env.IMAGE_NAME}}
+          image-tag: ${{env.IMAGE_VERSION}}
+          target-org: ${{env.TARGET_ORG}}
 
       - name: Install gha-runner-scale-set-controller
         id: install_arc_controller
@@ -558,11 +429,11 @@ jobs:
             --namespace=arc-runners \
             --from-literal=username=github \
             --from-literal=password='actions'
-          ARC_NAME=arc-runner-${{github.job}}-$(date +'%M-%S')-$(($RANDOM % 100 + 1))
+          ARC_NAME=${{github.job}}-$(date +'%M%S')$((($RANDOM + 100) % 100 + 1))
           helm install "$ARC_NAME" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
+          --set githubConfigUrl="https://github.com/${{ env.TARGET_ORG }}/${{env.TARGET_REPO}}" \
           --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
           --set proxy.https.url="http://host.minikube.internal:3128" \
           --set proxy.https.credentialSecretRef="proxy-auth" \
@@ -586,33 +457,17 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
-      - name: Test ARC scales pods up and down
-        id: test
-        run: |
-          export GITHUB_TOKEN="${{ steps.setup.outputs.token }}"
-          export ARC_NAME="${{ steps.install_arc.outputs.ARC_NAME }}"
-          export WORKFLOW_FILE="${{env.WORKFLOW_FILE}}"
-          go test ./test_e2e_arc -v
-
-      - name: Uninstall gha-runner-scale-set
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          helm uninstall ${{ steps.install_arc.outputs.ARC_NAME }} --namespace arc-runners
-          kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n demo -l app.kubernetes.io/instance=${{ steps.install_arc.outputs.ARC_NAME }}
-
-      - name: Dump gha-runner-scale-set-controller logs
-        if: always() && steps.install_arc_controller.outcome == 'success'
-        run: |
-          kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems
-
-      - name: Job summary
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          cat <<-EOF > $GITHUB_STEP_SUMMARY
-          | **Outcome**    | ${{ steps.test.outcome }}  |
-          |----------------|--------------------------------------------- |
-          | **References** | [Test workflow runs](https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}/actions/workflows/${{ env.WORKFLOW_FILE }}) |
-          EOF
+      - name: Test ARC E2E
+        uses: ./.github/actions/execute-assert-arc-e2e
+        timeout-minutes: 10
+        with:
+          auth-token: ${{ steps.setup.outputs.token }}
+          repo-owner: ${{ env.TARGET_ORG }}
+          repo-name: ${{env.TARGET_REPO}}
+          workflow-file: ${{env.WORKFLOW_FILE}}
+          arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
+          arc-namespace: "arc-runners"
+          arc-controller-namespace: "arc-systems"
 
   anonymous-proxy-setup:
     runs-on: ubuntu-latest
@@ -620,29 +475,17 @@ jobs:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
       - uses: actions/checkout@v3
-
-      - name: Resolve inputs
-        id: resolved_inputs
-        run: |
-          TARGET_ORG="${{env.TARGET_ORG}}"
-          TARGET_REPO="${{env.TARGET_REPO}}"
-          if [ ! -z "${{inputs.target_org}}" ]; then
-            TARGET_ORG="${{inputs.target_org}}"
-          fi
-          if [ ! -z "${{inputs.target_repo}}" ]; then
-            TARGET_REPO="${{inputs.target_repo}}"
-          fi
-          echo "TARGET_ORG=$TARGET_ORG" >> $GITHUB_OUTPUT
-          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_OUTPUT
+        with:
+          ref: ${{github.head_ref}}
 
       - uses: ./.github/actions/setup-arc-e2e
         id: setup
         with:
-          github-app-id: ${{secrets.ACTIONS_ACCESS_APP_ID}}
-          github-app-pk: ${{secrets.ACTIONS_ACCESS_PK}}
-          github-app-org: ${{steps.resolved_inputs.outputs.TARGET_ORG}}
-          docker-image-name: ${{env.IMAGE_NAME}}
-          docker-image-tag: ${{env.IMAGE_VERSION}}
+          app-id: ${{secrets.E2E_TESTS_ACCESS_APP_ID}}
+          app-pk: ${{secrets.E2E_TESTS_ACCESS_PK}}
+          image-name: ${{env.IMAGE_NAME}}
+          image-tag: ${{env.IMAGE_VERSION}}
+          target-org: ${{env.TARGET_ORG}}
 
       - name: Install gha-runner-scale-set-controller
         id: install_arc_controller
@@ -678,11 +521,11 @@ jobs:
             --name squid \
             --publish 3128:3128 \
             ubuntu/squid:latest
-          ARC_NAME=arc-runner-${{github.job}}-$(date +'%M-%S')-$(($RANDOM % 100 + 1))
+          ARC_NAME=${{github.job}}-$(date +'%M%S')$((($RANDOM + 100) % 100 + 1))
           helm install "$ARC_NAME" \
           --namespace "arc-runners" \
           --create-namespace \
-          --set githubConfigUrl="https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}" \
+          --set githubConfigUrl="https://github.com/${{ env.TARGET_ORG }}/${{env.TARGET_REPO}}" \
           --set githubConfigSecret.github_token="${{ steps.setup.outputs.token }}" \
           --set proxy.https.url="http://host.minikube.internal:3128" \
           --set "proxy.noProxy[0]=10.96.0.1:443" \
@@ -705,30 +548,14 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l auto-scaling-runner-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
-      - name: Test ARC scales pods up and down
-        id: test
-        run: |
-          export GITHUB_TOKEN="${{ steps.setup.outputs.token }}"
-          export ARC_NAME="${{ steps.install_arc.outputs.ARC_NAME }}"
-          export WORKFLOW_FILE="${{ env.WORKFLOW_FILE }}"
-          go test ./test_e2e_arc -v
-
-      - name: Uninstall gha-runner-scale-set
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          helm uninstall ${{ steps.install_arc.outputs.ARC_NAME }} --namespace arc-runners
-          kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n demo -l app.kubernetes.io/instance=${{ steps.install_arc.outputs.ARC_NAME }}
-
-      - name: Dump gha-runner-scale-set-controller logs
-        if: always() && steps.install_arc_controller.outcome == 'success'
-        run: |
-          kubectl logs deployment/arc-gha-runner-scale-set-controller -n arc-systems
-
-      - name: Job summary
-        if: always() && steps.install_arc.outcome == 'success'
-        run: |
-          cat <<-EOF > $GITHUB_STEP_SUMMARY
-          | **Outcome**    | ${{ steps.test.outcome }}  |
-          |----------------|--------------------------------------------- |
-          | **References** | [Test workflow runs](https://github.com/${{ steps.resolved_inputs.outputs.TARGET_ORG }}/${{steps.resolved_inputs.outputs.TARGET_REPO}}/actions/workflows/${{ env.WORKFLOW_FILE }}) |
-          EOF
+      - name: Test ARC E2E
+        uses: ./.github/actions/execute-assert-arc-e2e
+        timeout-minutes: 10
+        with:
+          auth-token: ${{ steps.setup.outputs.token }}
+          repo-owner: ${{ env.TARGET_ORG }}
+          repo-name: ${{env.TARGET_REPO}}
+          workflow-file: ${{env.WORKFLOW_FILE}}
+          arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
+          arc-namespace: "arc-runners"
+          arc-controller-namespace: "arc-systems"

--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   default-setup:
     runs-on: ubuntu-latest
-    # if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
@@ -107,7 +107,7 @@ jobs:
 
   single-namespace-setup:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
@@ -195,7 +195,7 @@ jobs:
 
   dind-mode-setup:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     env:
       WORKFLOW_FILE: arc-test-dind-workflow.yaml
     steps:
@@ -282,7 +282,7 @@ jobs:
 
   kubernetes-mode-setup:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-kubernetes-workflow.yaml"
     steps:
@@ -378,7 +378,7 @@ jobs:
 
   auth-proxy-setup:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
@@ -476,7 +476,7 @@ jobs:
 
   anonymous-proxy-setup:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:

--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
       branches:
       - master
   workflow_dispatch:
@@ -21,6 +21,7 @@ env:
 jobs:
   default-setup:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
@@ -106,6 +107,7 @@ jobs:
 
   single-namespace-setup:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
@@ -193,6 +195,7 @@ jobs:
 
   dind-mode-setup:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
     env:
       WORKFLOW_FILE: arc-test-dind-workflow.yaml
     steps:
@@ -279,6 +282,7 @@ jobs:
 
   kubernetes-mode-setup:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-kubernetes-workflow.yaml"
     steps:
@@ -374,6 +378,7 @@ jobs:
 
   auth-proxy-setup:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:
@@ -471,6 +476,7 @@ jobs:
 
   anonymous-proxy-setup:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:

--- a/.github/workflows/e2e-test-linux-vm.yaml
+++ b/.github/workflows/e2e-test-linux-vm.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   default-setup:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
+    # if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id != github.repository_id
     env:
       WORKFLOW_FILE: "arc-test-workflow.yaml"
     steps:


### PR DESCRIPTION
Changes:
- Move most repeat code behind `.github/actions/setup-arc-e2e` and `.github/actions/execute-assert-arc-e2e`, so extending E2E tests in the future should be easy.
- For workflow run triggered by the E2E test, assert the run is successfully completed.

https://github.com/actions/actions-runner-controller/actions/runs/4475143286

https://github.com/actions-runner-controller/arc_e2e_test_dummy/actions
