### PR TITLE
Helm-Template-Variable created for dind image

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -92,7 +92,7 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+image: {{ .Values.dockerDindImage }}
 securityContext:
   privileged: true
 volumeMounts:

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -196,3 +196,6 @@ template:
 # controllerServiceAccount:
 #   namespace: arc-system
 #   name: test-arc-gha-runner-scale-set-controller
+
+# This is the offcial Docker-in-Docker image. You can use this image directly form Docker, or alternatively, build your own image and reference it here.
+dockerDindImage: docker:dind


### PR DESCRIPTION
During the implementation of the Actions-runner-controller, I encountered several challenges. A primary issue was my inability to download images within the `dind container` due to persistent timeout issues. Upon closer examination, I realized that the `dind` container wasn't recognizing my specific configurations, including certificates, proxy settings, and `registry-mirror`. Despite numerous attempts, I couldn't correctly relay this information to the `dind` container. While I was able to execute Docker commands within the container, downloading images remained an obstacle.

To circumvent this issue, I created a custom `docker:dind` image that incorporated all the necessary configurations. I then uploaded this image to my own `registry-mirror` and replaced the default hard-coded `dind` image with my tailored version. This approach also allowed me to bypass the rate-limiting challenges I faced when downloading images within the container.

Although this method resolved the issues related to certificates, proxy, and `registry-mirror`, it introduced a downside: I had to make continuous adjustments to the Helm-Chart. Ideally, the chart should offer the flexibility to use a user-defined `docker:dind` image instead of relying on a hard-coded one.

Considering this, I've extended the chart to provide this flexibility. I hope these modifications prove useful to others, and I welcome any feedback or suggestions for improvement.