### PR TITLE
chore: Templates written in dind are now reflected.

### DIFF
--- a/charts/gha-runner-scale-set/tests/values_dind_merge_dind_container.yaml
+++ b/charts/gha-runner-scale-set/tests/values_dind_merge_dind_container.yaml
@@ -1,0 +1,33 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+template:
+  spec:
+    containers:
+    - name: dind
+      image: docker:dind
+      env:
+      - name: TEST_ENV
+        value: test1234
+      - name: MY_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
+      - name: dind-cert
+        mountPath: /certs/client
+      - name: dind-externals
+        mountPath: /home/runner/externals
+      - name: others
+        mountPath: /others
+      securityContext:
+        privileged: false
+        runAsUser: 8888
+      resources:
+        limits:
+          memory: 64Mi
+          cpu: 250m
+containerMode:
+  type: dind


### PR DESCRIPTION
You may want to change various items in dind, for example
We have supported this while maintaining backward compatibility.

```yaml
template:
  spec:
    containers:
    - image: public.ecr.aws/docker/library/docker:dind
      imagePullPolicy: Always
      name: dind
      securityContext: null
      resources:
        limits:
          cpu: '4'
          memory: 2Gi
        requests:
          cpu: '4'
          memory: 2Gi
```