### PR TITLE
Fix how hosted URLs are identified

### DIFF
--- a/github/actions/config.go
+++ b/github/actions/config.go
@@ -102,8 +102,7 @@ func isHostedGitHubURL(u *url.URL) bool {
 		return false
 	}
 
-	return strings.EqualFold(u.Host, "github.com") ||
-		strings.EqualFold(u.Host, "www.github.com") ||
+	return strings.HasSuffix(u.Host, "github.com") ||
 		strings.EqualFold(u.Host, "github.localhost") ||
 		strings.HasSuffix(u.Host, ".ghe.com")
 }

--- a/github/actions/config_test.go
+++ b/github/actions/config_test.go
@@ -128,6 +128,16 @@ func TestGitHubConfig(t *testing.T) {
 					IsHosted:     true,
 				},
 			},
+			{
+				configURL: "https://anything.github.com/org/",
+				expected: &actions.GitHubConfig{
+					Scope:        actions.GitHubScopeOrganization,
+					Enterprise:   "",
+					Organization: "org",
+					Repository:   "",
+					IsHosted:     true,
+				},
+			},
 		}
 
 		for _, test := range tests {


### PR DESCRIPTION
### Context

This change ignores anything that comes before the domain and tld in identifying hosted config URLs.