### PR TITLE
Removing Runner when runner container Not Ready

### DIFF
--- a/controllers/actions.github.com/ephemeralrunnerset_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller_test.go
@@ -1109,7 +1109,7 @@ var _ = Describe("Test EphemeralRunnerSet controller with proxy settings", func(
 		startManagers(GinkgoT(), mgr)
 	})
 
-	It("should create a proxy secret and delete the proxy secreat after the runner-set is deleted", func() {
+	It("should create a proxy secret and delete the proxy secret after the runner-set is deleted", func() {
 		secretCredentials := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "proxy-credentials",


### PR DESCRIPTION
When the runner container goes into a NotReady State the Pod is stuck in a Pending state and never gets deleted, this is causing our jobs to fail. Ideally it should early delete Pod when this scenario happens.