### PR TITLE
Fix documented dind expansion

### DIFF
--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -130,8 +130,7 @@ template:
   ##         - name: work
   ##           mountPath: /home/runner/_work
   ##         - name: dind-sock
-  ##           mountPath: /run/docker
-  ##           readOnly: true
+  ##           mountPath: /var/run
   ##     - name: dind
   ##       image: docker:dind
   ##       args:
@@ -147,7 +146,7 @@ template:
   ##         - name: work
   ##           mountPath: /home/runner/_work
   ##         - name: dind-sock
-  ##           mountPath: /run/docker
+  ##           mountPath: /var/run
   ##         - name: dind-externals
   ##           mountPath: /home/runner/externals
   ##     volumes:


### PR DESCRIPTION
PR #3337 introduced the change in docker socket path. This PR fixes the documentation in values.yaml to update the default volume mount for `dind` mode.