### PR TITLE
Remove `.Named()` from the ephemeral runner controller

### DIFF
--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -828,7 +828,6 @@ func (r *EphemeralRunnerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&v1alpha1.EphemeralRunner{}).
 		Owns(&corev1.Pod{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
-		Named("ephemeral-runner-controller").
 		Complete(r)
 }
 


### PR DESCRIPTION
Controller metrics would use the controller name as a label. Only the ephemeral runner controller was named, while default names are used for other controllers. This change removes the name change so it is consistent with other controllers