### PR TITLE
Make k8s client rate limiter parameters configurable

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -82,6 +82,12 @@ spec:
         {{- range .Values.flags.excludeLabelPropagationPrefixes }}
         - "--exclude-label-propagation-prefix={{ . }}"
         {{- end }}
+        {{- with .Values.flags.k8sClientRateLimiterQPS }}
+        - "--k8s-client-rate-limiter-qps={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.k8sClientRateLimiterBurst }}
+        - "--k8s-client-rate-limiter-burst={{ . }}"
+        {{- end }}
         command:
         - "/manager"
         {{- with .Values.metrics }}

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -130,3 +130,7 @@ flags:
   ## Labels that match prefix specified in the list are excluded from propagation.
   # excludeLabelPropagationPrefixes:
   #   - "argocd.argoproj.io/instance"
+
+  ## Defines the K8s client rate limiter parameters.
+  # k8sClientRateLimiterQPS: 20
+  # k8sClientRateLimiterBurst: 30

--- a/main.go
+++ b/main.go
@@ -103,6 +103,9 @@ func main() {
 		autoScalerImagePullSecrets stringSlice
 
 		commonRunnerLabels commaSeparatedStringSlice
+
+		k8sClientRateLimiterQPS   int
+		k8sClientRateLimiterBurst int
 	)
 	var c github.Config
 	err = envconfig.Process("github", &c)
@@ -145,6 +148,8 @@ func main() {
 	flag.BoolVar(&autoScalingRunnerSetOnly, "auto-scaling-runner-set-only", false, "Make controller only reconcile AutoRunnerScaleSet object.")
 	flag.StringVar(&updateStrategy, "update-strategy", "immediate", `Resources reconciliation strategy on upgrade with running/pending jobs. Valid values are: "immediate", "eventual". Defaults to "immediate".`)
 	flag.Var(&autoScalerImagePullSecrets, "auto-scaler-image-pull-secrets", "The default image-pull secret name for auto-scaler listener container.")
+	flag.IntVar(&k8sClientRateLimiterQPS, "k8s-client-rate-limiter-qps", 20, "The QPS value of the K8s client rate limiter.")
+	flag.IntVar(&k8sClientRateLimiterBurst, "k8s-client-rate-limiter-burst", 30, "The burst value of the K8s client rate limiter.")
 	flag.Parse()
 
 	runnerPodDefaults.RunnerImagePullSecrets = runnerImagePullSecrets
@@ -214,7 +219,11 @@ func main() {
 		})
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	cfg := ctrl.GetConfigOrDie()
+	cfg.QPS = float32(k8sClientRateLimiterQPS)
+	cfg.Burst = k8sClientRateLimiterBurst
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,


### PR DESCRIPTION
## WHAT

Make k8s client rate limiter parameters configurable.

## WHY

To reduce latency of runner pod creation (https://github.com/actions/actions-runner-controller/issues/3276).

EphemeralRunnerReconciler requires several k8s API calls until pod creation and those API calls are rate limited by a client library. It would be helpful if users can optimize the rate limiter parameter on their responsibility.

## TESTING

We have tested the change with QPS=80 and Burst=120 (4 times higher than the default) while running 50-100 runners and confirmed that the reconcile time of EphemeralRunnerReconciler has decreased from 60 ms to 20 ms.

![Screenshot 2024-12-02 at 21 43 19](https://github.com/user-attachments/assets/a7132351-081d-4894-b8e2-e3da115099d0)
