### PR TITLE
[helm]feat: add fullname override option for gha-runner-scale-set

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -11,7 +11,11 @@ gha-rs
 {{- end }}
 
 {{- define "gha-runner-scale-set.scale-set-name" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride -}}
+{{- else -}}
 {{ .Values.runnerScaleSetName | default .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -20,8 +20,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "gha-runner-scale-set.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride -}}
+{{- else -}}
 {{- $name := default (include "gha-base-name" .) }}
 {{- printf "%s-%s" (include "gha-runner-scale-set.scale-set-name" .) $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -48,6 +48,11 @@ githubConfigSecret:
 ## name of the runner scale set to create.  Defaults to the helm release name
 # runnerScaleSetName: ""
 
+## Override the fullname of the gha-runner-scale-set
+## This is useful for deploying multiple runner scale sets in the same namespace
+## with the same scale set name but different GitHub configuration URLs.
+fullnameOverride: ""
+
 ## A self-signed CA certificate for communication with the GitHub server can be
 ## provided using a config map key selector. If `runnerMountPath` is set, for
 ## each runner pod ARC will:


### PR DESCRIPTION
## Background

I want to introduce a feature in the gha-runner-scale-set Helm chart that allows users to override the `gha-runner-scale-set.fullname` from the values.yaml file. This feature is necessary to support the installation of two runner scale sets in the same namespace with the same scale set name but targeting different GitHub configuration URLs. This is particularly useful for us to migrate runner sets from GitHub Enterprise Server (GHES) to GitHub Enterprise Cloud (GHEC).

## Changes
- Introduced a `fullnameOverride` field in `values.yaml` to allow users to specify a custom full name for the runner scale set.
- Updated `_helpers.tpl` to use the override value if provided, enabling deployment of multiple runner scale sets in the same namespace with different GitHub configuration URLs.
- This change supports have multiple runner scale sets in the same namespace with the same scale set name.
