### PR TITLE
Removes high-cardinality labels from histogram metrics

### DIFF
--- a/cmd/ghalistener/metrics/metrics.go
+++ b/cmd/ghalistener/metrics/metrics.go
@@ -43,14 +43,13 @@ var (
 		labelKeyOrganization,
 		labelKeyEnterprise,
 		labelKeyJobName,
-		labelKeyJobWorkflowRef,
 		labelKeyEventName,
 	}
 
-	completedJobsTotalLabels   = append(jobLabels, labelKeyJobResult, labelKeyRunnerID, labelKeyRunnerName)
-	jobExecutionDurationLabels = append(jobLabels, labelKeyJobResult, labelKeyRunnerID, labelKeyRunnerName)
-	startedJobsTotalLabels     = append(jobLabels, labelKeyRunnerID, labelKeyRunnerName)
-	jobStartupDurationLabels   = append(jobLabels, labelKeyRunnerID, labelKeyRunnerName)
+	completedJobsTotalLabels   = append(jobLabels, labelKeyJobResult, labelKeyJobWorkflowRef, labelKeyRunnerID, labelKeyRunnerName)
+	jobExecutionDurationLabels = append(jobLabels, labelKeyJobResult)
+	startedJobsTotalLabels     = append(jobLabels, labelKeyJobWorkflowRef, labelKeyRunnerID, labelKeyRunnerName)
+	jobStartupDurationLabels   = append(jobLabels)
 )
 
 var (


### PR DESCRIPTION
This is to solve https://github.com/actions/actions-runner-controller/issues/3153

This removes runner_id, runner_name, and job_workflow_ref from the job_startup_duration_seconds and job_execution_duration_seconds metrics to reduce cardinality and allow histograms to be produced from them, with the idea that startup and execution data will be stored in "per repo + workflow" buckets.

I'm unsure whether removing `labelKeyJobWorkflowRef` from `jobLabels` is suitable or if this should be reworked more to come up with more suitable lists.

