### PR TITLE
Add runner_name as new metric label

### DIFF
--- a/pkg/actionsmetrics/event_reader.go
+++ b/pkg/actionsmetrics/event_reader.go
@@ -112,6 +112,13 @@ func (reader *EventReader) ProcessWorkflowJobEvent(ctx context.Context, event in
 	labels["workflow_name"] = wn
 	labels["head_branch"] = hb
 
+	var rn string
+	if n := e.WorkflowJob.RunnerName; n != nil {
+		rn = *n
+		keysAndValues = append(keysAndValues, "runner_name", *n)
+	}
+	labels["runner_name"] = rn
+
 	log := reader.Log.WithValues(keysAndValues...)
 
 	// switch on job status

--- a/pkg/actionsmetrics/metrics.go
+++ b/pkg/actionsmetrics/metrics.go
@@ -76,7 +76,7 @@ func metricLabels(extras ...string) []string {
 }
 
 var (
-	commonLabels                          = []string{"runs_on", "job_name", "organization", "repository", "repository_full_name", "owner", "workflow_name", "head_branch"}
+	commonLabels                          = []string{"runs_on", "job_name", "organization", "repository", "repository_full_name", "owner", "workflow_name", "head_branch", "runner_name"}
 	githubWorkflowJobQueueDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "github_workflow_job_queue_duration_seconds",


### PR DESCRIPTION
A common task we've been finding ourselves in as maintainers of CICD systems is improving the cost efficiency of our workflows/jobs.

While we have metrics on the resource usage of our individual runner pods, it's quite tricky to link the pods to a specific job or workflow since there are no common metrics between the two. This PR is an attempt to reconcile that. 

This PR simply adds the runner name as a new label on the already exposed `github_workflow_job_*` histograms. This will increase the cardinality of the metrics already reported however, so I will leave the decision to accept this up to the maintainers. 

I built the dockerfile and deployed to our dev environment and was able to get the metric working as expected. Below is a screenshot of it reporting the metrics (I blurred some things out but you should be able to get the gist) of it working. 
![Screenshot 2023-08-04 at 4 07 08 PM](https://github.com/actions/actions-runner-controller/assets/28708109/d0883d96-91ea-46d3-ab0b-b17706734605)