### PR TITLE
Allow Actions Github Client HTTP timeout to be configurable

### DIFF
--- a/github/actions/client.go
+++ b/github/actions/client.go
@@ -209,7 +209,7 @@ func NewClient(githubConfigURL string, creds *ActionsAuth, options ...ClientOpti
 	retryClient.RetryMax = ac.retryMax
 	retryClient.RetryWaitMax = ac.retryWaitMax
 
-	retryClient.HTTPClient.Timeout = 5 * time.Minute // timeout must be > 1m to accomodate long polling
+	retryClient.HTTPClient.Timeout = 90 * time.Second // timeout must be > 1m to accommodate long polling
 
 	transport, ok := retryClient.HTTPClient.Transport.(*http.Transport)
 	if !ok {

--- a/github/actions/client.go
+++ b/github/actions/client.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -209,7 +210,17 @@ func NewClient(githubConfigURL string, creds *ActionsAuth, options ...ClientOpti
 	retryClient.RetryMax = ac.retryMax
 	retryClient.RetryWaitMax = ac.retryWaitMax
 
-	retryClient.HTTPClient.Timeout = 90 * time.Second // timeout must be > 1m to accommodate long polling
+	ts, found := os.LookupEnv("ACTIONS_HTTP_CLIENT_TIMEOUT_SECONDS")
+	if !found {
+		// Default to 5 minutes
+		// timeout must be > 1m to accommodate long polling
+		ts = "300"
+	}
+	timeout, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert ACTIONS_HTTP_CLIENT_TIMEOUT_SECONDS to int64: %v", err)
+	}
+	retryClient.HTTPClient.Timeout = time.Duration(timeout) * time.Second
 
 	transport, ok := retryClient.HTTPClient.Transport.(*http.Transport)
 	if !ok {


### PR DESCRIPTION
We're on GHES and believe the 5 minute timeout on the listener to be too high for our network flow

This PR allows us to configure the HTTP timeout via the environment variable: `ACTIONS_HTTP_CLIENT_TIMEOUT_SECONDS`

If this variable is not provided then we will default to the current 5 minute (300 second) timeout. 