### PR TITLE
Allow multiple rs with same name in a namespace

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -20,8 +20,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "gha-runner-scale-set.fullname" -}}
-{{- $name := default (include "gha-base-name" .) }}
-{{- printf "%s-%s" (include "gha-runner-scale-set.scale-set-name" .) $name | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (include "gha-base-name" .) .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -51,7 +59,7 @@ Selector labels
 */}}
 {{- define "gha-runner-scale-set.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "gha-runner-scale-set.scale-set-name" . }}
-app.kubernetes.io/instance: {{ include "gha-runner-scale-set.scale-set-name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "gha-runner-scale-set.githubsecret" -}}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -1,13 +1,13 @@
 apiVersion: actions.github.com/v1alpha1
 kind: AutoscalingRunnerSet
 metadata:
-  {{- if or (not (include "gha-runner-scale-set.scale-set-name" .)) (gt (len (include "gha-runner-scale-set.scale-set-name" .)) 45) }}
+  {{- if or (not (include "gha-runner-scale-set.fullname" .)) (gt (len (include "gha-runner-scale-set.fullname" .)) 45) }}
   {{ fail "Name must have up to 45 characters" }}
   {{- end }}
   {{- if gt (len .Release.Namespace) 63 }}
   {{ fail "Namespace must have up to 63 characters" }}
   {{- end }}
-  name: {{ include "gha-runner-scale-set.scale-set-name" . }}
+  name: {{ include "gha-runner-scale-set.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: "autoscaling-runner-set"


### PR DESCRIPTION
Following changes are made:

**1. Update chart fullname**

i. Support fullnameOverride option 
ii. If release name contains chart name it will be used as a full name.
iii. Use `<release-name>-<chart-name>` as fullname

**2. Use chart fullname as resource name and selector instead of scale-set-name**


These changes assign a unique noPermissionServiceAccountName and AutoscalingRunnerSet name based on the release name so that two different scale-sets can be present in the same namespace when they are part of two different releases within the namespace.