### PR TITLE
Remove Typo in Grafana docs

### DIFF
--- a/docs/gha-runner-scale-set-controller/samples/grafana-dashboard/README.md
+++ b/docs/gha-runner-scale-set-controller/samples/grafana-dashboard/README.md
@@ -12,4 +12,4 @@ We do not intend to provide a supported ARC dashboard. This is simply a referenc
 
 1. Make sure to have [Grafana](https://grafana.com/docs/grafana/latest/installation/) and [Prometheus](https://prometheus.io/docs/prometheus/latest/installation/) running in your cluster.
 2. Make sure that Prometheus is properly scraping the metrics endpoints of the controller-manager and listeners.
-3. Import the [dashboard](ARC-Autoscaling-Runner-Set-Monitoring_1692627561838.json.json) into Grafana.
+3. Import the [dashboard](ARC-Autoscaling-Runner-Set-Monitoring_1692627561838.json) into Grafana.


### PR DESCRIPTION
## Typo Fix
- Grafana docs had a typo in the markdown
- Link to dashboard json was incorrect
- This PR corrects the link