### PR TITLE
[fix] Allow events events api

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
@@ -127,6 +127,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
@@ -108,6 +108,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings


### PR DESCRIPTION
```
ystem", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"Lease", Namespace:"arc-system", Name:"gha-rs-controller", UID:"7df82bf8-2f40-464f-bfaa-02055d3379b0", APIVersion:"coordination.k8s.io/v1", ResourceVersion:"55357371", FieldPath:""}, Reason:"LeaderElection", Message:"gha-rs-controller-c58d4454d-dp4qv_48434b5e-ad35-43e3-8732-1a18fb5240f1 became leader", Source:v1.EventSource{Component:"gha-rs-controller-c58d4454d-dp4qv_48434b5e-ad35-43e3-8732-1a18fb5240f1", Host:""}, FirstTimestamp:time.Date(2024, time.May, 8, 17, 26, 57, 872363492, time.Local), LastTimestamp:time.Date(2024, time.May, 8, 17, 26, 57, 872363492, time.Local), Count:1, Type:"Normal", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"gha-rs-controller-c58d4454d-dp4qv_48434b5e-ad35-43e3-8732-1a18fb5240f1", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:arc-system:gha-rs-controller" cannot create resource "events" in API group "" in the namespace "arc-system"' (will not retry!)
```