### PR TITLE
var-run size limit up to 5mb

### DIFF
--- a/controllers/actions.summerwind.net/new_runner_pod_test.go
+++ b/controllers/actions.summerwind.net/new_runner_pod_test.go
@@ -95,7 +95,7 @@ func TestNewRunnerPod(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							Medium:    corev1.StorageMediumMemory,
-							SizeLimit: resource.NewScaledQuantity(1, resource.Mega),
+							SizeLimit: resource.NewScaledQuantity(5, resource.Mega),
 						},
 					},
 				},
@@ -547,7 +547,7 @@ func TestNewRunnerPod(t *testing.T) {
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{
 								Medium:    corev1.StorageMediumMemory,
-								SizeLimit: resource.NewScaledQuantity(1, resource.Mega),
+								SizeLimit: resource.NewScaledQuantity(5, resource.Mega),
 							},
 						},
 					},
@@ -591,7 +591,7 @@ func TestNewRunnerPod(t *testing.T) {
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{
 								Medium:    corev1.StorageMediumMemory,
-								SizeLimit: resource.NewScaledQuantity(1, resource.Mega),
+								SizeLimit: resource.NewScaledQuantity(5, resource.Mega),
 							},
 						},
 					},
@@ -680,7 +680,7 @@ func TestNewRunnerPodFromRunnerController(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							Medium:    corev1.StorageMediumMemory,
-							SizeLimit: resource.NewScaledQuantity(1, resource.Mega),
+							SizeLimit: resource.NewScaledQuantity(5, resource.Mega),
 						},
 					},
 				},
@@ -1223,7 +1223,7 @@ func TestNewRunnerPodFromRunnerController(t *testing.T) {
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{
 								Medium:    corev1.StorageMediumMemory,
-								SizeLimit: resource.NewScaledQuantity(1, resource.Mega),
+								SizeLimit: resource.NewScaledQuantity(5, resource.Mega),
 							},
 						},
 					},


### PR DESCRIPTION
I've noticed issues resulting from too limited size of var-run, when running more complex tasks on Docker.
Example is:
`Error response from daemon: failed to create task for container: failed to start shim: 
start failed: write /var/run/docker/containerd/daemon/io.containerd.runtime.v2.task/moby/4606cb97b7bd8c20dfe0b5db891652bb9b0e629bcc0ce8d24ca158b264242108/shim-binary-path: no space left on device: unknown
Error: Process completed with exit code 1.`

Please review and consider the change to extend size limit from 1mb to 5mb.

I haven't found any way to configure the size in any other way since it seem to be created by default for every pod.