### PR TITLE
Remove service monitor that is not used in controller chart

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
@@ -126,7 +126,3 @@ Create the name of the service account to use
 {{- end }}
 {{- $names | join ","}}
 {{- end }}
-
-{{- define "gha-runner-scale-set-controller.serviceMonitorName" -}}
-{{- include "gha-runner-scale-set-controller.fullname" . }}-service-monitor
-{{- end }}


### PR DESCRIPTION
Removes unused service monitor helper template for name.

Fixes #3525