### PR TITLE
Update values.yaml

### DIFF
--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -101,6 +101,7 @@ template:
   ##     containers:
   ##     - name: runner
   ##       image: ghcr.io/actions/actions-runner:latest
+  ##       command: ["/home/runner/run.sh"]
   ##       env:
   ##         - name: DOCKER_HOST
   ##           value: tcp://localhost:2376
@@ -139,6 +140,7 @@ template:
   ##     containers:
   ##     - name: runner
   ##       image: ghcr.io/actions/actions-runner:latest
+  ##       command: ["/home/runner/run.sh"]
   ##       env:
   ##         - name: ACTIONS_RUNNER_CONTAINER_HOOKS
   ##           value: /home/runner/k8s/index.js


### PR DESCRIPTION
When using the dind template for customization, my pods were stuck in a restart loop. Providing the command field fixed the issue. Did not test the kubernetes template but I assume it needs the same start command.

Note that the docs [here](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#using-docker-in-docker-mode) are also missing the command field