### PR TITLE
chore: add OwnerReference to created resources

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -234,7 +234,7 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 	// Make sure the AutoscalingListener is up and running in the controller namespace
 	listener := new(v1alpha1.AutoscalingListener)
 	listenerFound := true
-	if err := r.Get(ctx, client.ObjectKey{Namespace: r.ControllerNamespace, Name: scaleSetListenerName(autoscalingRunnerSet)}, listener); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Namespace: autoscalingRunnerSet.Namespace, Name: scaleSetListenerName(autoscalingRunnerSet)}, listener); err != nil {
 		if !kerrors.IsNotFound(err) {
 			log.Error(err, "Failed to get AutoscalingListener resource")
 			return ctrl.Result{}, err
@@ -329,7 +329,7 @@ func (r *AutoscalingRunnerSetReconciler) drainingJobs(latestRunnerSetStatus *v1a
 func (r *AutoscalingRunnerSetReconciler) cleanupListener(ctx context.Context, autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet, logger logr.Logger) (done bool, err error) {
 	logger.Info("Cleaning up the listener")
 	var listener v1alpha1.AutoscalingListener
-	err = r.Get(ctx, client.ObjectKey{Namespace: r.ControllerNamespace, Name: scaleSetListenerName(autoscalingRunnerSet)}, &listener)
+	err = r.Get(ctx, client.ObjectKey{Namespace: autoscalingRunnerSet.Namespace, Name: scaleSetListenerName(autoscalingRunnerSet)}, &listener)
 	switch {
 	case err == nil:
 		if listener.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -651,7 +651,7 @@ func (r *AutoscalingRunnerSetReconciler) createAutoScalingListenerForRunnerSet(c
 		})
 	}
 
-	autoscalingListener, err := r.ResourceBuilder.newAutoScalingListener(autoscalingRunnerSet, ephemeralRunnerSet, r.ControllerNamespace, r.DefaultRunnerScaleSetListenerImage, imagePullSecrets)
+	autoscalingListener, err := r.ResourceBuilder.newAutoScalingListener(autoscalingRunnerSet, ephemeralRunnerSet, autoscalingRunnerSet.Namespace, r.DefaultRunnerScaleSetListenerImage, imagePullSecrets)
 	if err != nil {
 		log.Error(err, "Could not create AutoscalingListener spec")
 		return ctrl.Result{}, err

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // secret constants
@@ -111,6 +112,16 @@ func (b *ResourceBuilder) newAutoScalingListener(autoscalingRunnerSet *v1alpha1.
 			Namespace:   namespace,
 			Labels:      labels,
 			Annotations: annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingRunnerSet.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingRunnerSet.GroupVersionKind().Kind,
+					Name:               autoscalingRunnerSet.Name,
+					UID:                autoscalingRunnerSet.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Spec: v1alpha1.AutoscalingListenerSpec{
 			GitHubConfigUrl:               autoscalingRunnerSet.Spec.GitHubConfigUrl,
@@ -209,6 +220,16 @@ func (b *ResourceBuilder) newScaleSetListenerConfig(autoscalingListener *v1alpha
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      scaleSetListenerConfigName(autoscalingListener),
 			Namespace: autoscalingListener.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingListener.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingListener.GroupVersionKind().Kind,
+					Name:               autoscalingListener.Name,
+					UID:                autoscalingListener.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Data: map[string][]byte{
 			"config.json": buf.Bytes(),
@@ -284,6 +305,16 @@ func (b *ResourceBuilder) newScaleSetListenerPod(autoscalingListener *v1alpha1.A
 			Name:      autoscalingListener.Name,
 			Namespace: autoscalingListener.Namespace,
 			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingListener.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingListener.GroupVersionKind().Kind,
+					Name:               autoscalingListener.Name,
+					UID:                autoscalingListener.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Spec: podSpec,
 	}
@@ -418,6 +449,16 @@ func (b *ResourceBuilder) newScaleSetListenerServiceAccount(autoscalingListener 
 				LabelKeyGitHubScaleSetNamespace: autoscalingListener.Spec.AutoscalingRunnerSetNamespace,
 				LabelKeyGitHubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 			}),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingListener.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingListener.GroupVersionKind().Kind,
+					Name:               autoscalingListener.Name,
+					UID:                autoscalingListener.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 	}
 }
@@ -436,6 +477,16 @@ func (b *ResourceBuilder) newScaleSetListenerRole(autoscalingListener *v1alpha1.
 				labelKeyListenerName:            autoscalingListener.Name,
 				"role-policy-rules-hash":        rulesHash,
 			}),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingListener.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingListener.GroupVersionKind().Kind,
+					Name:               autoscalingListener.Name,
+					UID:                autoscalingListener.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Rules: rules,
 	}
@@ -471,6 +522,16 @@ func (b *ResourceBuilder) newScaleSetListenerRoleBinding(autoscalingListener *v1
 				"role-binding-role-ref-hash":    roleRefHash,
 				"role-binding-subject-hash":     subjectHash,
 			}),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingListener.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingListener.GroupVersionKind().Kind,
+					Name:               autoscalingListener.Name,
+					UID:                autoscalingListener.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		RoleRef:  roleRef,
 		Subjects: subjects,
@@ -491,6 +552,16 @@ func (b *ResourceBuilder) newScaleSetListenerSecretMirror(autoscalingListener *v
 				LabelKeyGitHubScaleSetName:      autoscalingListener.Spec.AutoscalingRunnerSetName,
 				"secret-data-hash":              dataHash,
 			}),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingListener.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingListener.GroupVersionKind().Kind,
+					Name:               autoscalingListener.Name,
+					UID:                autoscalingListener.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Data: secret.DeepCopy().Data,
 	}
@@ -530,6 +601,16 @@ func (b *ResourceBuilder) newEphemeralRunnerSet(autoscalingRunnerSet *v1alpha1.A
 			Namespace:    autoscalingRunnerSet.ObjectMeta.Namespace,
 			Labels:       labels,
 			Annotations:  newAnnotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         autoscalingRunnerSet.GroupVersionKind().GroupVersion().String(),
+					Kind:               autoscalingRunnerSet.GroupVersionKind().Kind,
+					Name:               autoscalingRunnerSet.Name,
+					UID:                autoscalingRunnerSet.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Spec: v1alpha1.EphemeralRunnerSetSpec{
 			Replicas: 0,
@@ -569,6 +650,16 @@ func (b *ResourceBuilder) newEphemeralRunner(ephemeralRunnerSet *v1alpha1.Epheme
 			Namespace:    ephemeralRunnerSet.Namespace,
 			Labels:       labels,
 			Annotations:  annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         ephemeralRunnerSet.GroupVersionKind().GroupVersion().String(),
+					Kind:               ephemeralRunnerSet.GroupVersionKind().Kind,
+					Name:               ephemeralRunnerSet.Name,
+					UID:                ephemeralRunnerSet.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Spec: ephemeralRunnerSet.Spec.EphemeralRunnerSpec,
 	}
@@ -607,6 +698,16 @@ func (b *ResourceBuilder) newEphemeralRunnerPod(ctx context.Context, runner *v1a
 		Namespace:   runner.ObjectMeta.Namespace,
 		Labels:      labels,
 		Annotations: annotations,
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         runner.GroupVersionKind().GroupVersion().String(),
+				Kind:               runner.GroupVersionKind().Kind,
+				Name:               runner.Name,
+				UID:                runner.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+		},
 	}
 
 	newPod.ObjectMeta = objectMeta
@@ -647,6 +748,16 @@ func (b *ResourceBuilder) newEphemeralRunnerJitSecret(ephemeralRunner *v1alpha1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ephemeralRunner.Name,
 			Namespace: ephemeralRunner.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         ephemeralRunner.GroupVersionKind().GroupVersion().String(),
+					Kind:               ephemeralRunner.GroupVersionKind().Kind,
+					Name:               ephemeralRunner.Name,
+					UID:                ephemeralRunner.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
 		},
 		Data: map[string][]byte{
 			jitTokenKey: []byte(ephemeralRunner.Status.RunnerJITConfig),


### PR DESCRIPTION
Hello,

This is basically an alternative implementation of https://github.com/actions/actions-runner-controller/pull/3575 taking into account the points raised by @nikola-jokic.

It improves upon it by:
- Setting the OwnerReference on all resources created in https://github.com/actions/actions-runner-controller/blob/master/controllers/actions.github.com/resourcebuilder.go
- Avoiding to hardcode `APIVersion` and `Kind`

Please note that I had to move the namespace where we create the `autoscalinglisteners` from the namespace where we run the controller to the namespace where we run the runners. Without this change, the `autoscalinglisteners` cannot be owned by their respective `AutoscalingRunnerSet`. If this is incorrect, please advise on the alternative approach so I can rework my PR accordingly.

It is running in my environment with no issues so far.

Best Regards.