### PR TITLE
chore: Set build version on make-runscaleset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ run: generate fmt vet manifests
 run-scaleset: generate fmt vet
 	CONTROLLER_MANAGER_POD_NAMESPACE=default \
 	CONTROLLER_MANAGER_CONTAINER_IMAGE="${DOCKER_IMAGE_NAME}:${VERSION}" \
-	go run ./main.go --auto-scaling-runner-set-only
+	go run -ldflags="-s -w -X 'github.com/actions/actions-runner-controller/build.Version=$(VERSION)'" \
+	./main.go --auto-scaling-runner-set-only
 
 # Install CRDs into a cluster
 install: manifests


### PR DESCRIPTION
This enables us to locally test various runner versions.

For example, you can now run `VERSION=0.4.0 make run-scaleset` to let the local runnerscaleset controller to manage runners deployed using the runner-scale-set chart v0.4.0.