### PR TITLE
Bump chart appVersion to 0.27.5

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 version: 0.23.4
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.4
+appVersion: 0.27.5
 
 home: https://github.com/actions/actions-runner-controller
 


### PR DESCRIPTION
Looks like bumping appVersion was forgot before releasing the new chart version

https://github.com/actions/actions-runner-controller/releases/tag/v0.27.5