### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/arc-publish-chart.yaml
+++ b/.github/workflows/arc-publish-chart.yaml
@@ -70,7 +70,7 @@ jobs:
       run: |
         changed=$(ct list-changed --config charts/.ci/ct-config.yaml)
         if [[ -n "$changed" ]]; then
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Run chart-testing (lint)

--- a/.github/workflows/arc-validate-chart.yaml
+++ b/.github/workflows/arc-validate-chart.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config charts/.ci/ct-config.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -76,7 +76,7 @@ jobs:
           ct version
           changed=$(ct list-changed --config charts/.ci/ct-config-gha.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
## Description

Resolve  #2678 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=changed::true"
```

**TO-BE**

```yml
echo "changed=true" >> $GITHUB_OUTPUT
```