### PR TITLE
Move top level metrics property up

### DIFF
--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -75,6 +75,17 @@ affinity: {}
 # PriorityClass: system-cluster-critical
 priorityClassName: ""
 
+## If `metrics:` object is not provided, or commented out, the following flags 
+## will be applied the controller-manager and listener pods with empty values: 
+## `--metrics-addr`, `--listener-metrics-addr`, `--listener-metrics-endpoint`. 
+## This will disable metrics.
+##
+## To enable metrics, uncomment the following lines.
+# metrics:
+#   controllerManagerAddr: ":8080"
+#   listenerAddr: ":8080"
+#   listenerEndpoint: "/metrics"
+
 flags:
   ## Log level can be set here with one of the following values: "debug", "info", "warn", "error".
   ## Defaults to "debug".
@@ -102,14 +113,3 @@ flags:
   ##   This can lead to a longer time to apply the change but it will ensure
   ##   that you don't have any overprovisioning of runners.
   updateStrategy: "immediate"
-
-## If `metrics:` object is not provided, or commented out, the following flags 
-## will be applied the controller-manager and listener pods with empty values: 
-## `--metrics-addr`, `--listener-metrics-addr`, `--listener-metrics-endpoint`. 
-## This will disable metrics.
-##
-## To enable metrics, uncomment the following lines.
-# metrics:
-#   controllerManagerAddr: ":8080"
-#   listenerAddr: ":8080"
-#   listenerEndpoint: "/metrics"


### PR DESCRIPTION
### Context

Fixes: https://github.com/github/c2c-actions-runtime/issues/2502

Minor ergonomic fix. Moving the `metrics` property above `flags` so that end-users are not confused and add unnecessary indentation.