### PR TITLE
Deprecation warning of older listener for 0.9.0 release

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/NOTES.txt
+++ b/charts/gha-runner-scale-set-controller/templates/NOTES.txt
@@ -2,3 +2,4 @@ Thank you for installing {{ .Chart.Name }}.
 
 Your release is named {{ .Release.Name }}.
 
+WARNING: Older version of the listener (githubrunnerscalesetlistener) is deprecated and will be removed in the future gha-runner-scale-set-0.10.0 release. If you are using environment variable override to force the old listener, please remove the environment variable and use the new listener (ghalistener) instead.


### PR DESCRIPTION
This pull request includes a change to the `charts/gha-runner-scale-set-controller/templates/NOTES.txt` file. A warning message has been added to alert users that an older version of the listener, `githubrunnerscalesetlistener`, is deprecated and will be removed in the future `gha-runner-scale-set-0.10.0` release. Users are advised to remove the environment variable override and use the new listener, `ghalistener`, instead.