### PR TITLE
Fix workflows concurrency group names

### DIFF
--- a/.github/workflows/arc-validate-chart.yaml
+++ b/.github/workflows/arc-validate-chart.yaml
@@ -31,7 +31,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/arc-validate-runners.yaml
+++ b/.github/workflows/arc-validate-runners.yaml
@@ -16,7 +16,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -22,7 +22,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -27,7 +27,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/global-run-codeql.yaml
+++ b/.github/workflows/global-run-codeql.yaml
@@ -14,7 +14,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,7 +22,7 @@ concurrency:
   # This will make sure we only apply the concurrency limits on pull requests 
   # but not pushes to master branch by making the concurrency group name unique
   # for pushes
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The concurrency group names are wrong. We need 1 instance per `workflow-(ref or run_id)` not 1 instance per `ref or run_id`. This fixes it.
