### PR TITLE
fix: gha controller needs further permissions

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
@@ -109,36 +109,65 @@ rules:
   resources:
   - ephemeralrunners/status
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - watch
   - patch
-  - update
 - apiGroups:
   - ""
   resources:
   - pods
   verbs:
+  - create
+  - delete
+  - get
   - list
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
   verbs:
+  - create
+  - delete
+  - get
   - list
   - watch
+  - patch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
   verbs:
+  - create
+  - delete
+  - get
   - list
   - watch
+  - patch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
   verbs:
+  - create
+  - delete
+  - get
   - list
   - watch
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
 {{- end }}


### PR DESCRIPTION
# Description

The current RBAC permissions cause several errors in the controller

https://github.com/actions/actions-runner-controller/discussions/3160
https://github.com/actions/actions-runner-controller/discussions/3197

These permissions allow my actions to run properly

# Testing

 Currently using this in our environment with kustomize to override the Cluster Role