### PR TITLE
Fix role and rolebinding cleanup for the listener controller

### DIFF
--- a/controllers/actions.github.com/autoscalinglistener_controller_test.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Test AutoScalingListener controller", func() {
 	})
 
 	Context("When deleting a new AutoScalingListener", func() {
-		FIt("It should cleanup all resources for a deleting AutoScalingListener before removing it", func() {
+		It("It should cleanup all resources for a deleting AutoScalingListener before removing it", func() {
 			// Waiting for the pod to be created
 			pod := new(corev1.Pod)
 			Eventually(


### PR DESCRIPTION
After investigation, it seems like we forgot to delete `Role` and `RoleBinding` resources when doing the listener cleanup. This PR aims to fix it

Fixes #2781 