### PR TITLE
Consistent use of UID in dind-rootless runner

### DIFF
--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -78,9 +78,9 @@ RUN cd "$RUNNER_ASSETS_DIR" \
     && rm -f runner-container-hooks.zip
 
 # Make the rootless runner directory executable
-RUN mkdir /run/user/1000 \
-    && chown runner:runner /run/user/1000 \
-    && chmod a+x /run/user/1000
+RUN mkdir /run/user/$RUNNER_USER_UID \
+    && chown runner:runner /run/user/$RUNNER_USER_UID \
+    && chmod a+x /run/user/$RUNNER_USER_UID
 
 # We place the scripts in `/usr/bin` so that users who extend this image can
 # override them with scripts of the same name placed in `/usr/local/bin`.
@@ -97,8 +97,8 @@ COPY hooks /etc/arc/hooks/
 # Add the Python "User Script Directory" to the PATH
 ENV PATH="${PATH}:${HOME}/.local/bin:/home/runner/bin"
 ENV ImageOS=ubuntu22
-ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
-ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/$RUNNER_USER_UID/docker.sock
+ENV XDG_RUNTIME_DIR=/run/user/$RUNNER_USER_UID
 
 RUN echo "PATH=${PATH}" > /etc/environment \
     && echo "ImageOS=${ImageOS}" >> /etc/environment \


### PR DESCRIPTION
There are some consistency issues in the dind-rootless runner image
that leads to some confusion on what exactly the UID of the runner is.

To stay consistent use the same UID everywhere.
