### PR TITLE
Check status code of fetch access token for github app

### DIFF
--- a/github/actions/client.go
+++ b/github/actions/client.go
@@ -1054,6 +1054,14 @@ func (c *Client) fetchAccessToken(ctx context.Context, gitHubConfigURL string, c
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusCreated {
+		return nil, &GitHubAPIError{
+			StatusCode: resp.StatusCode,
+			RequestID:  resp.Header.Get(HeaderGitHubRequestID),
+			Err:        fmt.Errorf("failed to get access token for GitHub App auth: %v", resp.Status),
+		}
+	}
+
 	// Format: https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app
 	var accessToken *accessToken
 	if err = json.NewDecoder(resp.Body).Decode(&accessToken); err != nil {


### PR DESCRIPTION
Previously, the status code was not checked on `fetchAccessToken`.

This PR aims to add a check for the endpoint described [here](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app). 

Fixes #3565