### PR TITLE
bugfix: allow DinD image to be configured via values

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -89,14 +89,22 @@ image: {{ $val.image }}
 command: ["cp"]
 args: ["-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
 volumeMounts:
-  - name: dind-externals
+  - name: -externals
     mountPath: /home/runner/tmpDir
   {{- end }}
 {{- end }}
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+
+{{- $dindImage := "docker:dind" -}}
+{{- range $i, $val := .Values.template.spec.containers }}
+  {{- if eq $val.name "dind" }}
+    {{- $dindImage = $val.image }}
+  {{- end }}
+{{- end }}
+
+image: {{ $dindImage }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -99,7 +99,7 @@ volumeMounts:
 
 {{- $dindImage := "docker:dind" -}}
 {{- range $i, $val := .Values.template.spec.containers }}
-  {{- if eq $val.name "dind" }}
+  {{- if and (eq $val.name "dind") (hasKey $val "image") }}
     {{- $dindImage = $val.image }}
   {{- end }}
 {{- end }}

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -89,7 +89,7 @@ image: {{ $val.image }}
 command: ["cp"]
 args: ["-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
 volumeMounts:
-  - name: -externals
+  - name: dind-externals
     mountPath: /home/runner/tmpDir
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR allows the `DinD` image to be configured via Helm values by checking the container spec for a container named `dind` and using the defined image if present. If no custom image is specified, it defaults to `docker:dind`.

This change is necessary because we're hitting Docker Hub rate limits when pulling the default DinD image. By making the image configurable, we can use a custom image from our own registry, which helps avoid these limitations and improves reliability in CI workflows.

The change is already tested in the cloned chart and is working as expected.