### PR TITLE
Fix bug preventing env variables from being specified

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -69,10 +69,10 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         {{- with .Values.env }}
-          {{- if kindIs "slice" .Values.env }}
-        {{- toYaml .Values.env | nindent 8 }}
+          {{- if kindIs "slice" . }}
+            {{- toYaml . | nindent 8 }}
           {{- else }}
-            {{- range $key, $val := .Values.env }}
+            {{- range $key, $val := . }}
         - name: {{ $key }}
           value: {{ $val | quote }}
             {{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -71,11 +71,6 @@ spec:
         {{- with .Values.env }}
           {{- if kindIs "slice" . }}
             {{- toYaml . | nindent 8 }}
-          {{- else }}
-            {{- range $key, $val := . }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-            {{- end }}
           {{- end }}
         {{- end }}
         {{- with .Values.resources }}

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -390,6 +390,8 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 			"imagePullSecrets[0].name":     "dockerhub",
 			"nameOverride":                 "gha-runner-scale-set-controller-override",
 			"fullnameOverride":             "gha-runner-scale-set-controller-fullname-override",
+			"env[0].name":                  "ENV_VAR_NAME_1",
+			"env[0].value":                 "ENV_VAR_VALUE_1",
 			"serviceAccount.name":          "gha-runner-scale-set-controller-sa",
 			"podAnnotations.foo":           "bar",
 			"podSecurityContext.fsGroup":   "1000",
@@ -432,6 +434,9 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 	assert.Equal(t, "bar", deployment.Spec.Template.Annotations["foo"])
 	assert.Equal(t, "manager", deployment.Spec.Template.Annotations["kubectl.kubernetes.io/default-container"])
 
+	assert.Equal(t, "ENV_VAR_NAME_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Name)
+	assert.Equal(t, "ENV_VAR_VALUE_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Value)
+
 	assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, 1)
 	assert.Equal(t, "dockerhub", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
 	assert.Equal(t, "gha-runner-scale-set-controller-sa", deployment.Spec.Template.Spec.ServiceAccountName)
@@ -467,9 +472,12 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 	assert.Equal(t, "--auto-scaler-image-pull-secrets=dockerhub", deployment.Spec.Template.Spec.Containers[0].Args[1])
 	assert.Equal(t, "--log-level=debug", deployment.Spec.Template.Spec.Containers[0].Args[2])
 
-	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 3)
 	assert.Equal(t, "CONTROLLER_MANAGER_CONTAINER_IMAGE", deployment.Spec.Template.Spec.Containers[0].Env[0].Name)
 	assert.Equal(t, managerImage, deployment.Spec.Template.Spec.Containers[0].Env[0].Value)
+
+	assert.Equal(t, "ENV_VAR_NAME_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Name)
+	assert.Equal(t, "ENV_VAR_VALUE_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Value)
 
 	assert.Equal(t, "CONTROLLER_MANAGER_POD_NAMESPACE", deployment.Spec.Template.Spec.Containers[0].Env[1].Name)
 	assert.Equal(t, "metadata.namespace", deployment.Spec.Template.Spec.Containers[0].Env[1].ValueFrom.FieldRef.FieldPath)
@@ -702,6 +710,45 @@ func TestTemplate_ControllerDeployment_WatchSingleNamespace(t *testing.T) {
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, 1)
 	assert.Equal(t, "tmp", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
 	assert.Equal(t, "/tmp", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
+}
+
+func TestTemplate_ControllerContainerEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set-controller")
+	require.NoError(t, err)
+
+	releaseName := "test-arc"
+	namespaceName := "test-" + strings.ToLower(random.UniqueId())
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"env[0].Name":                            "ENV_VAR_NAME_1",
+			"env[0].Value":                           "ENV_VAR_VALUE_1",
+			"env[1].Name":                            "ENV_VAR_NAME_2",
+			"env[1].ValueFrom.SecretKeyRef.Key":      "ENV_VAR_NAME_2",
+			"env[1].ValueFrom.SecretKeyRef.Name":     "secret-name",
+			"env[1].ValueFrom.SecretKeyRef.Optional": "true",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/deployment.yaml"})
+
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, output, &deployment)
+
+	assert.Equal(t, namespaceName, deployment.Namespace)
+	assert.Equal(t, "test-arc-gha-runner-scale-set-controller", deployment.Name)
+
+	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 4)
+	assert.Equal(t, "ENV_VAR_NAME_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Name)
+	assert.Equal(t, "ENV_VAR_VALUE_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Value)
+	assert.Equal(t, "ENV_VAR_NAME_2", deployment.Spec.Template.Spec.Containers[0].Env[3].Name)
+	assert.Equal(t, "secret-name", deployment.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "ENV_VAR_NAME_2", deployment.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Key)
+	assert.True(t, *deployment.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Optional)
 }
 
 func TestTemplate_WatchSingleNamespace_NotCreateManagerClusterRole(t *testing.T) {

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -730,6 +730,9 @@ func TestTemplate_ControllerContainerEnvironmentVariables(t *testing.T) {
 			"env[1].ValueFrom.SecretKeyRef.Key":      "ENV_VAR_NAME_2",
 			"env[1].ValueFrom.SecretKeyRef.Name":     "secret-name",
 			"env[1].ValueFrom.SecretKeyRef.Optional": "true",
+			"env[2].Name":                            "ENV_VAR_NAME_3",
+			"env[2].Value":                           "",
+			"env[3].Name":                            "ENV_VAR_NAME_4",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -742,13 +745,17 @@ func TestTemplate_ControllerContainerEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, namespaceName, deployment.Namespace)
 	assert.Equal(t, "test-arc-gha-runner-scale-set-controller", deployment.Name)
 
-	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 4)
+	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 6)
 	assert.Equal(t, "ENV_VAR_NAME_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Name)
 	assert.Equal(t, "ENV_VAR_VALUE_1", deployment.Spec.Template.Spec.Containers[0].Env[2].Value)
 	assert.Equal(t, "ENV_VAR_NAME_2", deployment.Spec.Template.Spec.Containers[0].Env[3].Name)
 	assert.Equal(t, "secret-name", deployment.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Name)
 	assert.Equal(t, "ENV_VAR_NAME_2", deployment.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Key)
 	assert.True(t, *deployment.Spec.Template.Spec.Containers[0].Env[3].ValueFrom.SecretKeyRef.Optional)
+	assert.Equal(t, "ENV_VAR_NAME_3", deployment.Spec.Template.Spec.Containers[0].Env[4].Name)
+	assert.Empty(t, deployment.Spec.Template.Spec.Containers[0].Env[4].Value)
+	assert.Equal(t, "ENV_VAR_NAME_4", deployment.Spec.Template.Spec.Containers[0].Env[5].Name)
+	assert.Empty(t, deployment.Spec.Template.Spec.Containers[0].Env[5].ValueFrom)
 }
 
 func TestTemplate_WatchSingleNamespace_NotCreateManagerClusterRole(t *testing.T) {

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -18,22 +18,22 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-## Define environment variables for the controller pod
-## There are 2 ways you could use this field:
-##
-## Option 1:
-##   env:
-##   - name: "ENV_VAR_NAME_1"
-##   value: "ENV_VAR_VALUE_1"
-##   - name: "ENV_VAR_NAME_2"
-##   valueFrom:
-##     secretKeyRef:
-##       key: ENV_VAR_NAME_2
-##       name: secret-name
-##       optional: true
-##
-## Option 2:
-##   env: {"ENV_VAR_NAME_1": "ENV_VAR_VALUE_1", "ENV_VAR_NAME_2": "ENV_VAR_VALUE_2}
+# Define environment variables for the controller pod
+# There are 2 ways you could use this field:
+#
+# Option 1:
+#   env:
+#   - name: "ENV_VAR_NAME_1"
+#   value: "ENV_VAR_VALUE_1"
+#   - name: "ENV_VAR_NAME_2"
+#   valueFrom:
+#     secretKeyRef:
+#       key: ENV_VAR_NAME_2
+#       name: secret-name
+#       optional: true
+#
+# Option 2:
+#   env: {"ENV_VAR_NAME_1": "ENV_VAR_VALUE_1", "ENV_VAR_NAME_2": "ENV_VAR_VALUE_2}
 env:
 
 serviceAccount:
@@ -60,10 +60,10 @@ securityContext: {}
 # runAsUser: 1000
 
 resources: {}
-# We usually recommend not to specify default resources and to leave this as a conscious
-# choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube. If you do want to specify resources, uncomment the following
-# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
 # limits:
 #   cpu: 100m
 #   memory: 128Mi
@@ -87,6 +87,6 @@ flags:
   # Defaults to "debug".
   logLevel: "debug"
 
-  # Restricts the controller to only watch resources in the desired namespace.
-  # Defaults to watch all namespaces when unset.
+  ## Restricts the controller to only watch resources in the desired namespace.
+  ## Defaults to watch all namespaces when unset.
   # watchSingleNamespace: ""

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -18,6 +18,11 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+## Define environment variables for the controller pod
+env: {}
+# - name: ""
+#   value: ""
+
 serviceAccount:
   # Specifies whether a service account should be created for running the controller pod
   create: true

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -19,9 +19,22 @@ nameOverride: ""
 fullnameOverride: ""
 
 ## Define environment variables for the controller pod
-env: {}
-# - name: ""
-#   value: ""
+## There are 2 ways you could use this field:
+##
+## Option 1:
+##   env:
+##   - name: "ENV_VAR_NAME_1"
+##   value: "ENV_VAR_VALUE_1"
+##   - name: "ENV_VAR_NAME_2"
+##   valueFrom:
+##     secretKeyRef:
+##       key: ENV_VAR_NAME_2
+##       name: secret-name
+##       optional: true
+##
+## Option 2:
+##   env: {"ENV_VAR_NAME_1": "ENV_VAR_VALUE_1", "ENV_VAR_NAME_2": "ENV_VAR_VALUE_2}
+env:
 
 serviceAccount:
   # Specifies whether a service account should be created for running the controller pod
@@ -36,27 +49,27 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+# fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
 
 nodeSelector: {}
 

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -18,23 +18,16 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# Define environment variables for the controller pod
-# There are 2 ways you could use this field:
-#
-# Option 1:
-#   env:
-#   - name: "ENV_VAR_NAME_1"
-#   value: "ENV_VAR_VALUE_1"
-#   - name: "ENV_VAR_NAME_2"
-#   valueFrom:
-#     secretKeyRef:
-#       key: ENV_VAR_NAME_2
-#       name: secret-name
-#       optional: true
-#
-# Option 2:
-#   env: {"ENV_VAR_NAME_1": "ENV_VAR_VALUE_1", "ENV_VAR_NAME_2": "ENV_VAR_VALUE_2}
 env:
+## Define environment variables for the controller pod
+#  - name: "ENV_VAR_NAME_1"
+#    value: "ENV_VAR_VALUE_1"
+#  - name: "ENV_VAR_NAME_2"
+#    valueFrom:
+#      secretKeyRef:
+#        key: ENV_VAR_NAME_2
+#        name: secret-name
+#        optional: true
 
 serviceAccount:
   # Specifies whether a service account should be created for running the controller pod


### PR DESCRIPTION
The chart was unable to properly parse the `env` list to add the variables to the controller pod. This fixes it.
