### PR TITLE
Fix - Actually Enable Sets in addition to Slices in `env`

### DIFF
--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -302,7 +302,7 @@ githubWebhookServer:
   #       key: GITHUB_WEBHOOK_SECRET_TOKEN
   #       name: prod-gha-controller-webhook-token
   #       optional: true
-  env: {}
+  # env:
 
 actionsMetrics:
   serviceAnnotations: {}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -151,8 +151,7 @@ podDisruptionBudget:
 # PriorityClass: system-cluster-critical
 priorityClassName: ""
 
-env:
-  {}
+# env:
   # specify additional environment variables for the controller pod.
   # It's possible to specify either key vale pairs e.g.:
   # http_proxy: "proxy.com:8080"


### PR DESCRIPTION
As mentioned in the comments and as implemented in [githubwebhook.deployment.yaml](https://github.com/actions/actions-runner-controller/blob/4536707/charts/actions-runner-controller/templates/githubwebhook.deployment.yaml#L120-L127) and [deployment.yaml](https://github.com/actions/actions-runner-controller/blob/4536707af666b3f3b1b548d2fbe961d32805eebf/charts/actions-runner-controller/templates/deployment.yaml#L124-L131) one can provide a set or slice in `env`.

This works, when one uses the helm chart source code and modifies the `values.yaml`. It does work - but prints warnings, when using the released chart directly. Hereby, when I set a slice, I get the following warning, since it it already defined as a set.

```
cannot overwrite table with non table for 
```

I'd recommend to remove the default `{}` value. Then users can actually use sets or slices.

*Edit:* Previously I mentioned, that it is an error, it is not. It is "only" a warning and works.