### PR TITLE
bump appVersion to latest available app

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.4
+version: 0.23.5
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.4
+appVersion: 0.27.5
 
 home: https://github.com/actions/actions-runner-controller
 


### PR DESCRIPTION
Seems like during release of new version of chart it was missed to bump the app version to latest available.