### PR TITLE
Add concurrency limits on all workflows to eliminate wasted cycles

### DIFF
--- a/.github/workflows/arc-publish-chart.yaml
+++ b/.github/workflows/arc-publish-chart.yaml
@@ -28,6 +28,10 @@ env:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   lint-chart:
     name: Lint Chart

--- a/.github/workflows/arc-publish.yaml
+++ b/.github/workflows/arc-publish.yaml
@@ -25,6 +25,10 @@ env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: actions-runner-controller
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   release-controller:
     name: Release

--- a/.github/workflows/arc-publish.yaml
+++ b/.github/workflows/arc-publish.yaml
@@ -97,15 +97,6 @@ jobs:
           jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${{ env.VERSION }}", "push_to_registries": "${{ env.PUSH_TO_REGISTRIES }}" }}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -
 
-      - name: Wait for the workflow to finish
-        run: sleep 5
-        # uses: peter-evans/wait-on-github-action@v1
-        # with:
-        #   github-token: ${{ secrets.GITHUB_TOKEN }}
-        #   workflow: "publish-arc.yaml"
-        #   event: "workflow_run"
-        #   workflow_conclusion: "success"
-
       - name: Job summary
         run: |
           echo "The [publish-arc](https://github.com/actions-runner-controller/releases/blob/main/.github/workflows/publish-arc.yaml) workflow has been triggered!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/arc-publish.yaml
+++ b/.github/workflows/arc-publish.yaml
@@ -97,6 +97,15 @@ jobs:
           jq -n '{"event_type": "arc", "client_payload": {"release_tag_name": "${{ env.VERSION }}", "push_to_registries": "${{ env.PUSH_TO_REGISTRIES }}" }}' \
             | gh api -X POST /repos/actions-runner-controller/releases/dispatches --input -
 
+      - name: Wait for the workflow to finish
+        run: sleep 5
+        # uses: peter-evans/wait-on-github-action@v1
+        # with:
+        #   github-token: ${{ secrets.GITHUB_TOKEN }}
+        #   workflow: "publish-arc.yaml"
+        #   event: "workflow_run"
+        #   workflow_conclusion: "success"
+
       - name: Job summary
         run: |
           echo "The [publish-arc](https://github.com/actions-runner-controller/releases/blob/main/.github/workflows/publish-arc.yaml) workflow has been triggered!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/arc-release-runners.yaml
+++ b/.github/workflows/arc-release-runners.yaml
@@ -19,6 +19,10 @@ env:
   TARGET_WORKFLOW: release-runners.yaml
   DOCKER_VERSION: 20.10.23
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build-runners:
     name: Trigger Build and Push of Runner Images

--- a/.github/workflows/arc-validate-chart.yaml
+++ b/.github/workflows/arc-validate-chart.yaml
@@ -28,8 +28,10 @@ permissions:
   contents: read
 
 concurrency:
-  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  # This will make sure we only apply the concurrency limits on pull requests 
+  # but not pushes to master branch by making the concurrency group name unique
+  # for pushes
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/arc-validate-chart.yaml
+++ b/.github/workflows/arc-validate-chart.yaml
@@ -27,6 +27,11 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-chart:
     name: Lint Chart

--- a/.github/workflows/arc-validate-chart.yaml
+++ b/.github/workflows/arc-validate-chart.yaml
@@ -31,7 +31,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/arc-validate-runners.yaml
+++ b/.github/workflows/arc-validate-runners.yaml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: runner / shellcheck

--- a/.github/workflows/arc-validate-runners.yaml
+++ b/.github/workflows/arc-validate-runners.yaml
@@ -13,8 +13,10 @@ permissions:
   contents: read
 
 concurrency:
-  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  # This will make sure we only apply the concurrency limits on pull requests 
+  # but not pushes to master branch by making the concurrency group name unique
+  # for pushes
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/arc-validate-runners.yaml
+++ b/.github/workflows/arc-validate-runners.yaml
@@ -16,7 +16,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -20,7 +20,8 @@ env:
 
 concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
-  # but not pushes to master branch
+  # but not pushes to master branch by making the concurrency group name unique
+  # for pushes
   group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -19,7 +19,8 @@ env:
   IMAGE_VERSION: "0.4.0"
 
 concurrency:
-  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
+  # This will make sure we only apply the concurrency limits on pull requests 
+  # but not pushes to master branch
   group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -19,6 +19,7 @@ env:
   IMAGE_VERSION: "0.4.0"
 
 concurrency:
+  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
   group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -22,7 +22,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -18,6 +18,10 @@ env:
   IMAGE_NAME: "arc-test-image"
   IMAGE_VERSION: "0.4.0"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == "pull_request" }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   default-setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -19,7 +19,7 @@ env:
   IMAGE_VERSION: "0.4.0"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == "pull_request" }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -20,7 +20,7 @@ env:
 
 concurrency:
   # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gha-publish-chart.yaml
+++ b/.github/workflows/gha-publish-chart.yaml
@@ -33,7 +33,11 @@ env:
   HELM_VERSION: v3.8.0
 
 permissions:
- packages: write
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   build-push-image:

--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -23,6 +23,11 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-chart:
     name: Lint Chart

--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -24,8 +24,10 @@ permissions:
   contents: read
 
 concurrency:
-  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  # This will make sure we only apply the concurrency limits on pull requests 
+  # but not pushes to master branch by making the concurrency group name unique
+  # for pushes
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -27,7 +27,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/global-publish-canary.yaml
+++ b/.github/workflows/global-publish-canary.yaml
@@ -37,6 +37,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   # Safeguard to prevent pushing images to registeries after build
   PUSH_TO_REGISTRIES: true

--- a/.github/workflows/global-run-codeql.yaml
+++ b/.github/workflows/global-run-codeql.yaml
@@ -10,6 +10,11 @@ on:
   schedule:
     - cron: '30 1 * * 0'
 
+concurrency:
+  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/global-run-codeql.yaml
+++ b/.github/workflows/global-run-codeql.yaml
@@ -14,7 +14,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/global-run-codeql.yaml
+++ b/.github/workflows/global-run-codeql.yaml
@@ -11,8 +11,10 @@ on:
     - cron: '30 1 * * 0'
 
 concurrency:
-  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  # This will make sure we only apply the concurrency limits on pull requests 
+  # but not pushes to master branch by making the concurrency group name unique
+  # for pushes
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) || github.run_id }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -19,8 +19,10 @@ permissions:
   contents: read
 
 concurrency:
-  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
-  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  # This will make sure we only apply the concurrency limits on pull requests 
+  # but not pushes to master branch by making the concurrency group name unique
+  # for pushes
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # This will make sure we only apply the concurrency limits on pull requests but not pushes to master
+  group: ${{ github.workflow }}-${{ contains(fromJSON('["pull_request"]'), github.event_name) }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Context

At the moment all workflows run without limits. This fix will guarantee:
1. All release workflows will have a concurrency limit of 1
2. All PR checks will have a concurrency limit of 1 per PR
3. All pushes to the master will run without limits

### Tests

https://github.com/Link-/actions-runner-controller/actions

#### TODO

- [x] This PR is associated and needs to be ✅ / merged as well: https://github.com/actions-runner-controller/releases/pull/9