### PR TITLE
fix: oci chart rendering version

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       labels:
         app.kubernetes.io/part-of: gha-rs-controller
         app.kubernetes.io/component: controller-manager
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        app.kubernetes.io/version: {{ .Chart.Version | replace "+" "_" }}
         {{- include "gha-runner-scale-set-controller.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This fixes a simple issue where upon rendering the chart with OCI manifests adds a +sha to it. This results in a failure to install because it's not a valid kubernetes label with the + in it.

[Other charts](https://github.com/stakater/Reloader/blob/master/deployments/kubernetes/chart/reloader/templates/_helpers.tpl#L25C27-L25C65) replace the + with a _ and that seems to be the standard fix.

```
actions-runner-controller    0.10.1+9f0f5cfb9a0e    False        False    Helm install failed for release actions-runner-system/actions-runner-controller with chart gha-runner-scale-set-controller@0.10.1+9f0f5cfb9a0e: 1 error occurred:
                                                                              * Deployment.apps "actions-runner-controller" is invalid: spec.template.labels: Invalid value: "0.10.1+9f0f5cfb9a0e": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```