### PR TITLE
Update ubuntu 22.04 images to have the same software as 20.04

### DIFF
--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -20,17 +20,39 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
+    build-essential \
     curl \
     ca-certificates \
+    dnsutils \
+    ftp \
     git \
     iproute2 \
+    iputils-ping \
     iptables \
     jq \
+    libunwind8 \
+    locales \
+    netcat \
+    net-tools \
+    openssh-client \
+    parallel \
+    python3-pip \
+    rsync \
+    shellcheck \
+    software-properties-common \
     sudo \
+    telnet \
+    time \
+    tzdata \
     uidmap \
     unzip \
+    upx \
+    wget \
     zip \
+    zstd \
     fuse-overlayfs \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version

--- a/runner/actions-runner-dind.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-22.04.dockerfile
@@ -17,15 +17,37 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
+    build-essential \
     curl \
     ca-certificates \
+    dnsutils \
+    ftp \
     git \
+    iproute2 \
+    iputils-ping \
     iptables \
     jq \
+    libunwind8 \
+    locales \
+    netcat \
+    net-tools \
+    openssh-client \
+    parallel \
+    python3-pip \
+    rsync \
+    shellcheck \
     software-properties-common \
     sudo \
+    telnet \
+    time \
+    tzdata \
     unzip \
+    upx \
+    wget \
     zip \
+    zstd \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -17,13 +17,34 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
+    build-essential \
     curl \
     ca-certificates \
+    dnsutils \
+    ftp \
     git \
+    iproute2 \
+    iputils-ping \
     jq \
+    libunwind8 \
+    locales \
+    netcat \
+    openssh-client \
+    parallel \
+    python3-pip \
+    rsync \
+    shellcheck \
     sudo \
+    telnet \
+    time \
+    tzdata \
     unzip \
+    upx \
+    wget \
     zip \
+    zstd \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version


### PR DESCRIPTION
This will make sure that `ubuntu22.04` contains the same software as `ubuntu20.04` to make upgrading a breeze.

## Existing difference
- The user / group ID's are different, this may still cause issues.