### PR TITLE
feat: add support for k8shook pod template

### DIFF
--- a/apis/actions.summerwind.net/v1alpha1/runner_types.go
+++ b/apis/actions.summerwind.net/v1alpha1/runner_types.go
@@ -80,7 +80,7 @@ type RunnerConfig struct {
 	ContainerMode string `json:"containerMode,omitempty"`
 
 	// +optional
-	PodTemplateName string `json:"podTemplateName,omitempty"`
+	PodTemplateFile string `json:"PodTemplateFile,omitempty"`
 
 	GitHubAPICredentialsFrom *GitHubAPICredentialsFrom `json:"githubAPICredentialsFrom,omitempty"`
 }

--- a/apis/actions.summerwind.net/v1alpha1/runner_types.go
+++ b/apis/actions.summerwind.net/v1alpha1/runner_types.go
@@ -79,6 +79,9 @@ type RunnerConfig struct {
 	// +optional
 	ContainerMode string `json:"containerMode,omitempty"`
 
+	// +optional
+	PodTemplateName string `json:"podTemplateName,omitempty"`
+
 	GitHubAPICredentialsFrom *GitHubAPICredentialsFrom `json:"githubAPICredentialsFrom,omitempty"`
 }
 

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -127,6 +127,8 @@ spec:
                     spec:
                       description: RunnerSpec defines the desired state of Runner
                       properties:
+                        PodTemplateFile:
+                          type: string
                         affinity:
                           description: Affinity is a group of affinity scheduling rules.
                           properties:
@@ -3417,8 +3419,6 @@ spec:
                           type: object
                         organization:
                           pattern: ^[^/]+$
-                          type: string
-                        podTemplateName:
                           type: string
                         priorityClassName:
                           type: string

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerdeployments.yaml
@@ -3418,6 +3418,8 @@ spec:
                         organization:
                           pattern: ^[^/]+$
                           type: string
+                        podTemplateName:
+                          type: string
                         priorityClassName:
                           type: string
                         repository:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -109,6 +109,8 @@ spec:
                     spec:
                       description: RunnerSpec defines the desired state of Runner
                       properties:
+                        PodTemplateFile:
+                          type: string
                         affinity:
                           description: Affinity is a group of affinity scheduling rules.
                           properties:
@@ -3399,8 +3401,6 @@ spec:
                           type: object
                         organization:
                           pattern: ^[^/]+$
-                          type: string
-                        podTemplateName:
                           type: string
                         priorityClassName:
                           type: string

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnerreplicasets.yaml
@@ -3400,6 +3400,8 @@ spec:
                         organization:
                           pattern: ^[^/]+$
                           type: string
+                        podTemplateName:
+                          type: string
                         priorityClassName:
                           type: string
                         repository:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -61,6 +61,8 @@ spec:
             spec:
               description: RunnerSpec defines the desired state of Runner
               properties:
+                PodTemplateFile:
+                  type: string
                 affinity:
                   description: Affinity is a group of affinity scheduling rules.
                   properties:
@@ -3351,8 +3353,6 @@ spec:
                   type: object
                 organization:
                   pattern: ^[^/]+$
-                  type: string
-                podTemplateName:
                   type: string
                 priorityClassName:
                   type: string

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runners.yaml
@@ -3352,6 +3352,8 @@ spec:
                 organization:
                   pattern: ^[^/]+$
                   type: string
+                podTemplateName:
+                  type: string
                 priorityClassName:
                   type: string
                 repository:

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnersets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnersets.yaml
@@ -119,6 +119,8 @@ spec:
                 podManagementPolicy:
                   description: podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
                   type: string
+                podTemplateName:
+                  type: string
                 replicas:
                   description: 'replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1. TODO: Consider a rename of this field.'
                   format: int32

--- a/charts/actions-runner-controller/crds/actions.summerwind.dev_runnersets.yaml
+++ b/charts/actions-runner-controller/crds/actions.summerwind.dev_runnersets.yaml
@@ -46,6 +46,8 @@ spec:
             spec:
               description: RunnerSetSpec defines the desired state of RunnerSet
               properties:
+                PodTemplateFile:
+                  type: string
                 containerMode:
                   type: string
                 dockerEnabled:
@@ -118,8 +120,6 @@ spec:
                   type: object
                 podManagementPolicy:
                   description: podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
-                  type: string
-                podTemplateName:
                   type: string
                 replicas:
                   description: 'replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1. TODO: Consider a rename of this field.'

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -127,6 +127,8 @@ spec:
                     spec:
                       description: RunnerSpec defines the desired state of Runner
                       properties:
+                        PodTemplateFile:
+                          type: string
                         affinity:
                           description: Affinity is a group of affinity scheduling rules.
                           properties:
@@ -3417,8 +3419,6 @@ spec:
                           type: object
                         organization:
                           pattern: ^[^/]+$
-                          type: string
-                        podTemplateName:
                           type: string
                         priorityClassName:
                           type: string

--- a/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
@@ -3418,6 +3418,8 @@ spec:
                         organization:
                           pattern: ^[^/]+$
                           type: string
+                        podTemplateName:
+                          type: string
                         priorityClassName:
                           type: string
                         repository:

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -109,6 +109,8 @@ spec:
                     spec:
                       description: RunnerSpec defines the desired state of Runner
                       properties:
+                        PodTemplateFile:
+                          type: string
                         affinity:
                           description: Affinity is a group of affinity scheduling rules.
                           properties:
@@ -3399,8 +3401,6 @@ spec:
                           type: object
                         organization:
                           pattern: ^[^/]+$
-                          type: string
-                        podTemplateName:
                           type: string
                         priorityClassName:
                           type: string

--- a/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
@@ -3400,6 +3400,8 @@ spec:
                         organization:
                           pattern: ^[^/]+$
                           type: string
+                        podTemplateName:
+                          type: string
                         priorityClassName:
                           type: string
                         repository:

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -61,6 +61,8 @@ spec:
             spec:
               description: RunnerSpec defines the desired state of Runner
               properties:
+                PodTemplateFile:
+                  type: string
                 affinity:
                   description: Affinity is a group of affinity scheduling rules.
                   properties:
@@ -3351,8 +3353,6 @@ spec:
                   type: object
                 organization:
                   pattern: ^[^/]+$
-                  type: string
-                podTemplateName:
                   type: string
                 priorityClassName:
                   type: string

--- a/config/crd/bases/actions.summerwind.dev_runners.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runners.yaml
@@ -3352,6 +3352,8 @@ spec:
                 organization:
                   pattern: ^[^/]+$
                   type: string
+                podTemplateName:
+                  type: string
                 priorityClassName:
                   type: string
                 repository:

--- a/config/crd/bases/actions.summerwind.dev_runnersets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnersets.yaml
@@ -119,6 +119,8 @@ spec:
                 podManagementPolicy:
                   description: podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
                   type: string
+                podTemplateName:
+                  type: string
                 replicas:
                   description: 'replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1. TODO: Consider a rename of this field.'
                   format: int32

--- a/config/crd/bases/actions.summerwind.dev_runnersets.yaml
+++ b/config/crd/bases/actions.summerwind.dev_runnersets.yaml
@@ -46,6 +46,8 @@ spec:
             spec:
               description: RunnerSetSpec defines the desired state of RunnerSet
               properties:
+                PodTemplateFile:
+                  type: string
                 containerMode:
                   type: string
                 dockerEnabled:
@@ -118,8 +120,6 @@ spec:
                   type: object
                 podManagementPolicy:
                   description: podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
-                  type: string
-                podTemplateName:
                   type: string
                 replicas:
                   description: 'replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1. TODO: Consider a rename of this field.'

--- a/controllers/actions.summerwind.net/new_runner_pod_test.go
+++ b/controllers/actions.summerwind.net/new_runner_pod_test.go
@@ -694,7 +694,7 @@ func TestNewRunnerPod(t *testing.T) {
 			},
 			config: arcv1alpha1.RunnerConfig{
 				ContainerMode:   "kubernetes",
-				PodTemplateFile: "example-template",
+				PodTemplateFile: "/templates/example-template.yaml",
 			},
 			want: newTestPod(baseKubernetesMode, func(p *corev1.Pod) {
 				envVars := []corev1.EnvVar{

--- a/controllers/actions.summerwind.net/new_runner_pod_test.go
+++ b/controllers/actions.summerwind.net/new_runner_pod_test.go
@@ -684,7 +684,7 @@ func TestNewRunnerPod(t *testing.T) {
 			}),
 		},
 		{
-			description: "it should set podTemplateName as an env var when containerMode is kubernetes",
+			description: "it should set container hook file as an env var when PodTemplateFile is set",
 			template: corev1.Pod{
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
@@ -694,7 +694,7 @@ func TestNewRunnerPod(t *testing.T) {
 			},
 			config: arcv1alpha1.RunnerConfig{
 				ContainerMode:   "kubernetes",
-				PodTemplateName: "example-template",
+				PodTemplateFile: "example-template",
 			},
 			want: newTestPod(baseKubernetesMode, func(p *corev1.Pod) {
 				envVars := []corev1.EnvVar{
@@ -756,9 +756,6 @@ func TestNewRunnerPod(t *testing.T) {
 				UseRunnerStatusUpdateHook: false,
 			})
 
-			if tc.description == "it should set podTemplateName as an env var when containerMode is kubernetes" {
-				print("hello")
-			}
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
 		})

--- a/controllers/actions.summerwind.net/runner_controller.go
+++ b/controllers/actions.summerwind.net/runner_controller.go
@@ -771,7 +771,7 @@ func runnerHookEnvs(pod *corev1.Pod, podTemplateFile string) ([]corev1.EnvVar, e
 	if podTemplateFile != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE",
-			Value: "/templates/" + podTemplateFile + ".yaml",
+			Value: podTemplateFile,
 		})
 	}
 

--- a/controllers/actions.summerwind.net/runner_controller.go
+++ b/controllers/actions.summerwind.net/runner_controller.go
@@ -731,7 +731,7 @@ func mutatePod(pod *corev1.Pod, token string) *corev1.Pod {
 	return updated
 }
 
-func runnerHookEnvs(pod *corev1.Pod, podTemplateName string) ([]corev1.EnvVar, error) {
+func runnerHookEnvs(pod *corev1.Pod, podTemplateFile string) ([]corev1.EnvVar, error) {
 	isRequireSameNode, err := isRequireSameNode(pod)
 	if err != nil {
 		return nil, err
@@ -768,10 +768,10 @@ func runnerHookEnvs(pod *corev1.Pod, podTemplateName string) ([]corev1.EnvVar, e
 		},
 	}
 
-	if podTemplateName != "" {
+	if podTemplateFile != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE",
-			Value: "/templates/" + podTemplateName + ".yaml",
+			Value: "/templates/" + podTemplateFile + ".yaml",
 		})
 	}
 
@@ -944,7 +944,7 @@ func newRunnerPodWithContainerMode(containerMode string, template corev1.Pod, ru
 
 	runnerContainer.Env = append(runnerContainer.Env, env...)
 	if containerMode == "kubernetes" {
-		hookEnvs, err := runnerHookEnvs(&template, runnerSpec.PodTemplateName)
+		hookEnvs, err := runnerHookEnvs(&template, runnerSpec.PodTemplateFile)
 		if err != nil {
 			return corev1.Pod{}, err
 		}


### PR DESCRIPTION
This PR adds support for the `ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE` env var added in https://github.com/actions/runner-container-hooks/pull/75 when using `containerMode: kubernetes`.

After this you can pass `podTemplateFile` as a parameter in the RunnerSpec that points to a pod template file ([example](https://github.com/actions/runner-container-hooks/blob/main/examples/extension.yaml)) that should be mounted by the user.

This PR is still in draft because I'd like to collect some feedback from maintainers if they agree with the direction I've taken to implement this. Please let me know what you think!

closes https://github.com/actions/actions-runner-controller/issues/1730