### PR TITLE
Add WGET and MAKE packages to Ubuntu 22.04 Images

### DIFF
--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update -y \
     uidmap \
     unzip \
     zip \
+    make \
+    wget \
     fuse-overlayfs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/runner/actions-runner-dind.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-22.04.dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update -y \
     sudo \
     unzip \
     zip \
+    make \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y \
     unzip \
     zip \
     make \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -y \
     sudo \
     unzip \
     zip \
+    make \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version


### PR DESCRIPTION
This pull request adds the `make` and `wget` packages to the list of installed packages in multiple Dockerfiles for the runner environment. These packages are necessary for building and downloading dependencies in the runner environment.

Main changes:

* <a href="diffhunk://#diff-6843242f28814664ad503ea283819d192b387e1647935388b53d660d75c5876aR27-R28">`runner/actions-runner.ubuntu-22.04.dockerfile`</a>: Added `make` and `wget` packages to the list of installed packages.
* <a href="diffhunk://#diff-09c5636570ed4cbedf9cfebbebded1e832fcb03b5abd8efdbd34f9c943f71ce4R33-R34">`runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile`</a>: Added `make` and `wget` packages to the list of installed packages.
* <a href="diffhunk://#diff-7f238c45a5e6c97db2db123a2ac6a3842e9e9399f00e22e09604e55751f23003R29-R30">`runner/actions-runner-dind.ubuntu-22.04.dockerfile`</a>: Added `make` and `wget` packages to the list of installed packages.