### PR TITLE
fix: allow resource requests in the dind container

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -88,6 +88,15 @@ volumeMounts:
 
 {{- define "gha-runner-scale-set.dind-container" -}}
 image: docker:dind
+{{- range $i, $container := .Values.template.spec.containers }}
+  {{- if eq $container.name "dind" }}
+    {{- range $key, $val := $container }}
+      {{- if and (ne $key "securityContext") (ne $key "volumeMounts") (ne $key "name") }}
+{{ $key }}: {{ $val | toYaml | nindent 2 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 securityContext:
   privileged: true
 volumeMounts:


### PR DESCRIPTION
Currently there is no way to set resource requests and limits on the DinD pod. 
It is possible for the runner pod so using the same mechanism to allow it for DinD so that it cannot take over nodes.