### PR TITLE
Fix serviceMonitor labels in actionsMetrics

### DIFF
--- a/charts/actions-runner-controller/templates/actionsmetrics.servicemonitor.yaml.yml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.servicemonitor.yaml.yml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{- include "actions-runner-controller.labels" . | nindent 4 }}
-  {{- with .Values.actionsMetricsServer.serviceMonitorLabels }}
+  {{- with .Values.actionsMetrics.serviceMonitorLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "actions-runner-controller-actions-metrics-server.serviceMonitorName" . }}


### PR DESCRIPTION
`serviceMonitorLabels` are defined under `actionsMetrics`, not `actionsMetricsServer`.

See: https://github.com/actions/actions-runner-controller/blob/master/charts/actions-runner-controller/values.yaml#L308