### PR TITLE
Change listener container name

### DIFF
--- a/controllers/actions.github.com/autoscalinglistener_controller.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	autoscalingListenerContainerName = "autoscaler"
+	autoscalingListenerContainerName = "listener"
 	autoscalingListenerFinalizerName = "autoscalinglistener.actions.github.com/finalizer"
 )
 

--- a/controllers/actions.github.com/autoscalinglistener_controller_test.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller_test.go
@@ -555,7 +555,7 @@ var _ = Describe("Test AutoScalingListener customization", func() {
 
 			Expect(pod.Spec.SecurityContext.RunAsUser).To(Equal(&runAsUser), "Pod should have the correct security context")
 
-			Expect(pod.Spec.Containers[0].Name).NotTo(Equal("listener"), "Pod should have the correct container name")
+			Expect(pod.Spec.Containers[0].Name).To(Equal(autoscalingListenerContainerName), "Pod should have the correct container name")
 			Expect(pod.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(&runAsUser), "Pod should have the correct security context")
 			Expect(pod.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullAlways), "Pod should have the correct image pull policy")
 
@@ -854,7 +854,7 @@ var _ = Describe("Test AutoScalingListener controller with template modification
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name:            "listener",
+						Name:            autoscalingListenerContainerName,
 						ImagePullPolicy: corev1.PullAlways,
 						SecurityContext: &corev1.SecurityContext{
 							RunAsUser: &runAsUser1001,


### PR DESCRIPTION
Followup on https://github.com/actions/actions-runner-controller/pull/3161

Changing the listener container name to be in line with the [ADR](https://github.com/actions/actions-runner-controller/blob/master/docs/adrs/2023-07-18-customize-listener-pod.md) 