### PR TITLE
[helm actions-runner-controller] Use namespaceSelector.matchExpression instead of matchLabels

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.3
+version: 0.23.4
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
 appVersion: 0.27.4

--- a/charts/actions-runner-controller/templates/webhook_configs.yaml
+++ b/charts/actions-runner-controller/templates/webhook_configs.yaml
@@ -19,7 +19,7 @@ webhooks:
   {{- if .Values.scope.singleNamespace }}
   namespaceSelector:
     matchLabels:
-      name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
@@ -50,7 +50,7 @@ webhooks:
   {{- if .Values.scope.singleNamespace }}
   namespaceSelector:
     matchLabels:
-      name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
@@ -81,7 +81,7 @@ webhooks:
   {{- if .Values.scope.singleNamespace }}
   namespaceSelector:
     matchLabels:
-      name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
@@ -112,7 +112,7 @@ webhooks:
   {{- if .Values.scope.singleNamespace }}
   namespaceSelector:
     matchLabels:
-      name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
@@ -156,7 +156,7 @@ webhooks:
   {{- if .Values.scope.singleNamespace }}
   namespaceSelector:
     matchLabels:
-      name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
@@ -187,7 +187,7 @@ webhooks:
   {{- if .Values.scope.singleNamespace }}
   namespaceSelector:
     matchLabels:
-      name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}
@@ -218,7 +218,7 @@ webhooks:
   {{- if .Values.scope.singleNamespace }}
   namespaceSelector:
     matchLabels:
-      name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.scope.watchNamespace }}
   {{- end }}
   clientConfig:
     {{- if .Values.admissionWebHooks.caBundle }}


### PR DESCRIPTION
The label `name` is a custom label that is not available on a standard
k8s installation. Instead we can use the default `kubernetes.io/metadata.name`
label (see
https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name)

matchLabels was introduced in https://github.com/actions/actions-runner-controller/commit/1f8a23c12961fdfa46bd32f572bee4b0a9c7740b#diff-f223f13177d34575a050c4333a9110e4494d40f9910f34024ec2c9b1baa11635R16 
This fixes https://github.com/actions/actions-runner-controller/issues/2794