### PR TITLE
Prepare 0.9.3 release

### DIFF
--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -16,7 +16,7 @@ env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: arc_e2e_test_dummy
   IMAGE_NAME: "arc-test-image"
-  IMAGE_VERSION: "0.9.2"
+  IMAGE_VERSION: "0.9.3"
 
 concurrency:
   # This will make sure we only apply the concurrency limits on pull requests

--- a/charts/gha-runner-scale-set-controller/Chart.yaml
+++ b/charts/gha-runner-scale-set-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.2"
+appVersion: "0.9.3"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/gha-runner-scale-set/Chart.yaml
+++ b/charts/gha-runner-scale-set/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.2"
+appVersion: "0.9.3"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/docs/gha-runner-scale-set-controller/README.md
+++ b/docs/gha-runner-scale-set-controller/README.md
@@ -43,6 +43,16 @@ You can follow [this troubleshooting guide](https://docs.github.com/en/actions/h
 
 ## Changelog
 
+### v0.9.3
+
+1. AutoscalingListener controller: Inspect listener container state instead of pod phase [#3548](https://github.com/actions/actions-runner-controller/pull/3548)
+1. Exclude label prefix propagation [#3607](https://github.com/actions/actions-runner-controller/pull/3607)
+1. Check status code of fetch access token for github app [#3568](https://github.com/actions/actions-runner-controller/pull/3568)
+1. Remove .Named() from the ephemeral runner controller [#3596](https://github.com/actions/actions-runner-controller/pull/3596)
+1. Customize work directory [#3477](https://github.com/actions/actions-runner-controller/pull/3477)
+1. Fix problem with ephemeralRunner Succeeded state before build executed [#3528](https://github.com/actions/actions-runner-controller/pull/3528)
+1. Remove finalizers in one pass to speed up cleanups AutoscalingRunnerSet [#3536](https://github.com/actions/actions-runner-controller/pull/3536)
+
 ### v0.9.2
 
 1. Refresh session if token expires during delete message [#3529](https://github.com/actions/actions-runner-controller/pull/3529)


### PR DESCRIPTION
#### Major changes

- AutoscalingListener controller: Inspect listener container state instead of pod phase [#3548](https://github.com/actions/actions-runner-controller/pull/3548)
- Exclude label prefix propagation [#3607](https://github.com/actions/actions-runner-controller/pull/3607)
- Check status code of fetch access token for github app [#3568](https://github.com/actions/actions-runner-controller/pull/3568)
- Remove .Named() from the ephemeral runner controller [#3596](https://github.com/actions/actions-runner-controller/pull/3596)
- Customize work directory [#3477](https://github.com/actions/actions-runner-controller/pull/3477)
- Fix problem with ephemeralRunner Succeeded state before build executed [#3528](https://github.com/actions/actions-runner-controller/pull/3528)
- Remove finalizers in one pass to speed up cleanups AutoscalingRunnerSet [#3536](https://github.com/actions/actions-runner-controller/pull/3536)