### PR TITLE
Fix the deletion of ScaleSet

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
@@ -131,6 +131,7 @@ rules:
   resources:
   - rolebindings
   verbs:
+  - delete
   - list
   - watch
 - apiGroups:

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
@@ -51,6 +51,7 @@ rules:
   resources:
   - rolebindings
   verbs:
+  - delete
   - list
   - watch
 - apiGroups:


### PR DESCRIPTION
Using terraform `helm_release` resource with helm chart of version `0.8.3`: after successful deployment, when trying to remove the ScaleSet, controller is failing with missing permission, which fails the terraform run.

```
User \"system:serviceaccount:my-service-account:my-controller-rs-controller\" cannot delete resource \"rolebindings\" in API group \"rbac.authorization.k8s.io\" in the namespace \"my-namespace\""
```
