### PR TITLE
Remove deprecated method.

### DIFF
--- a/testing/random.go
+++ b/testing/random.go
@@ -5,17 +5,17 @@ import (
 	"time"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 const letterBytes = "abcdefghijklmnopqrstuvwxyz"
+
+var (
+	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
 
 // Copied from https://stackoverflow.com/a/31832326 with thanks
 func RandStringBytesRmndr(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+		b[i] = letterBytes[random.Int63()%int64(len(letterBytes))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
```
lint: testing/random.go#L9SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access.  (staticcheck)
```

https://github.com/actions/actions-runner-controller/actions/runs/4611217178