### PR TITLE
Add exponential backoff when generating runner reg tokens

### DIFF
--- a/github/actions/github_api_request_test.go
+++ b/github/actions/github_api_request_test.go
@@ -170,7 +170,7 @@ func TestNewActionsServiceRequest(t *testing.T) {
 			}
 			failures := 0
 			unauthorizedHandler := func(w http.ResponseWriter, r *http.Request) {
-				if failures < 2 {
+				if failures < 5 {
 					failures++
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
Improve the retry mechanism and add exponential backoff with jitter when refreshing the session token.