### PR TITLE
Fix empty env and volumeMounts object on default setup

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -385,6 +385,9 @@ volumeMounts:
     {{- $setNodeExtraCaCerts = 1 }}
     {{- $setRunnerUpdateCaCerts = 1 }}
   {{- end }}
+
+  {{- $mountGitHubServerTLS := 0 }}
+  {{- if or $container.env $setNodeExtraCaCerts $setRunnerUpdateCaCerts }}
   env:
     {{- with $container.env }}
       {{- range $i, $env := . }}
@@ -405,10 +408,12 @@ volumeMounts:
     - name: RUNNER_UPDATE_CA_CERTS
       value: "1"
     {{- end }}
-    {{- $mountGitHubServerTLS := 0 }}
     {{- if $tlsConfig.runnerMountPath }}
       {{- $mountGitHubServerTLS = 1 }}
     {{- end }}
+  {{- end }}
+
+  {{- if or $container.volumeMounts $mountGitHubServerTLS }}
   volumeMounts:
     {{- with $container.volumeMounts }}
       {{- range $i, $volMount := . }}
@@ -423,6 +428,7 @@ volumeMounts:
       mountPath: {{ clean (print $tlsConfig.runnerMountPath "/" $tlsConfig.certificateFrom.configMapKeyRef.key) }}
       subPath: {{ $tlsConfig.certificateFrom.configMapKeyRef.key }}
     {{- end }}
+  {{- end}}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Previously, helm chart added an `env` and a `volumeMounts` field by default, which can in some circumstances be empty. That may cause some issues and workarounds adding fields just to avoid spec failures.

This PR checks if any of the `envs` and `volumeMounts` are going to be set, and only then provide a field.

Fixes #2949