### PR TITLE
Upgrade e2e tests to latest version (0.5.0)

### DIFF
--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -16,7 +16,7 @@ env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: arc_e2e_test_dummy
   IMAGE_NAME: "arc-test-image"
-  IMAGE_VERSION: "0.4.0"
+  IMAGE_VERSION: "0.5.0"
 
 concurrency:
   # This will make sure we only apply the concurrency limits on pull requests


### PR DESCRIPTION
Update e2e tests to run the latest (0.5.0) version of ARC