### PR TITLE
Bump legacy ARC chart's app version to v0.27.6

### DIFF
--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 version: 0.23.6
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.6
+appVersion: 0.27.7
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 version: 0.23.7
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.7
+appVersion: 0.27.6
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 version: 0.23.6
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
-appVersion: 0.27.5
+appVersion: 0.27.6
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/actions-runner-controller/Chart.yaml
+++ b/charts/actions-runner-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.6
+version: 0.23.7
 
 # Used as the default manager tag value when no tag property is provided in the values.yaml
 appVersion: 0.27.7


### PR DESCRIPTION
Bumps the appVersion to 0.27.6.
Please see https://github.com/actions/actions-runner-controller/releases/tag/v0.27.6 for more information about ARC v0.27.6!