### PR TITLE
Make `github_app_installation_id` optional

### DIFF
--- a/github/actions/multi_client.go
+++ b/github/actions/multi_client.go
@@ -2,11 +2,16 @@ package actions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 type MultiClient interface {
@@ -40,6 +45,15 @@ type ActionsAuth struct {
 type ActionsClientKey struct {
 	Identifier string
 	Namespace  string
+}
+
+type AppInstallationAccount struct {
+	Login string `json:"login"`
+}
+
+type AppInstallation struct {
+	ID      int64                  `json:"id"`
+	Account AppInstallationAccount `json:"account"`
 }
 
 func NewMultiClient(userAgent string, logger logr.Logger) MultiClient {
@@ -110,7 +124,7 @@ func (m *multiClient) GetClientFromSecret(ctx context.Context, githubConfigURL, 
 	appID := string(secretData["github_app_id"])
 	appInstallationID := string(secretData["github_app_installation_id"])
 	appPrivateKey := string(secretData["github_app_private_key"])
-	hasGitHubAppAuth := len(appID) > 0 && len(appInstallationID) > 0 && len(appPrivateKey) > 0
+	hasGitHubAppAuth := len(appID) > 0 && len(appPrivateKey) > 0
 
 	if hasToken && hasGitHubAppAuth {
 		return nil, fmt.Errorf("must provide secret with only PAT or GitHub App Auth to avoid ambiguity in client behavior")
@@ -132,11 +146,93 @@ func (m *multiClient) GetClientFromSecret(ctx context.Context, githubConfigURL, 
 		return nil, err
 	}
 
-	parsedAppInstallationID, err := strconv.ParseInt(appInstallationID, 10, 64)
-	if err != nil {
-		return nil, err
+	var parsedAppInstallationID int64
+	if len(appInstallationID) <= 0 {
+		config, err := ParseGitHubConfigFromURL(githubConfigURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse githubConfigURL: %w", err)
+		}
+
+		appToken, err := m.createAppJWT(appPrivateKey, parsedAppID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create app JWT: %w", err)
+		}
+
+		installations, err := m.listAppInstallations(config, appToken)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list app installations: %w", err)
+		}
+
+		for _, installation := range installations {
+			if installation.Account.Login == config.Organization {
+				parsedAppInstallationID = installation.ID
+				break
+			}
+		}
+
+		if parsedAppInstallationID == 0 {
+			return nil, fmt.Errorf("app installation id was not provided and can't find it automatically: %w", err)
+		}
+	} else {
+		parsedAppInstallationID, err = strconv.ParseInt(appInstallationID, 10, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	auth.AppCreds = &GitHubAppAuth{AppID: parsedAppID, AppInstallationID: parsedAppInstallationID, AppPrivateKey: appPrivateKey}
 	return m.GetClientFor(ctx, githubConfigURL, auth, namespace, options...)
+}
+
+func (m *multiClient) createAppJWT(privateKey string, appID int64) (string, error) {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(privateKey))
+	if err != nil {
+		return "", err
+	}
+
+	t := jwt.New(jwt.GetSigningMethod("RS256"))
+	t.Claims = &jwt.RegisteredClaims{
+		IssuedAt:  &jwt.NumericDate{Time: time.Now().Add(-time.Second * 60)}, // Allow 1 minute drift
+		ExpiresAt: &jwt.NumericDate{Time: time.Now().Add(time.Minute * 9)},   // Max is 10 mins, allow 1 minute drift
+		Issuer:    strconv.FormatInt(appID, 10),
+	}
+
+	token, err := t.SignedString(signKey)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+func (m *multiClient) listAppInstallations(config *GitHubConfig, appToken string) ([]AppInstallation, error) {
+	url := config.GitHubAPIURL("/app/installations")
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header = http.Header{
+		"Accept":        []string{"application/vnd.github.v3+json"},
+		"Authorization": []string{"Bearer " + appToken},
+	}
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	installations := []AppInstallation{}
+	if err := json.Unmarshal(body, &installations); err != nil {
+		return nil, err
+	}
+
+	return installations, nil
 }


### PR DESCRIPTION
Fixes #2584

https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app explains how to authenticate to GitHub "as app". The process is as simple as generating a local JWT and signing it with that same private key from github_app_private_key. The token has to be expiring within 15 minutes. Then you can list all installations of the app using a request like this:

```
curl --request GET \
--url "https://api.github.com/app/installations" \
--header "Accept: application/vnd.github+json" \
--header "Authorization: Bearer YOUR_JWT" \
--header "X-GitHub-Api-Version: 2022-11-28"
```

In the response you can find github_app_installation_id mapping to the respective organizations by their slug. Therefore the github_app_id and the github_app_private_key is sufficient enough information, and that one secret can be reused across as many organizations as needed as long as app is installed on them.