### PR TITLE
Revert QPS and Burst to their defaults (5 and 10)

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,8 +151,8 @@ func main() {
 	flag.BoolVar(&autoScalingRunnerSetOnly, "auto-scaling-runner-set-only", false, "Make controller only reconcile AutoRunnerScaleSet object.")
 	flag.StringVar(&updateStrategy, "update-strategy", "immediate", `Resources reconciliation strategy on upgrade with running/pending jobs. Valid values are: "immediate", "eventual". Defaults to "immediate".`)
 	flag.Var(&autoScalerImagePullSecrets, "auto-scaler-image-pull-secrets", "The default image-pull secret name for auto-scaler listener container.")
-	flag.IntVar(&k8sClientRateLimiterQPS, "k8s-client-rate-limiter-qps", 20, "The QPS value of the K8s client rate limiter.")
-	flag.IntVar(&k8sClientRateLimiterBurst, "k8s-client-rate-limiter-burst", 30, "The burst value of the K8s client rate limiter.")
+	flag.IntVar(&k8sClientRateLimiterQPS, "k8s-client-rate-limiter-qps", 5, "The QPS value of the K8s client rate limiter.")
+	flag.IntVar(&k8sClientRateLimiterBurst, "k8s-client-rate-limiter-burst", 10, "The burst value of the K8s client rate limiter.")
 	flag.Parse()
 
 	runnerPodDefaults.RunnerImagePullSecrets = runnerImagePullSecrets


### PR DESCRIPTION
In [`gha-runner-scale-set-0.10.0`](https://github.com/actions/actions-runner-controller/discussions/3850#discussioncomment-11581814) `k8sClientRateLimiterQPS` and `k8sClientRateLimiterBurst` were introduced to configure the client-go rate limits. The default values of client-go were changed from 5 to 20 for `k8sClientRateLimiterQPS` and from 10 to 30 for `k8sClientRateLimiterBurst`.

This PR reverts that change and resets the defaults. Some users might be running close to the limits on their cluster and this change might cause problems for them.

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L154-R155): Updated the QPS value of the Kubernetes client rate limiter from 20 to 5 and the burst value from 30 to 10.