### PR TITLE
Update quickstart guide to use create instead of apply

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,7 +73,7 @@ helm upgrade --install --namespace actions-runner-system --create-namespace\
 ##### Deploy ARC
 
 ```shell
-kubectl apply -f \
+kubectl create -f \
 https://github.com/actions/actions-runner-controller/\
 releases/download/v0.22.0/actions-runner-controller.yaml
 ```
@@ -89,7 +89,7 @@ kubectl create secret generic controller-manager \
 ````
 
 <sub> *note:- Replace REPLACE_YOUR_TOKEN_HERE with your PAT that was generated previously.</sub>
-  
+
   </details>
 
 2️⃣ Create the GitHub self hosted runners and configure to run against your repository.


### PR DESCRIPTION
Otherwise kubectl complains about

```
metadata.annotations: Too long: must have at most 262144 bytes
```

Close https://github.com/actions/actions-runner-controller/issues/2565