### PR TITLE
Check release tag version and chart versions during the release process

### DIFF
--- a/.github/workflows/publish-runner-scale-set.yaml
+++ b/.github/workflows/publish-runner-scale-set.yaml
@@ -47,6 +47,10 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Check chart versions
+        # Binary version and chart versions need to match.
+        # In case of an upgrade, the controller will try to clean up
+        # resources with older versions that should have been cleaned up
+        # during the upgrade process
         run: ./hack/check-gh-chart-versions.sh ${{ inputs.release_tag_name }}
 
       - name: Resolve parameters

--- a/.github/workflows/publish-runner-scale-set.yaml
+++ b/.github/workflows/publish-runner-scale-set.yaml
@@ -36,7 +36,7 @@ permissions:
  packages: write
 
 jobs:
-  build-push-image: 
+  build-push-image:
     name: Build and push controller image
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +46,10 @@ jobs:
           # If inputs.ref is empty, it'll resolve to the default branch
           ref: ${{ inputs.ref }}
 
-      - name: Resolve parameters 
+      - name: Check chart versions
+        run: ./hack/check-gh-chart-versions.sh
+
+      - name: Resolve parameters
         id: resolve_parameters
         run: |
           resolvedRef="${{ inputs.ref }}"
@@ -67,7 +70,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           # Pinning v0.9.1 for Buildx and BuildKit v0.10.6
-          # BuildKit v0.11 which has a bug causing intermittent 
+          # BuildKit v0.11 which has a bug causing intermittent
           # failures pushing images to GHCR
           version: v0.9.1
           driver-opts: image=moby/buildkit:v0.10.6
@@ -115,7 +118,7 @@ jobs:
           # If inputs.ref is empty, it'll resolve to the default branch
           ref: ${{ inputs.ref }}
 
-      - name: Resolve parameters 
+      - name: Resolve parameters
         id: resolve_parameters
         run: |
           resolvedRef="${{ inputs.ref }}"
@@ -126,7 +129,7 @@ jobs:
           echo "INFO: Resolving short SHA for $resolvedRef"
           echo "short_sha=$(git rev-parse --short $resolvedRef)" >> $GITHUB_OUTPUT
           echo "INFO: Normalizing repository name (lowercase)"
-          echo "repository_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT 
+          echo "repository_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Set up Helm
         # Using https://github.com/Azure/setup-helm/releases/tag/v3.5
@@ -163,7 +166,7 @@ jobs:
           # If inputs.ref is empty, it'll resolve to the default branch
           ref: ${{ inputs.ref }}
 
-      - name: Resolve parameters 
+      - name: Resolve parameters
         id: resolve_parameters
         run: |
           resolvedRef="${{ inputs.ref }}"
@@ -174,7 +177,7 @@ jobs:
           echo "INFO: Resolving short SHA for $resolvedRef"
           echo "short_sha=$(git rev-parse --short $resolvedRef)" >> $GITHUB_OUTPUT
           echo "INFO: Normalizing repository name (lowercase)"
-          echo "repository_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT 
+          echo "repository_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Set up Helm
         # Using https://github.com/Azure/setup-helm/releases/tag/v3.5

--- a/.github/workflows/publish-runner-scale-set.yaml
+++ b/.github/workflows/publish-runner-scale-set.yaml
@@ -47,7 +47,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Check chart versions
-        run: ./hack/check-gh-chart-versions.sh
+        run: ./hack/check-gh-chart-versions.sh ${{ inputs.release_tag_name }}
 
       - name: Resolve parameters
         id: resolve_parameters

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ bin
 .DS_STORE
 
 /test-assets
+
+/.tools

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ generate: controller-gen
 
 # Run shellcheck on runner scripts
 shellcheck: shellcheck-install
-	$(TOOLS_PATH)/shellcheck --shell bash --source-path runner runner/*.sh
+	$(TOOLS_PATH)/shellcheck --shell bash --source-path runner runner/*.sh hack/*.sh
 
 docker-buildx:
 	export DOCKER_CLI_EXPERIMENTAL=enabled ;\

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -14,7 +14,7 @@ target_version=$1
 if [[ $# -eq 0 ]]; then
     echo "Release version argument is required"
     echo
-    echo "Usage:  ${0} <release version>"
+    echo "Usage:  ${0} <VERSION>"
     exit 1
 fi
 

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+set -eo pipefail
 TEXT_RED='\033[0;31m'
 TEXT_RESET='\033[0m'
 TEXT_GREEN='\033[0;32m'

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -20,8 +20,12 @@ controller_app_version=$(cat $chart_dir/gha-runner-scale-set-controller/Chart.ya
 scaleset_version=$(cat $chart_dir/gha-runner-scale-set/Chart.yaml | yq .version)
 scaleset_app_version=$(cat $chart_dir/gha-runner-scale-set/Chart.yaml | yq .appVersion)
 
-if [[ $controller_version != $controller_app_version ]] || [[ $controller_version != $scaleset_version ]] || [[ $controller_version != $scaleset_app_version ]]; then
+if [[ $controller_version != $target_version ]] ||
+   [[ $controller_app_version != $target_version ]] ||
+   [[ $scaleset_version != $target_version ]] ||
+   [[ $scaleset_app_version != $target_version ]]; then
     echo -e "${TEXT_RED}Chart versions do not match${TEXT_RESET}"
+    echo "Target version:         $target_version"
     echo "Controller version:     $controller_version"
     echo "Controller app version: $controller_app_version"
     echo "Scale set version:      $scaleset_version"

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -4,6 +4,14 @@ TEXT_RED='\033[0;31m'
 TEXT_RESET='\033[0m'
 TEXT_GREEN='\033[0;32m'
 
+target_version=$1
+if [[ $# -eq 0 ]]; then
+    echo "Release version argument is required"
+    echo
+    echo "Usage:  ${0} <release version>"
+    exit 1
+fi
+
 chart_dir=$(pwd)/charts
 
 controller_version=$(cat $chart_dir/gha-runner-scale-set-controller/Chart.yaml | yq .version)

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
+# Checks the chart versions against an input version. Fails on mismatch.
+#
+# Usage:
+#   check-gh-chart-versions.sh <VERSION>
+
 set -eo pipefail
+
 TEXT_RED='\033[0;31m'
 TEXT_RESET='\033[0m'
 TEXT_GREEN='\033[0;32m'
@@ -14,23 +20,23 @@ fi
 
 chart_dir=$(pwd)/charts
 
-controller_version=$(cat $chart_dir/gha-runner-scale-set-controller/Chart.yaml | yq .version)
-controller_app_version=$(cat $chart_dir/gha-runner-scale-set-controller/Chart.yaml | yq .appVersion)
+controller_version=$(yq .version < "${chart_dir}/gha-runner-scale-set-controller/Chart.yaml")
+controller_app_version=$(yq .appVersion < "${chart_dir}/gha-runner-scale-set-controller/Chart.yaml")
 
-scaleset_version=$(cat $chart_dir/gha-runner-scale-set/Chart.yaml | yq .version)
-scaleset_app_version=$(cat $chart_dir/gha-runner-scale-set/Chart.yaml | yq .appVersion)
+scaleset_version=$(yq .version < "${chart_dir}/gha-runner-scale-set/Chart.yaml")
+scaleset_app_version=$(yq .appVersion < "${chart_dir}/gha-runner-scale-set/Chart.yaml")
 
-if [[ $controller_version != $target_version ]] ||
-   [[ $controller_app_version != $target_version ]] ||
-   [[ $scaleset_version != $target_version ]] ||
-   [[ $scaleset_app_version != $target_version ]]; then
+if [[ "${controller_version}" != "${target_version}" ]] ||
+   [[ "${controller_app_version}" != "${target_version}" ]] ||
+   [[ "${scaleset_version}" != "${target_version}" ]] ||
+   [[ "${scaleset_app_version}" != "${target_version}" ]]; then
     echo -e "${TEXT_RED}Chart versions do not match${TEXT_RESET}"
-    echo "Target version:         $target_version"
-    echo "Controller version:     $controller_version"
-    echo "Controller app version: $controller_app_version"
-    echo "Scale set version:      $scaleset_version"
-    echo "Scale set app version:  $scaleset_app_version"
+    echo "Target version:         ${target_version}"
+    echo "Controller version:     ${controller_version}"
+    echo "Controller app version: ${controller_app_version}"
+    echo "Scale set version:      ${scaleset_version}"
+    echo "Scale set app version:  ${scaleset_app_version}"
     exit 1
 fi
 
-echo -e "${TEXT_GREEN}Chart versions: $controller_version"
+echo -e "${TEXT_GREEN}Chart versions: ${controller_version}"

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -18,7 +18,7 @@ if [[ $# -eq 0 ]]; then
     exit 1
 fi
 
-chart_dir=$(pwd)/charts
+chart_dir="$(pwd)/charts"
 
 controller_version=$(yq .version < "${chart_dir}/gha-runner-scale-set-controller/Chart.yaml")
 controller_app_version=$(yq .appVersion < "${chart_dir}/gha-runner-scale-set-controller/Chart.yaml")

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+TEXT_RED='\033[0;31m'
+TEXT_RESET='\033[0m'
+
+chart_dir=$(pwd)/charts
+
+controller_version=$(cat $chart_dir/gha-runner-scale-set-controller/Chart.yaml | yq .version)
+controller_app_version=$(cat $chart_dir/gha-runner-scale-set-controller/Chart.yaml | yq .appVersion)
+
+scaleset_version=$(cat $chart_dir/gha-runner-scale-set/Chart.yaml | yq .version)
+scaleset_app_version=$(cat $chart_dir/gha-runner-scale-set/Chart.yaml | yq .appVersion)
+
+if [[ $controller_version != $controller_app_version ]] || [[ $controller_version != $scaleset_version ]] || [[ $controller_version != $scaleset_app_version ]]; then
+    echo -e "${TEXT_RED}Chart versions do not match${TEXT_RESET}"
+    echo "Controller version:     " $controller_version
+    echo "Controller app version: " $controller_app_version
+    echo "Scale set version:      " $scaleset_version
+    echo "Scale set app version:  " $scaleset_app_version
+    exit 1
+fi
+
+echo "Chart versions: $controller_version"

--- a/hack/check-gh-chart-versions.sh
+++ b/hack/check-gh-chart-versions.sh
@@ -2,6 +2,7 @@
 #
 TEXT_RED='\033[0;31m'
 TEXT_RESET='\033[0m'
+TEXT_GREEN='\033[0;32m'
 
 chart_dir=$(pwd)/charts
 
@@ -13,11 +14,11 @@ scaleset_app_version=$(cat $chart_dir/gha-runner-scale-set/Chart.yaml | yq .appV
 
 if [[ $controller_version != $controller_app_version ]] || [[ $controller_version != $scaleset_version ]] || [[ $controller_version != $scaleset_app_version ]]; then
     echo -e "${TEXT_RED}Chart versions do not match${TEXT_RESET}"
-    echo "Controller version:     " $controller_version
-    echo "Controller app version: " $controller_app_version
-    echo "Scale set version:      " $scaleset_version
-    echo "Scale set app version:  " $scaleset_app_version
+    echo "Controller version:     $controller_version"
+    echo "Controller app version: $controller_app_version"
+    echo "Scale set version:      $scaleset_version"
+    echo "Scale set app version:  $scaleset_app_version"
     exit 1
 fi
 
-echo "Chart versions: $controller_version"
+echo -e "${TEXT_GREEN}Chart versions: $controller_version"

--- a/hack/make-env.sh
+++ b/hack/make-env.sh
@@ -2,7 +2,7 @@
 
 COMMIT=$(git rev-parse HEAD)
 TAG=$(git describe --exact-match --abbrev=0 --tags "${COMMIT}" 2> /dev/null || true)
-BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | sed -e 's/[^a-zA-Z0-9+=._:/-]*//g' || true)
+BRANCH=$(git branch | grep "\*" | cut -d ' ' -f2 | sed -e 's/[^a-zA-Z0-9+=._:/-]*//g' || true)
 VERSION=""
 
 if [ -z "$TAG" ]; then


### PR DESCRIPTION
Charts published along with the image should match the image version. This check aims to make sure that binary version and version of charts are the same