### PR TITLE
Fix the path of the index.yaml in job summary

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -204,4 +204,4 @@ jobs:
         echo "New helm chart has been published" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Status:**" >> $GITHUB_STEP_SUMMARY
-        echo "- New [index.yaml](https://github.com/${{ env.CHART_TARGET_ORG }}/${{ env.CHART_TARGET_REPO }}/tree/main/actions-runner-controller) pushed" >> $GITHUB_STEP_SUMMARY
+        echo "- New [index.yaml](https://github.com/${{ env.CHART_TARGET_ORG }}/${{ env.CHART_TARGET_REPO }}/tree/master/actions-runner-controller) pushed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Fixes the path of the `index.yaml` in the publish helm chart workflow's job summary. The default branch was incorrectly defined as main instead of master.

![CleanShot 2023-04-17 at 15 06 07](https://user-images.githubusercontent.com/568794/232492809-f9e8ba65-67db-4141-aa81-cb843d786df1.png)
