### PR TITLE
Update ubuntu-22.04 Dockerfile to add python user script dir

### DIFF
--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -98,6 +98,8 @@ COPY docker-shim.sh /usr/local/bin/docker
 # Configure hooks folder structure.
 COPY hooks /etc/arc/hooks/
 
+# Add the Python "User Script Directory" to the PATH
+ENV PATH="${PATH}:${HOME}/.local/bin/"
 ENV ImageOS=ubuntu22
 
 RUN echo "PATH=${PATH}" > /etc/environment \


### PR DESCRIPTION
I was running into an issue after upgrading our ubuntu image to build off of 22.04 instead of 20.04 where pipx was looking like it wasn't found even though pulling my image showed pipx was installed. I noticed this line missing from the 22.04 Dockerfile that is present in 20.04.

I figured I'd open a PR adding it to keep the behavior consistent for future upgraders.