### PR TITLE
Update metrics to include repository on job-based label

### DIFF
--- a/cmd/ghalistener/listener/listener_test.go
+++ b/cmd/ghalistener/listener/listener_test.go
@@ -37,7 +37,6 @@ func TestNew(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, l)
 	})
-
 }
 
 func TestListener_createSession(t *testing.T) {
@@ -657,7 +656,7 @@ func TestListener_acquireAvailableJobs(t *testing.T) {
 			Return(nil, &actions.MessageQueueTokenExpiredError{}).
 			Once()
 
-		// First call to AcquireJobs will fail with a token expired error
+		// Second call should succeed
 		client.On("AcquireJobs", ctx, mock.Anything, mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				ids := args.Get(3).([]int64)

--- a/cmd/ghalistener/metrics/metrics.go
+++ b/cmd/ghalistener/metrics/metrics.go
@@ -223,7 +223,7 @@ type baseLabels struct {
 func (b *baseLabels) jobLabels(jobBase *actions.JobMessageBase) prometheus.Labels {
 	return prometheus.Labels{
 		labelKeyEnterprise:     b.enterprise,
-		labelKeyOrganization:   b.organization,
+		labelKeyOrganization:   jobBase.OwnerName,
 		labelKeyRepository:     jobBase.RepositoryName,
 		labelKeyJobName:        jobBase.JobDisplayName,
 		labelKeyJobWorkflowRef: jobBase.JobWorkflowRef,

--- a/cmd/ghalistener/metrics/metrics.go
+++ b/cmd/ghalistener/metrics/metrics.go
@@ -224,7 +224,7 @@ func (b *baseLabels) jobLabels(jobBase *actions.JobMessageBase) prometheus.Label
 	return prometheus.Labels{
 		labelKeyEnterprise:     b.enterprise,
 		labelKeyOrganization:   b.organization,
-		labelKeyRepository:     b.repository,
+		labelKeyRepository:     jobBase.RepositoryName,
 		labelKeyJobName:        jobBase.JobDisplayName,
 		labelKeyJobWorkflowRef: jobBase.JobWorkflowRef,
 		labelKeyEventName:      jobBase.EventName,
@@ -271,8 +271,10 @@ type ServerPublisher interface {
 	ListenAndServe(ctx context.Context) error
 }
 
-var _ Publisher = &discard{}
-var _ ServerPublisher = &exporter{}
+var (
+	_ Publisher       = &discard{}
+	_ ServerPublisher = &exporter{}
+)
 
 var Discard Publisher = &discard{}
 


### PR DESCRIPTION
When creating labels used for the job-related metrics, apply repository name based on the job message, instead of `githubConfigUrl`.

Also, fix the comment in listener_test.

Partially addresses #3185