### PR TITLE
[helmchart] customize dind container resources limits

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -101,9 +101,6 @@ args:
   - dockerd
   - --host=unix:///var/run/docker.sock
   - --group=$(DOCKER_GROUP_GID)
-env:
-  - name: DOCKER_GROUP_GID
-    value: "123"
 {{- range $i, $container := .Values.template.spec.containers }}
   {{- if eq $container.name "dind" }}
     {{- if hasKey $container "resources"  }}

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -104,6 +104,25 @@ args:
 env:
   - name: DOCKER_GROUP_GID
     value: "123"
+{{- range $i, $container := .Values.template.spec.containers }}
+  {{- if eq $container.name "dind" }}
+    {{- if hasKey $container "resources"  }}
+resources:
+      {{ $container.resources | toYaml | nindent 2 }}
+    {{- else }}
+resources:
+  limits:
+    cpu: 2
+    memory: "8Gi"
+  requests:
+    cpu: 2
+    memory: "8Gi"
+    {{- end }}
+  {{- end }}
+{{- end }}
+env:
+  - name: DOCKER_GROUP_GID
+    value: "123"
 securityContext:
   privileged: true
 volumeMounts:


### PR DESCRIPTION
Currently dind container has no `resources` key, it causes difficulties at monitoring self-hosted runners usage. 
This PR is about customizing dind container's resource limit by users taste and also it has default value as same as github hosted runners for private repositories.