### PR TITLE
feat: allow more dockerd options

### DIFF
--- a/docs/using-entrypoint-features.md
+++ b/docs/using-entrypoint-features.md
@@ -67,3 +67,46 @@ spec:
         - name: DOCKER_DEFAULT_ADDRESS_POOL_SIZE
           value: "24"
 ```
+
+More options can be configured by mounting a configmap to the daemon.json location:
+
+- rootless: /home/runner/.config/docker/daemon.json
+- rootful: /etc/docker/daemon.json
+
+```yaml
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: example-runnerdeployment
+spec:
+  template:
+    spec:
+      dockerdWithinRunnerContainer: true
+      image: summerwind/actions-runner-dind(-rootless)
+      volumeMounts:
+        - mountPath: /home/runner/.config/docker/daemon.json
+          name: daemon-config-volume
+          subPath: daemon.json
+      volumes:
+        - name: daemon-config-volume
+          configMap:
+            name: daemon-cm
+            items:
+              - key: daemon.json
+                path: daemon.json
+      securityContext:
+        fsGroup: 1001 # runner user id
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: daemon-cm
+data:
+  daemon.json: |
+    {
+      "log-level": "warn",
+      "dns": ["x.x.x.x"]
+    }
+```

--- a/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
@@ -146,5 +146,9 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && which docker-compose \
     && docker compose version
 
+# Create folder structure here to avoid permission issues
+# when mounting the daemon.json file from a configmap.
+RUN mkdir -p /home/runner/.config/docker
+
 ENTRYPOINT ["/bin/bash", "-c"]
 CMD ["entrypoint-dind-rootless.sh"]

--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -123,5 +123,9 @@ RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && which docker-compose \
     && docker compose version
 
+# Create folder structure here to avoid permission issues
+# when mounting the daemon.json file from a configmap.
+RUN mkdir -p /home/runner/.config/docker
+
 ENTRYPOINT ["/bin/bash", "-c"]
 CMD ["entrypoint-dind-rootless.sh"]

--- a/runner/entrypoint-dind-rootless.sh
+++ b/runner/entrypoint-dind-rootless.sh
@@ -5,7 +5,6 @@ trap graceful_stop TERM
 
 log.notice "Writing out Docker config file"
 /bin/bash <<SCRIPT
-mkdir -p /home/runner/.config/docker/
 
 if [ ! -f /home/runner/.config/docker/daemon.json ]; then
   echo "{}" > /home/runner/.config/docker/daemon.json


### PR DESCRIPTION
- Added a description how to mount a configmap to configure multiple docker daemon options
- Moved the directory structure creation for the rootless-docker runner to the image.
  That way it will not break permissions while mounting the configmap.

provides feature: https://github.com/actions/actions-runner-controller/issues/2700