### PR TITLE
Make EphemeralRunnerController MaxConcurrentReconciles configurable

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
         {{- with .Values.flags.watchSingleNamespace }}
         - "--watch-single-namespace={{ . }}"
         {{- end }}
+        {{- with .Values.runnerMaxConcurrentReconciles }}
+        - "--runner-max-concurrent-reconciles={{ . }}"
+        {{- end }}
         {{- with .Values.flags.updateStrategy }}
         - "--update-strategy={{ . }}"
         {{- end }}

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -106,6 +106,11 @@ flags:
   ## Defaults to watch all namespaces when unset.
   # watchSingleNamespace: ""
 
+  ## The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller.
+  # Increase this value to improve the throughput of the controller.
+  # It may also increase the load on the API server and the external service (e.g. GitHub API).
+  runnerMaxConcurrentReconciles: 2
+
   ## Defines how the controller should handle upgrades while having running jobs.
   ##
   ## The strategies available are:

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -823,12 +823,14 @@ func (r *EphemeralRunnerReconciler) deleteRunnerFromService(ctx context.Context,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *EphemeralRunnerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.EphemeralRunner{}).
-		Owns(&corev1.Pod{}).
-		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
-		Complete(r)
+func (r *EphemeralRunnerReconciler) SetupWithManager(mgr ctrl.Manager, opts ...Option) error {
+	return builderWithOptions(
+		ctrl.NewControllerManagedBy(mgr).
+			For(&v1alpha1.EphemeralRunner{}).
+			Owns(&corev1.Pod{}).
+			WithEventFilter(predicate.ResourceVersionChangedPredicate{}),
+		opts,
+	).Complete(r)
 }
 
 func runnerContainerStatus(pod *corev1.Pod) *corev1.ContainerStatus {

--- a/controllers/actions.github.com/options.go
+++ b/controllers/actions.github.com/options.go
@@ -1,0 +1,90 @@
+package actionsgithubcom
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// Options is the optional configuration for the controllers, which can be
+// set via command-line flags or environment variables.
+type Options struct {
+	// RunnerMaxConcuncurrentReconciles is the maximum number of concurrent Reconciles which can be run
+	// by the EphemeralRunnerController.
+	RunnerMaxConcuncurrentReconciles int
+}
+
+// OptionsWithDefault returns the default options.
+// This is here to maintain the options and their default values in one place,
+// rather than having to correlate those in multiple places.
+func OptionsWithDefault() Options {
+	return Options{
+		RunnerMaxConcuncurrentReconciles: 1,
+	}
+}
+
+// LoadEnv loads the options from the environment variables.
+// This updates the option value only if the environment variable is set.
+// If the option is already set (via a command-line flag), the value from the environment variable takes precedence.
+func (o *Options) LoadEnv() error {
+	v, err := o.getEnvInt("RUNNER_MAX_CONCURRENT_RECONCILES")
+	if err != nil {
+		return err
+	}
+
+	if v != nil {
+		o.RunnerMaxConcuncurrentReconciles = *v
+	}
+
+	return nil
+}
+
+func (o *Options) getEnvInt(name string) (*int, error) {
+	s := os.Getenv(name)
+	if s == "" {
+		return nil, nil
+	}
+
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert %s=%s to int: %w", name, s, err)
+	}
+
+	return &v, nil
+}
+
+type Option func(*controller.Options)
+
+// WithMaxConcurrentReconciles sets the maximum number of concurrent Reconciles which can be run.
+//
+// This is useful to improve the throughput of the controller, but it may also increase the load on the API server and
+// the external service (e.g. GitHub API). The default value is 1, as defined by the controller-runtime.
+//
+// See https://github.com/actions/actions-runner-controller/issues/3021 for more information
+// on real-world use cases and the potential impact of this option.
+func WithMaxConcurrentReconciles(n int) Option {
+	return func(b *controller.Options) {
+		b.MaxConcurrentReconciles = n
+	}
+}
+
+// builderWithOptions applies the given options to the provided builder, if any.
+// This is a helper function to avoid the need to import the controller-runtime package in every reconciler source file
+// and the command package that creates the controller.
+// This is also useful for reducing code duplication around setting controller options in
+// multiple reconcilers.
+func builderWithOptions(b *builder.Builder, opts []Option) *builder.Builder {
+	if len(opts) == 0 {
+		return b
+	}
+
+	var controllerOpts controller.Options
+	for _, opt := range opts {
+		opt(&controllerOpts)
+	}
+
+	return b.WithOptions(controllerOpts)
+}

--- a/controllers/actions.github.com/options.go
+++ b/controllers/actions.github.com/options.go
@@ -22,7 +22,7 @@ type Options struct {
 // rather than having to correlate those in multiple places.
 func OptionsWithDefault() Options {
 	return Options{
-		RunnerMaxConcuncurrentReconciles: 1,
+		RunnerMaxConcuncurrentReconciles: 2,
 	}
 }
 

--- a/controllers/actions.github.com/options.go
+++ b/controllers/actions.github.com/options.go
@@ -1,10 +1,6 @@
 package actionsgithubcom
 
 import (
-	"fmt"
-	"os"
-	"strconv"
-
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
@@ -12,9 +8,9 @@ import (
 // Options is the optional configuration for the controllers, which can be
 // set via command-line flags or environment variables.
 type Options struct {
-	// RunnerMaxConcuncurrentReconciles is the maximum number of concurrent Reconciles which can be run
+	// RunnerMaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
 	// by the EphemeralRunnerController.
-	RunnerMaxConcuncurrentReconciles int
+	RunnerMaxConcurrentReconciles int
 }
 
 // OptionsWithDefault returns the default options.
@@ -22,38 +18,8 @@ type Options struct {
 // rather than having to correlate those in multiple places.
 func OptionsWithDefault() Options {
 	return Options{
-		RunnerMaxConcuncurrentReconciles: 2,
+		RunnerMaxConcurrentReconciles: 2,
 	}
-}
-
-// LoadEnv loads the options from the environment variables.
-// This updates the option value only if the environment variable is set.
-// If the option is already set (via a command-line flag), the value from the environment variable takes precedence.
-func (o *Options) LoadEnv() error {
-	v, err := o.getEnvInt("RUNNER_MAX_CONCURRENT_RECONCILES")
-	if err != nil {
-		return err
-	}
-
-	if v != nil {
-		o.RunnerMaxConcuncurrentReconciles = *v
-	}
-
-	return nil
-}
-
-func (o *Options) getEnvInt(name string) (*int, error) {
-	s := os.Getenv(name)
-	if s == "" {
-		return nil, nil
-	}
-
-	v, err := strconv.Atoi(s)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert %s=%s to int: %w", name, s, err)
-	}
-
-	return &v, nil
 }
 
 type Option func(*controller.Options)

--- a/main.go
+++ b/main.go
@@ -102,6 +102,8 @@ func main() {
 
 		autoScalerImagePullSecrets stringSlice
 
+		opts = actionsgithubcom.OptionsWithDefault()
+
 		commonRunnerLabels commaSeparatedStringSlice
 	)
 	var c github.Config
@@ -136,6 +138,7 @@ func main() {
 	flag.DurationVar(&defaultScaleDownDelay, "default-scale-down-delay", actionssummerwindnet.DefaultScaleDownDelay, "The approximate delay for a scale down followed by a scale up, used to prevent flapping (down->up->down->... loop)")
 	flag.IntVar(&port, "port", 9443, "The port to which the admission webhook endpoint should bind")
 	flag.DurationVar(&syncPeriod, "sync-period", 1*time.Minute, "Determines the minimum frequency at which K8s resources managed by this controller are reconciled.")
+	flag.IntVar(&opts.RunnerMaxConcuncurrentReconciles, "runner-max-concurrent-reconciles", opts.RunnerMaxConcuncurrentReconciles, "The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller. Increase this value to improve the throughput of the controller, but it may also increase the load on the API server and the external service (e.g. GitHub API).")
 	flag.Var(&commonRunnerLabels, "common-runner-labels", "Runner labels in the K1=V1,K2=V2,... format that are inherited all the runners created by the controller. See https://github.com/actions/actions-runner-controller/issues/321 for more information")
 	flag.StringVar(&namespace, "watch-namespace", "", "The namespace to watch for custom resources. Set to empty for letting it watch for all namespaces.")
 	flag.StringVar(&watchSingleNamespace, "watch-single-namespace", "", "Restrict to watch for custom resources in a single namespace.")
@@ -155,6 +158,12 @@ func main() {
 		os.Exit(1)
 	}
 	c.Log = &log
+
+	if err := opts.LoadEnv(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: loading environment variables: %v\n", err)
+		os.Exit(1)
+	}
+	log.Info("Using options", "runner-max-concurrent-reconciles", opts.RunnerMaxConcuncurrentReconciles)
 
 	if !autoScalingRunnerSetOnly {
 		ghClient, err = c.NewClient()
@@ -285,7 +294,7 @@ func main() {
 			Scheme:          mgr.GetScheme(),
 			ActionsClient:   actionsMultiClient,
 			ResourceBuilder: rb,
-		}).SetupWithManager(mgr); err != nil {
+		}).SetupWithManager(mgr, actionsgithubcom.WithMaxConcurrentReconciles(opts.RunnerMaxConcuncurrentReconciles)); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunner")
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 	flag.DurationVar(&defaultScaleDownDelay, "default-scale-down-delay", actionssummerwindnet.DefaultScaleDownDelay, "The approximate delay for a scale down followed by a scale up, used to prevent flapping (down->up->down->... loop)")
 	flag.IntVar(&port, "port", 9443, "The port to which the admission webhook endpoint should bind")
 	flag.DurationVar(&syncPeriod, "sync-period", 1*time.Minute, "Determines the minimum frequency at which K8s resources managed by this controller are reconciled.")
-	flag.IntVar(&opts.RunnerMaxConcuncurrentReconciles, "runner-max-concurrent-reconciles", opts.RunnerMaxConcuncurrentReconciles, "The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller. Increase this value to improve the throughput of the controller, but it may also increase the load on the API server and the external service (e.g. GitHub API).")
+	flag.IntVar(&opts.RunnerMaxConcurrentReconciles, "runner-max-concurrent-reconciles", opts.RunnerMaxConcurrentReconciles, "The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller. Increase this value to improve the throughput of the controller, but it may also increase the load on the API server and the external service (e.g. GitHub API).")
 	flag.Var(&commonRunnerLabels, "common-runner-labels", "Runner labels in the K1=V1,K2=V2,... format that are inherited all the runners created by the controller. See https://github.com/actions/actions-runner-controller/issues/321 for more information")
 	flag.StringVar(&namespace, "watch-namespace", "", "The namespace to watch for custom resources. Set to empty for letting it watch for all namespaces.")
 	flag.StringVar(&watchSingleNamespace, "watch-single-namespace", "", "Restrict to watch for custom resources in a single namespace.")
@@ -159,11 +159,7 @@ func main() {
 	}
 	c.Log = &log
 
-	if err := opts.LoadEnv(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: loading environment variables: %v\n", err)
-		os.Exit(1)
-	}
-	log.Info("Using options", "runner-max-concurrent-reconciles", opts.RunnerMaxConcuncurrentReconciles)
+	log.Info("Using options", "runner-max-concurrent-reconciles", opts.RunnerMaxConcurrentReconciles)
 
 	if !autoScalingRunnerSetOnly {
 		ghClient, err = c.NewClient()
@@ -294,7 +290,7 @@ func main() {
 			Scheme:          mgr.GetScheme(),
 			ActionsClient:   actionsMultiClient,
 			ResourceBuilder: rb,
-		}).SetupWithManager(mgr, actionsgithubcom.WithMaxConcurrentReconciles(opts.RunnerMaxConcuncurrentReconciles)); err != nil {
+		}).SetupWithManager(mgr, actionsgithubcom.WithMaxConcurrentReconciles(opts.RunnerMaxConcurrentReconciles)); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunner")
 			os.Exit(1)
 		}


### PR DESCRIPTION
Improve the runner pod startup times by using more goroutines(almost "more cpus", assuming you are NOT K8s API or network bounded) for ephemeralrunner reconciliation.

Today, `cotroller-runtime` and hence ARC reconciles EphemeralRunnerPod one by one, which should be limiting the runner pod creation throughput to almost `unit time / latency of the GHA jit config API`.

If you are not bounded by CPU, K8s, network, or GHA-API yet, setting N MaxConcurrentReconciles should improve the throughput by N.

This is the PR for the second commit mentioned in https://github.com/actions/actions-runner-controller/issues/3276#issuecomment-2496636965.