### PR TITLE
Switch git-lfs source to packagecloud

### DIFF
--- a/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update -y \
     dnsutils \
     ftp \
     git \
-    git-lfs \
     iproute2 \
     iputils-ping \
     iptables \
@@ -55,6 +54,10 @@ RUN apt-get update -y \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
 
 # Runner user
 RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner

--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update -y \
     curl \
     ca-certificates \
     git \
-    git-lfs \
     iproute2 \
     iptables \
     jq \
@@ -32,6 +31,10 @@ RUN apt-get update -y \
     unzip \
     zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
 
 # Runner user
 RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner

--- a/runner/actions-runner-dind.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-20.04.dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -y \
     dnsutils \
     ftp \
     git \
-    git-lfs \
     iproute2 \
     iputils-ping \
     iptables \
@@ -52,6 +51,10 @@ RUN apt-get update -y \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
 
 # Runner user
 RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner \

--- a/runner/actions-runner-dind.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-22.04.dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update -y \
     curl \
     ca-certificates \
     git \
-    git-lfs \
     iptables \
     jq \
     software-properties-common \
@@ -28,6 +27,10 @@ RUN apt-get update -y \
     unzip \
     zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
 
 # Runner user
 RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \

--- a/runner/actions-runner.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner.ubuntu-20.04.dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -y \
     dnsutils \
     ftp \
     git \
-    git-lfs \
     iproute2 \
     iputils-ping \
     jq \
@@ -49,6 +48,10 @@ RUN apt-get update -y \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
 
 RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner \
     && groupadd docker --gid $DOCKER_GID \

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -20,12 +20,15 @@ RUN apt-get update -y \
     curl \
     ca-certificates \
     git \
-    git-lfs \
     jq \
     sudo \
     unzip \
     zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
 
 RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
     && groupadd docker --gid $DOCKER_GROUP_GID \


### PR DESCRIPTION
`git-lfs` from the [Ubuntu source](https://launchpad.net/ubuntu/+source/git-lfs) is using golang `github.com/golang/go:1.13.5` for Ubuntu 20 and `github.com/golang/go:1.18.1` for Ubuntu 22.  

Both of these versions of Go have known vulnerabilities causing our internal security scanning to fail. 

Update to the recommended install instructions for [git-lfs](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) (packagecloud source). 

We're now pulling in: `git-lfs/3.3.0 (GitHub; linux arm64; go 1.19.3)`