### PR TITLE
Allow reading AutoscalingRunnerSet githubConfigSecret from controller namespace

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
         {{- with .Values.flags.updateStrategy }}
         - "--update-strategy={{ . }}"
         {{- end }}
+        {{- if .Values.flags.readGitHubConfigSecretFromControllerNamespace }}
+        - "--read-github-config-secret-from-controller-namespace"
+        {{- end }}
         {{- if .Values.metrics }}
         {{- with .Values.metrics }}
         - "--listener-metrics-addr={{ .listenerAddr }}"

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -122,6 +122,12 @@ flags:
   ##   that you don't have any overprovisioning of runners.
   updateStrategy: "immediate"
 
+  ## This flag determines whether the githubConfigSecret on the AutoscalingRunnerSet will be read from the
+  ## namespace that the controller is running in or the namespace that the AutoscalingRunnerSet resource is in.
+  ##
+  ## Defaults to false, so the secret will be read from the namespace that the runner lives in.
+  readGitHubConfigSecretFromControllerNamespace: false
+
   ## Defines a list of prefixes that should not be propagated to internal resources.
   ## This is useful when you have labels that are used for internal purposes and should not be propagated to internal resources.
   ## See https://github.com/actions/actions-runner-controller/issues/3533 for more information.

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -52,6 +52,10 @@ type EphemeralRunnerReconciler struct {
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
 	ActionsClient actions.MultiClient
+
+	ControllerNamespace                           string
+	ReadGitHubConfigSecretFromControllerNamespace bool
+
 	ResourceBuilder
 }
 
@@ -592,6 +596,14 @@ func (r *EphemeralRunnerReconciler) updateStatusWithRunnerConfig(ctx context.Con
 	return ctrl.Result{}, nil
 }
 
+func (r *EphemeralRunnerReconciler) deriveConfigSecretNamespace(ephemeralRunner *v1alpha1.EphemeralRunner) string {
+	secretNamespace := ephemeralRunner.Namespace
+	if r.ReadGitHubConfigSecretFromControllerNamespace {
+		secretNamespace = r.ControllerNamespace
+	}
+	return secretNamespace
+}
+
 func (r *EphemeralRunnerReconciler) createPod(ctx context.Context, runner *v1alpha1.EphemeralRunner, secret *corev1.Secret, log logr.Logger) (ctrl.Result, error) {
 	var envs []corev1.EnvVar
 	if runner.Spec.ProxySecretRef != "" {
@@ -712,7 +724,7 @@ func (r *EphemeralRunnerReconciler) updateRunStatusFromPod(ctx context.Context, 
 
 func (r *EphemeralRunnerReconciler) actionsClientFor(ctx context.Context, runner *v1alpha1.EphemeralRunner) (actions.ActionsService, error) {
 	secret := new(corev1.Secret)
-	if err := r.Get(ctx, types.NamespacedName{Namespace: runner.Namespace, Name: runner.Spec.GitHubConfigSecret}, secret); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: r.deriveConfigSecretNamespace(runner), Name: runner.Spec.GitHubConfigSecret}, secret); err != nil {
 		return nil, fmt.Errorf("failed to get secret: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -94,11 +94,12 @@ func main() {
 		runnerImagePullSecrets stringSlice
 		runnerPodDefaults      actionssummerwindnet.RunnerPodDefaults
 
-		namespace                       string
-		logLevel                        string
-		logFormat                       string
-		watchSingleNamespace            string
-		excludeLabelPropagationPrefixes stringSlice
+		namespace                                     string
+		logLevel                                      string
+		logFormat                                     string
+		watchSingleNamespace                          string
+		readGithubConfigSecretFromControllerNamespace bool
+		excludeLabelPropagationPrefixes               stringSlice
 
 		autoScalerImagePullSecrets stringSlice
 
@@ -139,6 +140,7 @@ func main() {
 	flag.Var(&commonRunnerLabels, "common-runner-labels", "Runner labels in the K1=V1,K2=V2,... format that are inherited all the runners created by the controller. See https://github.com/actions/actions-runner-controller/issues/321 for more information")
 	flag.StringVar(&namespace, "watch-namespace", "", "The namespace to watch for custom resources. Set to empty for letting it watch for all namespaces.")
 	flag.StringVar(&watchSingleNamespace, "watch-single-namespace", "", "Restrict to watch for custom resources in a single namespace.")
+	flag.BoolVar(&readGithubConfigSecretFromControllerNamespace, "read-github-config-secret-from-controller-namespace", false, "Read AutoscalingRunnerSet githubConfigSecret from controller namespace.")
 	flag.Var(&excludeLabelPropagationPrefixes, "exclude-label-propagation-prefix", "The list of prefixes that should be excluded from label propagation")
 	flag.StringVar(&logLevel, "log-level", logging.LogLevelDebug, `The verbosity of the logging. Valid values are "debug", "info", "warn", "error". Defaults to "debug".`)
 	flag.StringVar(&logFormat, "log-format", "text", `The log format. Valid options are "text" and "json". Defaults to "text"`)
@@ -265,25 +267,28 @@ func main() {
 		}
 
 		if err = (&actionsgithubcom.AutoscalingRunnerSetReconciler{
-			Client:                             mgr.GetClient(),
-			Log:                                log.WithName("AutoscalingRunnerSet").WithValues("version", build.Version),
-			Scheme:                             mgr.GetScheme(),
-			ControllerNamespace:                managerNamespace,
-			DefaultRunnerScaleSetListenerImage: managerImage,
-			ActionsClient:                      actionsMultiClient,
-			UpdateStrategy:                     actionsgithubcom.UpdateStrategy(updateStrategy),
+			Client:              mgr.GetClient(),
+			Log:                 log.WithName("AutoscalingRunnerSet").WithValues("version", build.Version),
+			Scheme:              mgr.GetScheme(),
+			ControllerNamespace: managerNamespace,
+			ReadGitHubConfigSecretFromControllerNamespace: readGithubConfigSecretFromControllerNamespace,
+			DefaultRunnerScaleSetListenerImage:            managerImage,
+			ActionsClient:                                 actionsMultiClient,
+			UpdateStrategy:                                actionsgithubcom.UpdateStrategy(updateStrategy),
 			DefaultRunnerScaleSetListenerImagePullSecrets: autoScalerImagePullSecrets,
-			ResourceBuilder: rb,
+			ResourceBuilder:                               rb,
 		}).SetupWithManager(mgr); err != nil {
 			log.Error(err, "unable to create controller", "controller", "AutoscalingRunnerSet")
 			os.Exit(1)
 		}
 
 		if err = (&actionsgithubcom.EphemeralRunnerReconciler{
-			Client:          mgr.GetClient(),
-			Log:             log.WithName("EphemeralRunner").WithValues("version", build.Version),
-			Scheme:          mgr.GetScheme(),
-			ActionsClient:   actionsMultiClient,
+			Client:              mgr.GetClient(),
+			Log:                 log.WithName("EphemeralRunner").WithValues("version", build.Version),
+			Scheme:              mgr.GetScheme(),
+			ActionsClient:       actionsMultiClient,
+			ControllerNamespace: managerNamespace,
+			ReadGitHubConfigSecretFromControllerNamespace: readGithubConfigSecretFromControllerNamespace,
 			ResourceBuilder: rb,
 		}).SetupWithManager(mgr); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunner")
@@ -291,11 +296,13 @@ func main() {
 		}
 
 		if err = (&actionsgithubcom.EphemeralRunnerSetReconciler{
-			Client:          mgr.GetClient(),
-			Log:             log.WithName("EphemeralRunnerSet").WithValues("version", build.Version),
-			Scheme:          mgr.GetScheme(),
-			ActionsClient:   actionsMultiClient,
-			PublishMetrics:  metricsAddr != "0",
+			Client:              mgr.GetClient(),
+			Log:                 log.WithName("EphemeralRunnerSet").WithValues("version", build.Version),
+			Scheme:              mgr.GetScheme(),
+			ActionsClient:       actionsMultiClient,
+			PublishMetrics:      metricsAddr != "0",
+			ControllerNamespace: managerNamespace,
+			ReadGitHubConfigSecretFromControllerNamespace: readGithubConfigSecretFromControllerNamespace,
 			ResourceBuilder: rb,
 		}).SetupWithManager(mgr); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunnerSet")
@@ -303,12 +310,13 @@ func main() {
 		}
 
 		if err = (&actionsgithubcom.AutoscalingListenerReconciler{
-			Client:                  mgr.GetClient(),
-			Log:                     log.WithName("AutoscalingListener").WithValues("version", build.Version),
-			Scheme:                  mgr.GetScheme(),
-			ListenerMetricsAddr:     listenerMetricsAddr,
-			ListenerMetricsEndpoint: listenerMetricsEndpoint,
-			ResourceBuilder:         rb,
+			Client: mgr.GetClient(),
+			Log:    log.WithName("AutoscalingListener").WithValues("version", build.Version),
+			Scheme: mgr.GetScheme(),
+			ReadGitHubConfigSecretFromControllerNamespace: readGithubConfigSecretFromControllerNamespace,
+			ListenerMetricsAddr:                           listenerMetricsAddr,
+			ListenerMetricsEndpoint:                       listenerMetricsEndpoint,
+			ResourceBuilder:                               rb,
 		}).SetupWithManager(mgr); err != nil {
 			log.Error(err, "unable to create controller", "controller", "AutoscalingListener")
 			os.Exit(1)


### PR DESCRIPTION
There isn't an open issue for this because the issue templates state that features for `actions.github.com` controllers should be raised elsewhere, which I have done [here](https://github.com/orgs/community/discussions/132518) but I haven't had a response yet. I also raised a discussion on this repo [here](https://github.com/actions/actions-runner-controller/discussions/3693).

The reason I am raising this PR is because in my setup the `AutoscalingRunnerSet`s we provide are specific to users, so users can mount their own config maps and secrets. This is a problem because it means they can see the secret referenced in `githubConfigSecret` since it must currently be in the same namespace as the runner itself. We are [configuring ARC to register at the organisation level](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#authenticating-arc-with-a-github-app) so this means that users will have access to secrets for a GitHub App with "Self-hosted runners: Read and write" org level permissions, which we do not want.

To resolve this problem, this PR introduces a flag for the controller that, when enabled, tells the controller to read the secret referenced by `githubConfigSecret` from the same namespace as the controller. This is disabled by default.

I spent some time looking into the code and I couldn't actually see a technical reason for the runner secret to be in the same namespace as the runner, because the secret that gets read by the runner pod is a completely different secret - that one is the jitconfig secret that is created on the fly by the controller.

I have run this on a local kind cluster and verified that it works, from what I can see the e2e tests are only for the legacy controllers so I haven't added any coverage there. If there are e2e tests for the new controllers that I should add to please let me know.