### PR TITLE
Revert docker socket path to `/var/run/docker.sock`

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -99,7 +99,7 @@ volumeMounts:
 image: docker:dind
 args:
   - dockerd
-  - --host=unix:///run/docker/docker.sock
+  - --host=unix:///var/run/docker.sock
   - --group=$(DOCKER_GROUP_GID)
 env:
   - name: DOCKER_GROUP_GID
@@ -110,7 +110,7 @@ volumeMounts:
   - name: work
     mountPath: /home/runner/_work
   - name: dind-sock
-    mountPath: /run/docker
+    mountPath: /var/run
   - name: dind-externals
     mountPath: /home/runner/externals
 {{- end }}
@@ -223,7 +223,7 @@ env:
     {{- end }}
     {{- if $setDockerHost }}
   - name: DOCKER_HOST
-    value: unix:///run/docker/docker.sock
+    value: unix:///var/run/docker.sock
     {{- end }}
     {{- if $setRunnerWaitDocker }}
   - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
@@ -264,7 +264,7 @@ volumeMounts:
     {{- end }}
     {{- if $mountDindCert }}
   - name: dind-sock
-    mountPath: /run/docker
+    mountPath: /var/run
     readOnly: true
     {{- end }}
     {{- if $mountGitHubServerTLS }}


### PR DESCRIPTION
This pull request primarily includes changes to the `charts/gha-runner-scale-set/templates/_helpers.tpl` file, where the Docker socket's path has been updated from `/run/docker/docker.sock` to `/var/run/docker.sock`. 

The default path for the docker daemon's unix socket is `/var/run/docker.sock` as per [this reference](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-socket-option). There's no reason to use any other path.