### PR TITLE
chart: Bump version to 0.23.0

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.0
+version: 0.23.0
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.0
+appVersion: 0.27.1
 
 home: https://github.com/actions/actions-runner-controller
 


### PR DESCRIPTION
Let's cut the new chart version to update `appVersion` to the latest ARC patch release, `0.27.1`.

Also, this is the first chart release that contains various fixes and enhancements made to the chart for the last two months.

Relevant issues and pull requests:

- https://github.com/actions/actions-runner-controller/pull/2398
- https://github.com/actions/actions-runner-controller/pull/2310
- https://github.com/actions/actions-runner-controller/pull/2265
- https://github.com/actions/actions-runner-controller/issues/2426