### PR TITLE
Add listener graceful termination period and background context after the message is received

### DIFF
--- a/cmd/ghalistener/listener/listener_test.go
+++ b/cmd/ghalistener/listener/listener_test.go
@@ -420,6 +420,7 @@ func TestListener_Listen(t *testing.T) {
 		}
 		client.On("CreateMessageSession", ctx, mock.Anything, mock.Anything).Return(session, nil).Once()
 		client.On("DeleteMessageSession", mock.Anything, session.RunnerScaleSet.Id, session.SessionId).Return(nil).Once()
+
 		config.Client = client
 
 		l, err := New(config)
@@ -463,6 +464,7 @@ func TestListener_Listen(t *testing.T) {
 			Statistics:              &actions.RunnerScaleSetStatistic{},
 		}
 		client.On("CreateMessageSession", ctx, mock.Anything, mock.Anything).Return(session, nil).Once()
+		client.On("DeleteMessageSession", mock.Anything, session.RunnerScaleSet.Id, session.SessionId).Return(nil).Once()
 
 		msg := &actions.RunnerScaleSetMessage{
 			MessageId:   1,

--- a/cmd/ghalistener/listener/metrics_test.go
+++ b/cmd/ghalistener/listener/metrics_test.go
@@ -82,6 +82,7 @@ func TestInitialMetrics(t *testing.T) {
 
 		client := listenermocks.NewClient(t)
 		client.On("CreateMessageSession", mock.Anything, mock.Anything, mock.Anything).Return(session, nil).Once()
+		client.On("DeleteMessageSession", mock.Anything, session.RunnerScaleSet.Id, session.SessionId).Return(nil).Once()
 		config.Client = client
 
 		handler := listenermocks.NewHandler(t)


### PR DESCRIPTION
The listener can be interrupted at any point of upgrade. If interrupted at a time when the listener receives a message, acquires jobs but fails to patch, that may cause some jobs to be left in a scheduled state. 

This PR intends to replace context after the message is received, and to allow some period for the listener to actually patch the ephemeral runner set. Only after patching, the listener should return and therefore exit.