### PR TITLE
Make DIND image configurable and remove non-runner-containers helper to avoid unintended DIND inclusion

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -96,7 +96,14 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+{{- $dindImage := "docker:dind" -}}
+{{- range $i, $val := .Values.template.spec.containers }}
+  {{- if eq $val.name "dind" }}
+    {{- $dindImage = $val.image }}
+  {{- end }}
+{{- end }}
+
+image: {{ $dindImage }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock
@@ -166,14 +173,6 @@ volumeMounts:
   {{- range $i, $volume := .Values.template.spec.volumes }}
     {{- if ne $volume.name "work" }}
 - {{ $volume | toYaml | nindent 2 }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-
-{{- define "gha-runner-scale-set.non-runner-containers" -}}
-  {{- range $i, $container := .Values.template.spec.containers }}
-    {{- if ne $container.name "runner" }}
-- {{ $container | toYaml | nindent 2 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -141,7 +141,7 @@ spec:
       {{- else if eq $containerMode.type "kubernetes" }}
       - name: runner
         {{- include "gha-runner-scale-set.kubernetes-mode-runner-container" . | nindent 8 }}
-      {{- include "gha-runner-scale-set.non-runner-containers" . | nindent 6 }}
+      {{- include "gha-runner-scale-set.non-runner-non-dind-containers" . | nindent 6 }}
       {{- else }}
       {{- include "gha-runner-scale-set.default-mode-runner-containers" . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
This PR updates the `gha-runner-scale-set` Helm chart templates to allow the DIND image to be configurable based on `.Values.template.spec.containers`. With this change, the chart will continue to use `docker:dind` by default, but if a container named `dind` is defined, that image is used instead. This provides greater flexibility for users who need to customize their DIND image.

As a result of making the DIND image configurable, the `non-runner-containers` helper now inadvertently includes the DIND container in scenarios where it’s not intended, specifically when using Kubernetes mode. To address this, we remove the `non-runner-containers` helper and rely exclusively on `non-runner-non-dind-containers`. This ensures that DIND remains properly scoped and does not appear where it should not.