### PR TITLE
Add a link to GoogleCloudPlatform/arcgke

### DIFF
--- a/contrib/examples/arcgke/README.md
+++ b/contrib/examples/arcgke/README.md
@@ -1,0 +1,6 @@
+# Actions Runner Controller (ARC) - GKE recipe
+
+This project facilitates setting up Actions Runner Controller on Google Kubernetes Engine (GKE)
+offering a flexibe, powerful and easy to use syntax.
+
+The project is available here: https://github.com/GoogleCloudPlatform/arcgke


### PR DESCRIPTION
Add a link to a contrib project that supports using ARC on GKE.