### PR TITLE
Add missing command

### DIFF
--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -101,6 +101,7 @@ template:
   ##     containers:
   ##     - name: runner
   ##       image: ghcr.io/actions/actions-runner:latest
+  ##       command: ["/home/runner/run.sh"]
   ##       env:
   ##         - name: DOCKER_HOST
   ##           value: tcp://localhost:2376
@@ -139,6 +140,7 @@ template:
   ##     containers:
   ##     - name: runner
   ##       image: ghcr.io/actions/actions-runner:latest
+  ##       command: ["/home/runner/run.sh"]
   ##       env:
   ##         - name: ACTIONS_RUNNER_CONTAINER_HOOKS
   ##           value: /home/runner/k8s/index.js


### PR DESCRIPTION
Extends the existing examples with the needed `command` to startup the runner. This is mentioned a few line later - but actually copy & paste of the example is not working and lead to debugging. So having the required line it would have made my day less debugging stuff 😉 