### PR TITLE
feat: GHA controller Helm Chart quoted labels

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
@@ -48,7 +48,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/part-of: gha-rs-controller
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $k, $v := .Values.labels }}
-{{ $k }}: {{ $v }}
+{{ $k }}: {{ $v | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -404,6 +404,8 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 		SetValues: map[string]string{
 			"labels.foo":                   "bar",
 			"labels.github":                "actions",
+			"labels.team":                  "GitHub Team",
+			"labels.teamMail":              "team@github.com",
 			"replicaCount":                 "1",
 			"image.pullPolicy":             "Always",
 			"image.tag":                    "dev",
@@ -445,6 +447,8 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 	assert.Equal(t, "gha-rs-controller", deployment.Labels["app.kubernetes.io/part-of"])
 	assert.Equal(t, "bar", deployment.Labels["foo"])
 	assert.Equal(t, "actions", deployment.Labels["github"])
+	assert.Equal(t, "GitHub Team", deployment.Labels["team"])
+	assert.Equal(t, "team@github.com", deployment.Labels["teamMail"])
 
 	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
 


### PR DESCRIPTION
The GHA controller Helm Chart currently applies the labels it gets as-is. If you have labels with spaces or special characters, the objects fail to be applied with the labels as they cannot be recognized as a string. By always quoting the values of the labels, anything can be passed along as a label.

In our case, we simply need to be able to set labels on the objects with spaces in the values for monitoring purposes.