### PR TITLE
Treat `.ghe.com` domain as hosted environment

### DIFF
--- a/github/actions/config.go
+++ b/github/actions/config.go
@@ -80,14 +80,11 @@ func (c *GitHubConfig) GitHubAPIURL(path string) *url.URL {
 	isHosted := isHostedGitHubURL(c.ConfigURL)
 
 	if isHosted {
-		// Hosted
-		if strings.EqualFold("github.com", c.ConfigURL.Host) ||
-			strings.EqualFold("github.localhost", c.ConfigURL.Host) ||
-			strings.HasSuffix(c.ConfigURL.Host, ".ghe.com") {
-			result.Host = fmt.Sprintf("api.%s", c.ConfigURL.Host)
-		} else if strings.EqualFold("www.github.com", c.ConfigURL.Host) {
+		if strings.EqualFold("www.github.com", c.ConfigURL.Host) {
 			// re-routing www.github.com to api.github.com
 			result.Host = "api.github.com"
+		} else {
+		        result.Host = fmt.Sprintf("api.%s", c.ConfigURL.Host)
 		}
 	} else {
 		// Enterprise


### PR DESCRIPTION
Copy the logic from https://github.com/actions/runner/pull/2420 and make ARC consider the URL ends with  `.ghe.com` as the hosted environment.

https://github.com/github/c2c-actions/issues/6135