### PR TITLE
Allow dind image to be specified in Helm charts

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -96,7 +96,13 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+{{ $image := "docker:dind" }}
+{{- range $i, $val := .Values.template.spec.containers }}
+  {{- if eq $val.name "dind" }}
+    {{ $image = $val.image | default $image }}
+  {{- end }}
+{{- end }}
+image: {{ $image }}
 args:
   - dockerd
   - --host=unix:///run/docker/docker.sock


### PR DESCRIPTION
Now, `docker:dind` image can only download from Docker Hub.
There can be problems like the following: 

- Rate limit
- Download speed when geographically distant
- Ease of customization

For that reason, it is preferable for users to be able to flexibly choose a mirror registry.

```yaml
template:
  spec:
    containers:
      - name: runner
        image: ghcr.io/actions/actions-runner:latest
        command: ["/home/runner/run.sh"]
      - name: dind
        # e.g. image: public.ecr.aws/docker/library/docker:dind
        image: {{ mirror-registory }}/docker:dind
```