### PR TITLE
Fix namespaced Role and non-namespaces ClusterRoleBindig in helm chart

### DIFF
--- a/charts/actions-runner-controller/templates/manager_role_binding_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_role_binding_secrets.yaml
@@ -6,7 +6,9 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ include "actions-runner-controller.managerRoleName" . }}-secrets
+  {{- if .Values.scope.singleNamespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.scope.singleNamespace }}

--- a/charts/actions-runner-controller/templates/manager_role_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_role_secrets.yaml
@@ -7,6 +7,9 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: {{ include "actions-runner-controller.managerRoleName" . }}-secrets
+  {{- if .Values.scope.singleNamespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
This MR:
- Removes namespace from non-namespaced `ClusterRoleBinding` object
- Adds namespace to namespaced `Role` object