### PR TITLE
Add wait for docker in default dind spec

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -102,6 +102,8 @@ args:
   - --host=unix:///var/run/docker.sock
   - --group=$(DOCKER_GROUP_GID)
 env:
+  - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+    value: "15"
   - name: DOCKER_GROUP_GID
     value: "123"
 securityContext:

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -302,6 +302,8 @@ template:
   ##         - --host=unix:///var/run/docker.sock
   ##         - --group=$(DOCKER_GROUP_GID)
   ##       env:
+  ##         - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+  ##           value: "15"
   ##         - name: DOCKER_GROUP_GID
   ##           value: "123"
   ##       securityContext:


### PR DESCRIPTION
Add env variable `RUNNER_WAIT_FOR_DOCKER_IN_SECONDS` to be applied for the default `dind` spec, which can take care of potential start failures for runners running in `dind` mode.

Fixes #3828