### PR TITLE
Bump chart version to v0.23.3 for ARC v0.27.4

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.2
+version: 0.23.3
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.3
+appVersion: 0.27.4
 
 home: https://github.com/actions/actions-runner-controller
 


### PR DESCRIPTION
Sorry for the delayed release!

This chart version is mainly for upgrading ARC to v0.27.4, along with a few fixes to the chart itself (#2504, #2498)

Please also refer to https://github.com/actions/actions-runner-controller/releases/tag/v0.27.4 for more details about changes made in ARC v0.27.4.