### PR TITLE
Fix `panic: slice bounds out of range` when runner spec contains `volumeMounts`.

### DIFF
--- a/controllers/actions.summerwind.net/runner_controller.go
+++ b/controllers/actions.summerwind.net/runner_controller.go
@@ -607,10 +607,13 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 			if runnerSpec.ContainerMode == "kubernetes" {
 				return pod, errors.New("volume mount \"work\" should be specified by workVolumeClaimTemplate in container mode kubernetes")
 			}
-			// remove work volume since it will be provided from runnerSpec.Volumes
-			// if we don't remove it here we would get a duplicate key error, i.e. two volumes named work
-			_, index := workVolumeMountPresent(pod.Spec.Containers[0].VolumeMounts)
-			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts[:index], pod.Spec.Containers[0].VolumeMounts[index+1:]...)
+
+			podSpecIsPresent, index := workVolumeMountPresent(pod.Spec.Containers[0].VolumeMounts)
+			if podSpecIsPresent {
+				// remove work volume since it will be provided from runnerSpec.Volumes
+				// if we don't remove it here we would get a duplicate key error, i.e. two volumes named work
+				pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts[:index], pod.Spec.Containers[0].VolumeMounts[index+1:]...)
+			}
 		}
 
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, runnerSpec.VolumeMounts...)
@@ -623,11 +626,13 @@ func (r *RunnerReconciler) newPod(runner v1alpha1.Runner) (corev1.Pod, error) {
 			if runnerSpec.ContainerMode == "kubernetes" {
 				return pod, errors.New("volume \"work\" should be specified by workVolumeClaimTemplate in container mode kubernetes")
 			}
-			_, index := workVolumePresent(pod.Spec.Volumes)
 
-			// remove work volume since it will be provided from runnerSpec.Volumes
-			// if we don't remove it here we would get a duplicate key error, i.e. two volumes named work
-			pod.Spec.Volumes = append(pod.Spec.Volumes[:index], pod.Spec.Volumes[index+1:]...)
+			podSpecIsPresent, index := workVolumePresent(pod.Spec.Volumes)
+			if podSpecIsPresent {
+				// remove work volume since it will be provided from runnerSpec.Volumes
+				// if we don't remove it here we would get a duplicate key error, i.e. two volumes named work
+				pod.Spec.Volumes = append(pod.Spec.Volumes[:index], pod.Spec.Volumes[index+1:]...)
+			}
 		}
 
 		pod.Spec.Volumes = append(pod.Spec.Volumes, runnerSpec.Volumes...)


### PR DESCRIPTION
As observed in #2719, if a `Runner` contains a `work` volume mount, this
will cause a panic in `newPod()` where the code is assuming that the
`work` volume mount will be present in the `pod` definition generated by
`newRunnerPodWithContainerMode()`.

However that isn't always the case, and if it's not present the `-1`
returned by `workVolumeMountPresent` results in the `slice bounds out of
range` exception.

So instead, check the `bool` return value, and only attempt to remove
the `work` volume mount if it's actually present.

Also apply the same fix to the `volumes` logic.

Fixes #2719

Signed-off-by: Gavin Williams <gavin.williams@machinemax.com>
