### PR TITLE
Add CR and CRB to the helm chart

### DIFF
--- a/charts/actions-runner-controller/templates/actionsmetrics.role.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.githubWebhookServer.enabled }}
+{{- if .Values.actionsMetricsServer.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/actions-runner-controller/templates/actionsmetrics.role.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.role.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.githubWebhookServer.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: {{ include "actions-runner-controller-actions-metrics-server.roleName" . }}
+rules:
+- apiGroups: 
+  - actions.summerwind.dev
+  resources:
+  - horizontalrunnerautoscalers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - actions.summerwind.dev
+  resources:
+  - horizontalrunnerautoscalers/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - actions.summerwind.dev
+  resources:
+  - horizontalrunnerautoscalers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - actions.summerwind.dev
+  resources:
+  - runnersets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - actions.summerwind.dev
+  resources:
+  - runnerdeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - actions.summerwind.dev
+  resources:
+  - runnerdeployments/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - actions.summerwind.dev
+  resources:
+  - runnerdeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/charts/actions-runner-controller/templates/actionsmetrics.role_binding.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.role_binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.githubWebhookServer.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "actions-runner-controller-actions-metrics-server.roleName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "actions-runner-controller-actions-metrics-server.roleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "actions-runner-controller-actions-metrics-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/actions-runner-controller/templates/actionsmetrics.role_binding.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.role_binding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.githubWebhookServer.enabled }}
+{{- if .Values.actionsMetricsServer.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/actions-runner-controller/templates/actionsmetrics.service.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "actions-runner-controller-actions-metrics-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "actions-runner-controller.labels" . | nindent 4 }}
+    {{- include "actions-runner-controller-actions-metrics-server.selectorLabels" . | nindent 4 }}
 {{- if .Values.actionsMetricsServer.service.annotations }}
   annotations:
     {{ toYaml .Values.actionsMetricsServer.service.annotations | nindent 4 }}


### PR DESCRIPTION
In response to https://github.com/actions/actions-runner-controller/issues/2212 , the ARC helm chart is missing ClusterRoleBinding and ClusterRole for the ActionsMetricsServer resulting on missing permissions.

This also fix the labels of the ActionsMetricsServer Service as it is selected by the ServiceMonitor with those labels.