### PR TITLE
Fix nil map panic if listener annotations is set

### DIFF
--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -320,6 +320,9 @@ func mergeListenerPodWithTemplate(pod *corev1.Pod, tmpl *corev1.PodTemplateSpec)
 	// apply metadata
 	for k, v := range tmpl.Annotations {
 		if _, ok := pod.Annotations[k]; !ok {
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
 			pod.Annotations[k] = v
 		}
 	}


### PR DESCRIPTION
## Problem to solve
If an `AutoscalingRunnerSet` has `spec.listenerTemplate.metadata.annotations` field, the controller panics as follows:

> Observed a panic in reconciler: assignment to entry in nil map	{"controller": "autoscalinglistener", "controllerGroup": "actions.github.com", "controllerKind": "AutoscalingListener", "AutoscalingListener": {"name":"example-754b578d-listener","namespace":"arc-systems"}, "namespace": "arc-systems", "name": "example-754b578d-listener", "reconcileID": "c553f2e1-ab06-4231-b9c6-7fdbf0760ac7"}
>panic: assignment to entry in nil map [recovered]

See https://github.com/actions/actions-runner-controller/issues/2881#issuecomment-1728674469 for details.

## How to solve
Add nil check to the map operation.
