### PR TITLE
Metrics: set max and min runners during startup time

### DIFF
--- a/cmd/githubrunnerscalesetlistener/autoScalerService.go
+++ b/cmd/githubrunnerscalesetlistener/autoScalerService.go
@@ -82,6 +82,7 @@ func NewService(
 }
 
 func (s *Service) Start() error {
+	s.metricsExporter.publishStatic(s.settings.MaxRunners, s.settings.MinRunners)
 	for {
 		s.logger.Info("waiting for message...")
 		select {

--- a/cmd/githubrunnerscalesetlistener/metrics.go
+++ b/cmd/githubrunnerscalesetlistener/metrics.go
@@ -297,6 +297,12 @@ func (m *metricsExporter) withBaseLabels(base baseLabels) {
 	m.baseLabels = base
 }
 
+func (m *metricsExporter) publishStatic(max, min int) {
+	l := m.scaleSetLabels()
+	maxRunners.With(l).Set(float64(max))
+	minRunners.With(l).Set(float64(min))
+}
+
 func (m *metricsExporter) publishStatistics(stats *actions.RunnerScaleSetStatistic) {
 	l := m.scaleSetLabels()
 


### PR DESCRIPTION
Fixes #3030