### PR TITLE
chore: update go and jwt minor versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/actions/actions-runner-controller
 
-go 1.22.4
+go 1.22.9
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.8.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/go-logr/logr v1.4.1
-	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,9 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
We're seeing minor security vulnerabilities when running a `grype` scan; let's update to address these:

```
% grype ghcr.io/actions/gha-runner-scale-set-controller:canary
 ✔ Parsed image                                                                                                                                                                                        sha256:c9c9f7e8e0dc3eb1b3d27e531fb44217933ad20e3ea830bb24618f98bbe060d8
 ✔ Cataloged contents                                                                                                                                                                                         8a2f8e0309e6ccb01f4a12662b89d5c0d7ce2e23af0e7feaf5e19a215aff5d6e
   ├── ✔ Packages                        [340 packages]
   ├── ✔ File digests                    [947 files]
   ├── ✔ File metadata                   [947 locations]
   └── ✔ Executables                     [6 executables]
 ✔ Scanned for vulnerabilities     [29 vulnerability matches]
   ├── by severity: 0 critical, 18 high, 6 medium, 5 low, 0 negligible
   └── by status:   29 fixed, 0 not-fixed, 0 ignored
NAME                          INSTALLED  FIXED-IN         TYPE       VULNERABILITY        SEVERITY
github.com/golang-jwt/jwt/v4  v4.5.0     4.5.1            go-module  GHSA-29wx-vh33-7x7r  Low
stdlib                        go1.22.4   1.22.7, 1.23.1   go-module  CVE-2024-34158       High
stdlib                        go1.22.4   1.22.7, 1.23.1   go-module  CVE-2024-34156       High
stdlib                        go1.22.4   1.21.12, 1.22.5  go-module  CVE-2024-24791       High
stdlib                        go1.22.4   1.22.7, 1.23.1   go-module  CVE-2024-34155       Medium
```