### PR TITLE
Revert actions-runner-controller image tag in kustomization to latest

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: summerwind/actions-runner-controller
-  newTag: dev
+  newTag: latest
 
 replacements:
 - path: env-replacement.yaml


### PR DESCRIPTION
The tag was changed to `dev` in commit [`aa6dab5`](https://github.com/actions/actions-runner-controller/commit/aa6dab5a9ac2a730ecd009a45ca49c7413fd8c42). This tag does not exist.