### PR TITLE
chore(gha-runner-scale-set): update indentation of initContainers

### DIFF
--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -119,7 +119,7 @@ spec:
         {{- include "gha-runner-scale-set.dind-init-container" . | nindent 8 }}
         {{- end }}
         {{- with .Values.template.spec.initContainers }}
-      {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
         {{- end }}
       {{- end }}
       containers:

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -694,6 +694,50 @@ func TestTemplateRenderedAutoScalingRunnerSet_ExtraVolumes(t *testing.T) {
 	assert.Equal(t, "/data", ars.Spec.Template.Spec.Volumes[2].HostPath.Path, "Volume host path should be /data")
 }
 
+func TestTemplateRenderedAutoScalingRunnerSet_DinD_ExtraInitContainers(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	testValuesPath, err := filepath.Abs("../tests/values_dind_extra_init_containers.yaml")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueId())
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
+		ValuesFiles:    []string{testValuesPath},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+
+	var ars v1alpha1.AutoscalingRunnerSet
+	helm.UnmarshalK8SYaml(t, output, &ars)
+
+	assert.Len(t, ars.Spec.Template.Spec.InitContainers, 3, "InitContainers should be 3")
+	assert.Equal(t, "kube-init", ars.Spec.Template.Spec.InitContainers[1].Name, "InitContainers[1] Name should be kube-init")
+	assert.Equal(t, "runner-image:latest", ars.Spec.Template.Spec.InitContainers[1].Image, "InitContainers[1] Image should be runner-image:latest")
+	assert.Equal(t, "sudo", ars.Spec.Template.Spec.InitContainers[1].Command[0], "InitContainers[1] Command[0] should be sudo")
+	assert.Equal(t, "chown", ars.Spec.Template.Spec.InitContainers[1].Command[1], "InitContainers[1] Command[1] should be chown")
+	assert.Equal(t, "-R", ars.Spec.Template.Spec.InitContainers[1].Command[2], "InitContainers[1] Command[2] should be -R")
+	assert.Equal(t, "1001:123", ars.Spec.Template.Spec.InitContainers[1].Command[3], "InitContainers[1] Command[3] should be 1001:123")
+	assert.Equal(t, "/home/runner/_work", ars.Spec.Template.Spec.InitContainers[1].Command[4], "InitContainers[1] Command[4] should be /home/runner/_work")
+	assert.Equal(t, "work", ars.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].Name, "InitContainers[1] VolumeMounts[0] Name should be work")
+	assert.Equal(t, "/home/runner/_work", ars.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].MountPath, "InitContainers[1] VolumeMounts[0] MountPath should be /home/runner/_work")
+
+	assert.Equal(t, "ls", ars.Spec.Template.Spec.InitContainers[2].Name, "InitContainers[2] Name should be ls")
+	assert.Equal(t, "ubuntu:latest", ars.Spec.Template.Spec.InitContainers[2].Image, "InitContainers[2] Image should be ubuntu:latest")
+	assert.Equal(t, "ls", ars.Spec.Template.Spec.InitContainers[2].Command[0], "InitContainers[2] Command[0] should be ls")
+}
+
 func TestTemplateRenderedAutoScalingRunnerSet_DinD_ExtraVolumes(t *testing.T) {
 	t.Parallel()
 

--- a/charts/gha-runner-scale-set/tests/values_dind_extra_init_containers.yaml
+++ b/charts/gha-runner-scale-set/tests/values_dind_extra_init_containers.yaml
@@ -1,0 +1,17 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+template:
+  spec:
+    initContainers:
+    - name: kube-init
+      image: runner-image:latest
+      command: ["sudo", "chown", "-R", "1001:123", "/home/runner/_work"]
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
+    - name: ls
+      image: ubuntu:latest
+      command: ["ls"]
+containerMode:
+  type: dind


### PR DESCRIPTION
When setting dind and initContainers with values like the following, the following error occurs:

```
Error: UPGRADE FAILED: YAML parse error on gha-runner-scale-set/templates/autoscalingrunnerset.yaml: error converting YAML to JSON: yaml: line 49: did not find expected key
```

```yaml
containerMode:
  type: "dind"
template:
  spec:
    initContainers:
    - name: kube-init
      image: ghcr.io/actions/actions-runner:latest
      imagePullPolicy: IfNotPresent
      command: ["sudo", "chown", "-R", "1001:123", "/home/runner/_work"]
      volumeMounts:
      - name: work
        mountPath: /home/runner/_work
```

When outputting with the debug option, the indentation was shifted as follows:

```yaml
      initContainers:
      - name: init-dind-externals

        image: quay.io/kahirokunn/actions-runner:latest
        command: ["cp"]
        args: ["-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
        volumeMounts:
          - name: dind-externals
            mountPath: /home/runner/tmpDir
        - command:
          - sudo
          - chown
          - -R
          - 1001:123
          - /home/runner/_work
          image: quay.io/kahirokunn/actions-runner:latest
          name: kube-init
          volumeMounts:
          - mountPath: /home/runner/_work
            name: work
```

Therefore, in this modification, the indentation will be corrected as follows:

```yaml
  initContainers:
  - name: init-dind-externals
    image: ghcr.io/actions/actions-runner:latest
    command: ["cp"]
    args: ["-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
    volumeMounts:
      - name: dind-externals
        mountPath: /home/runner/tmpDir
  - command:
    - sudo
    - chown
    - -R
    - 1001:123
    - /home/runner/_work
    image: ghcr.io/actions/actions-runner:latest
    name: kube-init
    volumeMounts:
    - mountPath: /home/runner/_work
      name: work
```