### PR TITLE
cmd/ghalistener/config: export Validate

### DIFF
--- a/cmd/ghalistener/config/config.go
+++ b/cmd/ghalistener/config/config.go
@@ -46,14 +46,15 @@ func Read(path string) (Config, error) {
 		return Config{}, fmt.Errorf("failed to decode config: %w", err)
 	}
 
-	if err := config.validate(); err != nil {
+	if err := config.Validate(); err != nil {
 		return Config{}, fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	return config, nil
 }
 
-func (c *Config) validate() error {
+// Validate checks the configuration for errors.
+func (c *Config) Validate() error {
 	if len(c.ConfigureUrl) == 0 {
 		return fmt.Errorf("GitHubConfigUrl is not provided")
 	}

--- a/cmd/ghalistener/config/config_test.go
+++ b/cmd/ghalistener/config/config_test.go
@@ -17,7 +17,7 @@ func TestConfigValidationMinMax(t *testing.T) {
 		MaxRunners:                  2,
 		Token:                       "token",
 	}
-	err := config.validate()
+	err := config.Validate()
 	assert.ErrorContains(t, err, "MinRunners '5' cannot be greater than MaxRunners '2", "Expected error about MinRunners > MaxRunners")
 }
 
@@ -28,7 +28,7 @@ func TestConfigValidationMissingToken(t *testing.T) {
 		EphemeralRunnerSetName:      "deployment",
 		RunnerScaleSetId:            1,
 	}
-	err := config.validate()
+	err := config.Validate()
 	expectedError := fmt.Sprintf("GitHub auth credential is missing, token length: '%d', appId: '%d', installationId: '%d', private key length: '%d", len(config.Token), config.AppID, config.AppInstallationID, len(config.AppPrivateKey))
 	assert.ErrorContains(t, err, expectedError, "Expected error about missing auth")
 }
@@ -42,7 +42,7 @@ func TestConfigValidationAppKey(t *testing.T) {
 		EphemeralRunnerSetName:      "deployment",
 		RunnerScaleSetId:            1,
 	}
-	err := config.validate()
+	err := config.Validate()
 	expectedError := fmt.Sprintf("GitHub auth credential is missing, token length: '%d', appId: '%d', installationId: '%d', private key length: '%d", len(config.Token), config.AppID, config.AppInstallationID, len(config.AppPrivateKey))
 	assert.ErrorContains(t, err, expectedError, "Expected error about missing auth")
 }
@@ -58,7 +58,7 @@ func TestConfigValidationOnlyOneTypeOfCredentials(t *testing.T) {
 		EphemeralRunnerSetName:      "deployment",
 		RunnerScaleSetId:            1,
 	}
-	err := config.validate()
+	err := config.Validate()
 	expectedError := fmt.Sprintf("only one GitHub auth method supported at a time. Have both PAT and App auth: token length: '%d', appId: '%d', installationId: '%d', private key length: '%d", len(config.Token), config.AppID, config.AppInstallationID, len(config.AppPrivateKey))
 	assert.ErrorContains(t, err, expectedError, "Expected error about missing auth")
 }
@@ -74,7 +74,7 @@ func TestConfigValidation(t *testing.T) {
 		Token:                       "asdf",
 	}
 
-	err := config.validate()
+	err := config.Validate()
 
 	assert.NoError(t, err, "Expected no error")
 }
@@ -86,7 +86,7 @@ func TestConfigValidationConfigUrl(t *testing.T) {
 		RunnerScaleSetId:            1,
 	}
 
-	err := config.validate()
+	err := config.Validate()
 
 	assert.ErrorContains(t, err, "GitHubConfigUrl is not provided", "Expected error about missing ConfigureUrl")
 }


### PR DESCRIPTION
Since the `Config` type is fully exported, it can be instantiated directly, in which case the caller will also need the `Validate` functionality.