### PR TITLE
Remove deletion of Autoscaling Runner Set when versions dont match

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -156,19 +156,10 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	if autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion] != build.Version {
-		if err := r.Delete(ctx, autoscalingRunnerSet); err != nil {
-			log.Error(err, "Failed to delete autoscaling runner set on version mismatch",
-				"targetVersion", build.Version,
-				"actualVersion", autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion],
-			)
-			return ctrl.Result{}, nil
-		}
-
-		log.Info("Autoscaling runner set version doesn't match the build version. Deleting the resource.",
+		log.Info("Autoscaling runner set version doesn't match the controller build version. You need to update the Autoscaling runner set.",
 			"targetVersion", build.Version,
 			"actualVersion", autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion],
 		)
-		return ctrl.Result{}, nil
 	}
 
 	if !controllerutil.ContainsFinalizer(autoscalingRunnerSet, autoscalingRunnerSetFinalizerName) {


### PR DESCRIPTION
Deleting the autoscalingrunnerset from the controller results in errors during upgrade procedures. The controller should enable the runnerset to live with a version skew, and leave the upgrade procedure to other tooling like flux, argo or helm.

This is one way of implementing https://github.com/actions/actions-runner-controller/discussions/3090 which aims to discuss issue #3082. 

I think that it should be possible to update the controller ahead of upgrading the scalesets, and this is a quick fix to mitigate the current behavior.
And an error in annotation of the version number should not result in the deletion of the scalesets.
I think that there could be more work to be done to ensure that the scale set controller adheres to the design of kubebuilder and controller manager. However, I have been unable to find the design of the choises done in this controller at the moment, and as such there could be technical reasons for this implementation. Can anyone elaborate on this?

Thank you