### PR TITLE
Add status check before deserializing runner-registration response

### DIFF
--- a/github/actions/client.go
+++ b/github/actions/client.go
@@ -922,7 +922,13 @@ func (c *Client) getActionsServiceAdminConnection(ctx context.Context, rt *regis
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("unexpected response from Actions service during registration call: %v", resp.StatusCode)
+		registrationErr := fmt.Errorf("unexpected response from Actions service during registration call: %v", resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("%v - %v", registrationErr, err)
+		}
+		return nil, fmt.Errorf("%v - %v", registrationErr, string(body))
 	}
 
 	var actionsServiceAdminConnection *ActionsServiceAdminConnection

--- a/github/actions/client.go
+++ b/github/actions/client.go
@@ -921,6 +921,10 @@ func (c *Client) getActionsServiceAdminConnection(ctx context.Context, rt *regis
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("unexpected response from Actions service during registration call: %v", resp.StatusCode)
+	}
+
 	var actionsServiceAdminConnection *ActionsServiceAdminConnection
 	if err := json.NewDecoder(resp.Body).Decode(&actionsServiceAdminConnection); err != nil {
 		return nil, err

--- a/github/actions/github_api_request_test.go
+++ b/github/actions/github_api_request_test.go
@@ -2,6 +2,7 @@ package actions_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -120,6 +121,26 @@ func TestNewActionsServiceRequest(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, "Bearer "+newToken, req.Header.Get("Authorization"))
+		})
+
+		t.Run("admin token refresh failure", func(t *testing.T) {
+			newToken := defaultActionsToken(t)
+			unauthorizedHandler := func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(fmt.Sprintf(`{"token":"%s", "url": "test"}`, newToken)))
+			}
+			server := testserver.New(t, nil, testserver.WithActionsToken("random-token"), testserver.WithActionsToken(newToken), testserver.WithActionsRegistrationTokenHandler(unauthorizedHandler))
+			client, err := actions.NewClient(server.ConfigURLForOrg("my-org"), defaultCreds)
+			require.NoError(t, err)
+			expiringToken := "expiring-token"
+			expiresAt := time.Now().Add(59 * time.Second)
+			client.ActionsServiceAdminToken = expiringToken
+			client.ActionsServiceAdminTokenExpiresAt = expiresAt
+			_, err = client.NewActionsServiceRequest(ctx, http.MethodGet, "my-path", nil)
+			require.Error(t, err)
+			assert.Equal(t, client.ActionsServiceAdminToken, expiringToken)
+			assert.Equal(t, client.ActionsServiceAdminTokenExpiresAt, expiresAt)
 		})
 
 		t.Run("token is currently valid", func(t *testing.T) {

--- a/github/actions/testserver/server.go
+++ b/github/actions/testserver/server.go
@@ -106,7 +106,6 @@ func (s *actionsServer) setDefaults(t ginkgo.GinkgoTInterface) {
 
 			w.WriteHeader(http.StatusCreated)
 			w.Write([]byte(`{"url":"` + s.URL + `/tenant/123/","token":"` + s.token + `"}`))
-			return
 		}
 	}
 }

--- a/github/actions/testserver/server.go
+++ b/github/actions/testserver/server.go
@@ -35,6 +35,8 @@ func NewUnstarted(t ginkgo.GinkgoTInterface, handler http.Handler, options ...ac
 		server.Close()
 	})
 
+	server.setDefaults(t)
+
 	for _, option := range options {
 		option(server)
 	}
@@ -42,18 +44,13 @@ func NewUnstarted(t ginkgo.GinkgoTInterface, handler http.Handler, options ...ac
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// handle getRunnerRegistrationToken
 		if strings.HasSuffix(r.URL.Path, "/runners/registration-token") {
-			w.WriteHeader(http.StatusCreated)
-			w.Write([]byte(`{"token":"token"}`))
+			server.runnerRegistrationTokenHandler(w, r)
 			return
 		}
 
 		// handle getActionsServiceAdminConnection
 		if strings.HasSuffix(r.URL.Path, "/actions/runner-registration") {
-			if server.token == "" {
-				server.token = DefaultActionsToken(t)
-			}
-
-			w.Write([]byte(`{"url":"` + s.URL + `/tenant/123/","token":"` + server.token + `"}`))
+			server.actionRegistrationTokenHandler(w, r)
 			return
 		}
 
@@ -73,10 +70,45 @@ func WithActionsToken(token string) actionsServerOption {
 	}
 }
 
+func WithRunnerRegistrationTokenHandler(h http.HandlerFunc) actionsServerOption {
+	return func(s *actionsServer) {
+		s.runnerRegistrationTokenHandler = h
+	}
+}
+
+func WithActionsRegistrationTokenHandler(h http.HandlerFunc) actionsServerOption {
+	return func(s *actionsServer) {
+		s.actionRegistrationTokenHandler = h
+	}
+}
+
 type actionsServer struct {
 	*httptest.Server
 
-	token string
+	token                          string
+	runnerRegistrationTokenHandler http.HandlerFunc
+	actionRegistrationTokenHandler http.HandlerFunc
+}
+
+func (s *actionsServer) setDefaults(t ginkgo.GinkgoTInterface) {
+	if s.runnerRegistrationTokenHandler == nil {
+		s.runnerRegistrationTokenHandler = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"token":"token"}`))
+		}
+	}
+
+	if s.actionRegistrationTokenHandler == nil {
+		s.actionRegistrationTokenHandler = func(w http.ResponseWriter, r *http.Request) {
+			if s.token == "" {
+				s.token = DefaultActionsToken(t)
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"url":"` + s.URL + `/tenant/123/","token":"` + s.token + `"}`))
+			return
+		}
+	}
 }
 
 func (s *actionsServer) ConfigURLForOrg(org string) string {


### PR DESCRIPTION
The purpose of this PR is to ensure the listener does not panic if the status code returned by the actions service is not in 2xx range.

Previously, we would try to unmarshal JSON which would leave nil values for actions service admin token. When later used, the listener would panic.

Added check similar to one in the runner making sure the status code is success, and log the error message if returned from the actions service

https://github.com/actions/runner/blob/9c57205c1c1cd7ada73cb08b556293ec0411f8d4/src/Runner.Listener/Configuration/ConfigurationManager.cs#L777C50-L777C50