### PR TITLE
chore: Added `OwnerReferences` during resource creation for `EphemeralRunnerSet`, `EphemeralRunner`, and `EphemeralRunnerPod`

### DIFF
--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -73,6 +73,11 @@ type ResourceBuilder struct {
 	ExcludeLabelPropagationPrefixes []string
 }
 
+// boolPtr returns a pointer to a bool value
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func (b *ResourceBuilder) newAutoScalingListener(autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet, ephemeralRunnerSet *v1alpha1.EphemeralRunnerSet, namespace, image string, imagePullSecrets []corev1.LocalObjectReference) (*v1alpha1.AutoscalingListener, error) {
 	runnerScaleSetId, err := strconv.Atoi(autoscalingRunnerSet.Annotations[runnerScaleSetIdAnnotationKey])
 	if err != nil {
@@ -284,6 +289,16 @@ func (b *ResourceBuilder) newScaleSetListenerPod(autoscalingListener *v1alpha1.A
 			Name:      autoscalingListener.Name,
 			Namespace: autoscalingListener.Namespace,
 			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingListener.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingListener.GetObjectKind().GroupVersionKind().Kind,
+					UID:                autoscalingListener.GetUID(),
+					Name:               autoscalingListener.GetName(),
+					Controller:         boolPtr(true),
+					BlockOwnerDeletion: boolPtr(true),
+				},
+			},
 		},
 		Spec: podSpec,
 	}
@@ -530,6 +545,16 @@ func (b *ResourceBuilder) newEphemeralRunnerSet(autoscalingRunnerSet *v1alpha1.A
 			Namespace:    autoscalingRunnerSet.ObjectMeta.Namespace,
 			Labels:       labels,
 			Annotations:  newAnnotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingRunnerSet.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingRunnerSet.GetObjectKind().GroupVersionKind().Kind,
+					UID:                autoscalingRunnerSet.GetUID(),
+					Name:               autoscalingRunnerSet.GetName(),
+					Controller:         boolPtr(true),
+					BlockOwnerDeletion: boolPtr(true),
+				},
+			},
 		},
 		Spec: v1alpha1.EphemeralRunnerSetSpec{
 			Replicas: 0,
@@ -569,6 +594,16 @@ func (b *ResourceBuilder) newEphemeralRunner(ephemeralRunnerSet *v1alpha1.Epheme
 			Namespace:    ephemeralRunnerSet.Namespace,
 			Labels:       labels,
 			Annotations:  annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         ephemeralRunnerSet.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+					Kind:               ephemeralRunnerSet.GetObjectKind().GroupVersionKind().Kind,
+					UID:                ephemeralRunnerSet.GetUID(),
+					Name:               ephemeralRunnerSet.GetName(),
+					Controller:         boolPtr(true),
+					BlockOwnerDeletion: boolPtr(true),
+				},
+			},
 		},
 		Spec: ephemeralRunnerSet.Spec.EphemeralRunnerSpec,
 	}
@@ -607,6 +642,16 @@ func (b *ResourceBuilder) newEphemeralRunnerPod(ctx context.Context, runner *v1a
 		Namespace:   runner.ObjectMeta.Namespace,
 		Labels:      labels,
 		Annotations: annotations,
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         runner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+				Kind:               runner.GetObjectKind().GroupVersionKind().Kind,
+				UID:                runner.GetUID(),
+				Name:               runner.GetName(),
+				Controller:         boolPtr(true),
+				BlockOwnerDeletion: boolPtr(true),
+			},
+		},
 	}
 
 	newPod.ObjectMeta = objectMeta

--- a/controllers/actions.github.com/resourcebuilder_test.go
+++ b/controllers/actions.github.com/resourcebuilder_test.go
@@ -182,3 +182,69 @@ func TestGitHubURLTrimLabelValues(t *testing.T) {
 		assert.Len(t, listener.Labels[LabelKeyGitHubRepository], 0)
 	})
 }
+
+func TestOwnershipRelationships(t *testing.T) {
+	// Create an AutoscalingRunnerSet
+	autoscalingRunnerSet := v1alpha1.AutoscalingRunnerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-scale-set",
+			Namespace: "test-ns",
+			UID:       "test-autoscaling-runner-set-uid",
+			Labels: map[string]string{
+				LabelKeyKubernetesPartOf:  labelValueKubernetesPartOf,
+				LabelKeyKubernetesVersion: "0.2.0",
+			},
+			Annotations: map[string]string{
+				runnerScaleSetIdAnnotationKey:         "1",
+				AnnotationKeyGitHubRunnerGroupName:    "test-group",
+				AnnotationKeyGitHubRunnerScaleSetName: "test-scale-set",
+				annotationKeyValuesHash:               "test-hash",
+			},
+		},
+		Spec: v1alpha1.AutoscalingRunnerSetSpec{
+			GitHubConfigUrl: "https://github.com/org/repo",
+		},
+	}
+
+	// Initialize ResourceBuilder
+	b := ResourceBuilder{}
+
+	// Create EphemeralRunnerSet
+	ephemeralRunnerSet, err := b.newEphemeralRunnerSet(&autoscalingRunnerSet)
+	require.NoError(t, err)
+
+	// Test EphemeralRunnerSet ownership
+	require.Len(t, ephemeralRunnerSet.OwnerReferences, 1, "EphemeralRunnerSet should have exactly one owner reference")
+	ownerRef := ephemeralRunnerSet.OwnerReferences[0]
+	assert.Equal(t, autoscalingRunnerSet.GetName(), ownerRef.Name, "Owner reference name should match AutoscalingRunnerSet name")
+	assert.Equal(t, autoscalingRunnerSet.GetUID(), ownerRef.UID, "Owner reference UID should match AutoscalingRunnerSet UID")
+	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
+	assert.Equal(t, true, *ownerRef.BlockOwnerDeletion, "BlockOwnerDeletion flag should be true")
+
+	// Create EphemeralRunner
+	ephemeralRunner := b.newEphemeralRunner(ephemeralRunnerSet)
+
+	// Test EphemeralRunner ownership
+	require.Len(t, ephemeralRunner.OwnerReferences, 1, "EphemeralRunner should have exactly one owner reference")
+	ownerRef = ephemeralRunner.OwnerReferences[0]
+	assert.Equal(t, ephemeralRunnerSet.GetName(), ownerRef.Name, "Owner reference name should match EphemeralRunnerSet name")
+	assert.Equal(t, ephemeralRunnerSet.GetUID(), ownerRef.UID, "Owner reference UID should match EphemeralRunnerSet UID")
+	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
+	assert.Equal(t, true, *ownerRef.BlockOwnerDeletion, "BlockOwnerDeletion flag should be true")
+
+	// Create EphemeralRunnerPod
+	runnerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-secret",
+		},
+	}
+	pod := b.newEphemeralRunnerPod(context.TODO(), ephemeralRunner, runnerSecret)
+
+	// Test EphemeralRunnerPod ownership
+	require.Len(t, pod.OwnerReferences, 1, "EphemeralRunnerPod should have exactly one owner reference")
+	ownerRef = pod.OwnerReferences[0]
+	assert.Equal(t, ephemeralRunner.GetName(), ownerRef.Name, "Owner reference name should match EphemeralRunner name")
+	assert.Equal(t, ephemeralRunner.GetUID(), ownerRef.UID, "Owner reference UID should match EphemeralRunner UID")
+	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
+	assert.Equal(t, true, *ownerRef.BlockOwnerDeletion, "BlockOwnerDeletion flag should be true")
+}


### PR DESCRIPTION
Remove the "argocd.argoproj.io/instance" label from resources created by the controller. This prevents ArgoCD from pruning and deleting these resources when syncing.