### PR TITLE
Prepare 0.6.1 release

### DIFF
--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -16,7 +16,7 @@ env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: arc_e2e_test_dummy
   IMAGE_NAME: "arc-test-image"
-  IMAGE_VERSION: "0.6.0"
+  IMAGE_VERSION: "0.6.1"
 
 concurrency:
   # This will make sure we only apply the concurrency limits on pull requests

--- a/charts/gha-runner-scale-set-controller/Chart.yaml
+++ b/charts/gha-runner-scale-set-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0"
+appVersion: "0.6.1"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/gha-runner-scale-set/Chart.yaml
+++ b/charts/gha-runner-scale-set/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0"
+appVersion: "0.6.1"
 
 home: https://github.com/actions/dev-arc
 

--- a/docs/gha-runner-scale-set-controller/README.md
+++ b/docs/gha-runner-scale-set-controller/README.md
@@ -43,6 +43,12 @@ You can follow [this troubleshooting guide](https://docs.github.com/en/actions/h
 
 ## Changelog
 
+### v0.6.1
+1. Replace TLS dockerd connection with unix socket (#2833)[https://github.com/actions/actions-runner-controller/pull/2833]
+1. Fix name override labels when runnerScaleSetName value is set (#2915)[https://github.com/actions/actions-runner-controller/pull/2915]
+1. Fix nil map when annotations are applied (#2916)[https://github.com/actions/actions-runner-controller/pull/2916]
+1. Updates: container-hooks to v0.4.0 (#2928)[https://github.com/actions/actions-runner-controller/pull/2928]
+
 ### v0.6.0
 1. Fix parsing AcquireJob MessageQueueTokenExpiredError (#2837)[https://github.com/actions/actions-runner-controller/pull/2837]
 1. Set restart policy on the runner pod to Never if restartPolicy is not set in template (#2787)[https://github.com/actions/actions-runner-controller/pull/2787]


### PR DESCRIPTION
#### v0.6.1

- [gha-runner-scale-set-controller controller image](https://github.com/actions/actions-runner-controller/pkgs/container/gha-runner-scale-set-controller/131516093?tag=0.6.1)
- [gha-runner-scale-set-controller helm chart](https://github.com/actions/actions-runner-controller/pkgs/container/actions-runner-controller-charts%2Fgha-runner-scale-set-controller/131516620?tag=0.6.1)
- [gha-runner-scale-set helm chart](https://github.com/actions/actions-runner-controller/pkgs/container/actions-runner-controller-charts%2Fgha-runner-scale-set/131516745?tag=0.6.1)

#### ⚠️ Warning

The following might be a breaking change. Please read: [Update docker in docker configuration to use Unix sockets instead of HTTPS (TLS)](https://github.com/actions/actions-runner-controller/discussions/2930)

#### Major changes
- Replace TLS dockerd connection with unix socket [#2833](https://github.com/actions/actions-runner-controller/pull/2833)
- Fix name override labels when runnerScaleSetName value is set [#2915](https://github.com/actions/actions-runner-controller/pull/2915)
- Fix nil map when annotations are applied [#2916](https://github.com/actions/actions-runner-controller/pull/2916)
- Updates: container-hooks to v0.4.0 [#2928](https://github.com/actions/actions-runner-controller/pull/2928)