### PR TITLE
Add ResizePolicy and RestartPolicy on mergeListenerContainer

### DIFF
--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -383,6 +383,8 @@ func mergeListenerContainer(base, from *corev1.Container) {
 	base.TerminationMessagePolicy = from.TerminationMessagePolicy
 	base.ImagePullPolicy = from.ImagePullPolicy
 	base.SecurityContext = from.SecurityContext
+	base.ResizePolicy = from.ResizePolicy
+	base.RestartPolicy = from.RestartPolicy
 	base.Stdin = from.Stdin
 	base.StdinOnce = from.StdinOnce
 	base.TTY = from.TTY


### PR DESCRIPTION
This pull request to `controllers/actions.github.com/resourcebuilder.go` adds more control over container behavior during resizing and restarting. Fields are added in the last [CRDs](https://github.com/actions/actions-runner-controller/pull/2947) update.

Main interface changes:

* <a href="diffhunk://#diff-0da4ad3df2adb1be6255c667628b8d5cef9b7d7d4cf58cd0ee2dc1ee4fb8ab5dR386-R387">`controllers/actions.github.com/resourcebuilder.go`</a>: Added more control over container behavior during resizing and restarting.