### PR TITLE
Fix template tests and add go test on gha-validate-chart

### DIFF
--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -5,16 +5,16 @@ on:
     branches:
       - master
     paths:
-      - "charts/**"
-      - ".github/workflows/gha-validate-chart.yaml"
-      - "!charts/actions-runner-controller/**"
-      - "!**.md"
+      - 'charts/**'
+      - '.github/workflows/gha-validate-chart.yaml'
+      - '!charts/actions-runner-controller/**'
+      - '!**.md'
   push:
     paths:
-      - "charts/**"
-      - ".github/workflows/gha-validate-chart.yaml"
-      - "!charts/actions-runner-controller/**"
-      - "!**.md"
+      - 'charts/**'
+      - '.github/workflows/gha-validate-chart.yaml'
+      - '!charts/actions-runner-controller/**'
+      - '!**.md'
   workflow_dispatch:
 env:
   KUBE_SCORE_VERSION: 1.16.1
@@ -52,21 +52,20 @@ jobs:
           chmod 755 kube-score
 
       - name: Kube-score generated manifests
-        run:
-          helm template  --values charts/.ci/values-kube-score.yaml charts/* | ./kube-score score -
-          --ignore-test pod-networkpolicy
-          --ignore-test deployment-has-poddisruptionbudget
-          --ignore-test deployment-has-host-podantiaffinity
-          --ignore-test container-security-context
-          --ignore-test pod-probes
-          --ignore-test container-image-tag
-          --enable-optional-test container-security-context-privileged
-          --enable-optional-test container-security-context-readonlyrootfilesystem
+        run: helm template  --values charts/.ci/values-kube-score.yaml charts/* | ./kube-score score -
+              --ignore-test pod-networkpolicy
+              --ignore-test deployment-has-poddisruptionbudget
+              --ignore-test deployment-has-host-podantiaffinity
+              --ignore-test container-security-context
+              --ignore-test pod-probes
+              --ignore-test container-image-tag
+              --enable-optional-test container-security-context-privileged
+              --enable-optional-test container-security-context-readonlyrootfilesystem
 
       # python is a requirement for the chart-testing action below (supports yamllint among other tests)
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
@@ -114,11 +113,11 @@ jobs:
       - name: Load image into cluster
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          export DOCKER_IMAGE_NAME=test-arc
-          export VERSION=dev
-          export IMG_RESULT=load
-          make docker-buildx
-          kind load docker-image test-arc:dev --name chart-testing
+            export DOCKER_IMAGE_NAME=test-arc
+            export VERSION=dev
+            export IMG_RESULT=load
+            make docker-buildx
+            kind load docker-image test-arc:dev --name chart-testing
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -5,16 +5,16 @@ on:
     branches:
       - master
     paths:
-      - 'charts/**'
-      - '.github/workflows/gha-validate-chart.yaml'
-      - '!charts/actions-runner-controller/**'
-      - '!**.md'
+      - "charts/**"
+      - ".github/workflows/gha-validate-chart.yaml"
+      - "!charts/actions-runner-controller/**"
+      - "!**.md"
   push:
     paths:
-      - 'charts/**'
-      - '.github/workflows/gha-validate-chart.yaml'
-      - '!charts/actions-runner-controller/**'
-      - '!**.md'
+      - "charts/**"
+      - ".github/workflows/gha-validate-chart.yaml"
+      - "!charts/actions-runner-controller/**"
+      - "!**.md"
   workflow_dispatch:
 env:
   KUBE_SCORE_VERSION: 1.16.1
@@ -52,20 +52,21 @@ jobs:
           chmod 755 kube-score
 
       - name: Kube-score generated manifests
-        run: helm template  --values charts/.ci/values-kube-score.yaml charts/* | ./kube-score score -
-              --ignore-test pod-networkpolicy
-              --ignore-test deployment-has-poddisruptionbudget
-              --ignore-test deployment-has-host-podantiaffinity
-              --ignore-test container-security-context
-              --ignore-test pod-probes
-              --ignore-test container-image-tag
-              --enable-optional-test container-security-context-privileged
-              --enable-optional-test container-security-context-readonlyrootfilesystem
+        run:
+          helm template  --values charts/.ci/values-kube-score.yaml charts/* | ./kube-score score -
+          --ignore-test pod-networkpolicy
+          --ignore-test deployment-has-poddisruptionbudget
+          --ignore-test deployment-has-host-podantiaffinity
+          --ignore-test container-security-context
+          --ignore-test pod-probes
+          --ignore-test container-image-tag
+          --enable-optional-test container-security-context-privileged
+          --enable-optional-test container-security-context-readonlyrootfilesystem
 
       # python is a requirement for the chart-testing action below (supports yamllint among other tests)
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
@@ -113,13 +114,27 @@ jobs:
       - name: Load image into cluster
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-            export DOCKER_IMAGE_NAME=test-arc
-            export VERSION=dev
-            export IMG_RESULT=load
-            make docker-buildx
-            kind load docker-image test-arc:dev --name chart-testing
+          export DOCKER_IMAGE_NAME=test-arc
+          export VERSION=dev
+          export IMG_RESULT=load
+          make docker-buildx
+          kind load docker-image test-arc:dev --name chart-testing
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config charts/.ci/ct-config-gha.yaml
+  test-chart:
+    name: Test Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: false
+      - name: Test gha-runner-scale-set
+        run: go test ./charts/gha-runner-scale-set/...
+      - name: Test gha-runner-scale-set-controller
+        run: go test ./charts/gha-runner-scale-set-controller/...

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -366,6 +366,7 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 		"--metrics-addr=0",
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
+		"--runner-max-concurrent-reconciles=2",
 	}
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
 
@@ -518,6 +519,7 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
+		"--runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -646,6 +648,7 @@ func TestTemplate_EnableLeaderElection(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
+		"--runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -686,6 +689,7 @@ func TestTemplate_ControllerDeployment_ForwardImagePullSecrets(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
+		"--runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -776,6 +780,7 @@ func TestTemplate_ControllerDeployment_WatchSingleNamespace(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
+		"--runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)


### PR DESCRIPTION
When new change is added only to the values and the charts, only lint will be called. Since the change is not related to the go file, go tests don't run, causing missed test calls on charts.

This change calls go test on chart tests, and adds missing flag applied by default