### PR TITLE
feat(gha-runner-scale-set): ability to set annotations on noPermission service account

### DIFF
--- a/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
@@ -5,6 +5,10 @@ kind: ServiceAccount
 metadata:
   name: {{ include "gha-runner-scale-set.noPermissionServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.noPermissionServiceAccount.annotations }}
+  annotations:
+    {{ toYaml .Values.noPermissionServiceAccount.annotations | indent 4 }}
+  {{- end }}
   labels:
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
   finalizers:

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -201,3 +201,7 @@ template:
 # controllerServiceAccount:
 #   namespace: arc-system
 #   name: test-arc-gha-runner-scale-set-controller
+
+## Optionally add annotations to the noPermission service account
+noPermissionServiceAccount:
+  annotations: {}


### PR DESCRIPTION
Fixes #3678 
Fixes #3672

This pull request adds the ability to set custom annotations on the no_permission_serviceaccount for our gha runner scale sets.

This can be needed in some Google Workload Identity setups:

`iam.gke.io/gcp-service-account=IAM_SA_NAME@IAM_SA_PROJECT_ID.iam.gserviceaccount.com`

Source: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam