### PR TITLE
feature: allow custom envornment variables in metricsservice

### DIFF
--- a/charts/actions-runner-controller/templates/actionsmetrics.deployment.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.deployment.yaml
@@ -111,6 +111,9 @@ spec:
               name: {{ include "actions-runner-controller.secretName" . }}
               optional: true
         {{- end }}
+        {{- if kindIs "slice" .Values.actionsMetricsServer.env }}
+        {{- toYaml .Values.actionsMetricsServer.env | nindent 8 }}
+        {{- else }}
         {{- range $key, $val := .Values.actionsMetricsServer.env }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/charts/actions-runner-controller/templates/actionsmetrics.deployment.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.deployment.yaml
@@ -118,6 +118,7 @@ spec:
         - name: {{ $key }}
           value: {{ $val | quote }}
         {{- end }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag  | default (cat "v" .Chart.AppVersion | replace " " "") }}"
         name: actions-metrics-server
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -321,6 +321,19 @@ actionsMetrics:
     image:
       repository: quay.io/brancz/kube-rbac-proxy
       tag: v0.13.1
+  # specify additional environment variables for the webhook server pod.
+  # It's possible to specify either key vale pairs e.g.:
+  # my_env_var: "some value"
+  # my_other_env_var: "other value"
+
+  # or a list of complete environment variable definitions e.g.:
+  # - name: GITHUB_WEBHOOK_SECRET_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: GITHUB_WEBHOOK_SECRET_TOKEN
+  #       name: prod-gha-controller-webhook-token
+  #       optional: true
+  # env:
 
 actionsMetricsServer:
   enabled: false


### PR DESCRIPTION
In order to use the metrics service with a CSI secrets provider module, we need to be able to set custom environment variables. 
This change was as well done to the ARC `deployment.tpl` (and `githubwebhook.deployment.yaml`)  and just allows to specify a slice instead of key value pairs.
