### PR TITLE
[charts/gha-runner-scale-set-controller] Add missing RBAC permissions on `events` to the `ClusterRole` `gha-runner-scale-set-controller-gha-rs-controller`

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
@@ -141,4 +141,13 @@ rules:
   - list
   - watch
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 {{- end }}


### PR DESCRIPTION
With a clean deployment of `oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller`, version 0.9.1, the following error is observed in the logs:

```
$ kubectl -n gha-runners logs gha-runner-scale-set-controller-gha-rs-controller-69bb5cfbff2xg
I0501 02:16:19.002950       1 leaderelection.go:250] attempting to acquire leader lease gha-runners/gha-runner-scale-set-controller-gha-rs-controller...
I0501 02:16:35.768876       1 leaderelection.go:260] successfully acquired lease gha-runners/gha-runner-scale-set-controller-gha-rs-controller
E0501 02:16:35.779247       1 event.go:280] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"gha-runner-scale-set-controller-gha-rs-controller.17cb3bc3e99fa4f1", GenerateName:"", Namespace:"gha-runners", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"Lease", Namespace:"gha-runners", Name:"gha-runner-scale-set-controller-gha-rs-controller", UID:"0669289f-7a26-4956-9668-00fdc9fe4739", APIVersion:"coordination.k8s.io/v1", ResourceVersion:"233694020", FieldPath:""}, Reason:"LeaderElection", Message:"gha-runner-scale-set-controller-gha-rs-controller-69bb5cfbff2xg_e47f6629-6767-4063-838e-a394157d727d became leader", Source:v1.EventSource{Component:"gha-runner-scale-set-controller-gha-rs-controller-69bb5cfbff2xg_e47f6629-6767-4063-838e-a394157d727d", Host:""}, FirstTimestamp:time.Date(2024, time.May, 1, 2, 16, 35, 768820977, time.Local), LastTimestamp:time.Date(2024, time.May, 1, 2, 16, 35, 768820977, time.Local), Count:1, Type:"Normal", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"gha-runner-scale-set-controller-gha-rs-controller-69bb5cfbff2xg_e47f6629-6767-4063-838e-a394157d727d", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:gha-runners:gha-runner-scale-set-controller-gha-rs-controller" cannot create resource "events" in API group "" in the namespace "gha-runners"' (will not retry!)
```

With the proposed change, and following a `rollout restart deployment gha-runner-scale-set-controller-gha-rs-controller`, the issue seems to be fixed:

```
$ kdt -n gha-runners logs gha-runner-scale-set-controller-gha-rs-controller-76f6bfd9jf8s8
I0501 02:26:44.044465       1 leaderelection.go:250] attempting to acquire leader lease gha-runners/gha-runner-scale-set-controller-gha-rs-controller...
I0501 02:27:02.298319       1 leaderelection.go:260] successfully acquired lease gha-runners/gha-runner-scale-set-controller-gha-rs-controller
```

Helm value overrides:
```
replicaCount: 3
flags.logLevel: "warn"
```