### PR TITLE
Fix helm chart bug related to `runnerMaxConcurrentReconciles`

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         {{- with .Values.flags.watchSingleNamespace }}
         - "--watch-single-namespace={{ . }}"
         {{- end }}
-        {{- with .Values.runnerMaxConcurrentReconciles }}
+        {{- with .Values.flags.runnerMaxConcurrentReconciles }}
         - "--runner-max-concurrent-reconciles={{ . }}"
         {{- end }}
         {{- with .Values.flags.updateStrategy }}


### PR DESCRIPTION
This pull request includes a small change to the `charts/gha-runner-scale-set-controller/templates/deployment.yaml` file. The change updates the reference to `runnerMaxConcurrentReconciles` to use the correct path under `flags`.