### PR TITLE
fix(chart): correctly template actionsmetrics service ports

### DIFF
--- a/charts/actions-runner-controller/templates/actionsmetrics.service.yaml
+++ b/charts/actions-runner-controller/templates/actionsmetrics.service.yaml
@@ -13,9 +13,7 @@ metadata:
 spec:
   type: {{ .Values.actionsMetricsServer.service.type }}
   ports:
-    {{ range $_, $port := .Values.actionsMetricsServer.service.ports -}}
-    - {{ $port | toYaml | nindent 6 }}
-    {{- end }}
+    {{- toYaml .Values.actionsMetricsServer.service.ports | nindent 4 }}
     {{- if .Values.actionsMetrics.serviceMonitor.enable }}
     - name: metrics-port
       port: {{ .Values.actionsMetrics.port }}


### PR DESCRIPTION
- currently setting the service ports via `actionsMetricsServer.enabled: true` gives:
  ```
  Warning  UpgradeFailed  2s  helm-controller  Helm upgrade failed for release namespace/actions-runner-controller with chart actions-runner-controller@0.23.7: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 19: mapping key "name" already defined at line 15
  line 20: mapping key "port" already defined at line 16
  line 21: mapping key "protocol" already defined at line 17
  line 22: mapping key "targetPort" already defined at line 18
  ```
 
since the values.yaml already provides the key/values for the ports, just use `toYaml` which does correctly template the values. This change outputs (with the default values):

```
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 80
      protocol: TCP
      targetPort: http
```

