### PR TITLE
chart: Bump version to 0.23.1

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.0
+version: 0.23.1
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.1
+appVersion: 0.27.2
 
 home: https://github.com/actions/actions-runner-controller
 


### PR DESCRIPTION
This pull request will update the image tag to v0.27.2.
https://github.com/actions/actions-runner-controller/releases/tag/v0.27.2

Could you create a new release of Helm chart?

Related to https://github.com/actions/actions-runner-controller/pull/2449#issuecomment-1491972974.