### PR TITLE
fix(metrics): Make sure repository/organization is set for job metrics

### DIFF
--- a/cmd/ghalistener/metrics/metrics.go
+++ b/cmd/ghalistener/metrics/metrics.go
@@ -221,10 +221,21 @@ type baseLabels struct {
 }
 
 func (b *baseLabels) jobLabels(jobBase *actions.JobMessageBase) prometheus.Labels {
+	organization := b.organization
+	repository := b.repository
+
+	if organization == "" { // Runner configured for an enterprise will have empty organization
+		organization = jobBase.OwnerName
+	}
+
+	if repository == "" { // Runner configured for an enterprise/organization will have empty repository
+		repository = jobBase.RepositoryName
+	}
+
 	return prometheus.Labels{
 		labelKeyEnterprise:     b.enterprise,
-		labelKeyOrganization:   b.organization,
-		labelKeyRepository:     b.repository,
+		labelKeyOrganization:   organization,
+		labelKeyRepository:     repository,
 		labelKeyJobName:        jobBase.JobDisplayName,
 		labelKeyJobWorkflowRef: jobBase.JobWorkflowRef,
 		labelKeyEventName:      jobBase.EventName,


### PR DESCRIPTION
These fields are empty when the runner is assigned to an enterprise/organization.

Jobs metrics are somewhat useless if not linked to their associated job.

NOT TESTED YET, will try do to that ASAP. 