### PR TITLE
Relax version requirements to allow patch version mismatch

### DIFF
--- a/apis/actions.github.com/v1alpha1/version.go
+++ b/apis/actions.github.com/v1alpha1/version.go
@@ -1,7 +1,9 @@
 package v1alpha1
 
+import "strings"
+
 func IsVersionAllowed(resourceVersion, buildVersion string) bool {
-	if buildVersion == "dev" || resourceVersion == buildVersion {
+	if buildVersion == "dev" || resourceVersion == buildVersion || strings.HasPrefix(buildVersion, "canary-") {
 		return true
 	}
 

--- a/apis/actions.github.com/v1alpha1/version.go
+++ b/apis/actions.github.com/v1alpha1/version.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 func IsVersionAllowed(resourceVersion, buildVersion string) bool {
-	if buildVersion == "dev" {
+	if buildVersion == "dev" || resourceVersion == buildVersion {
 		return true
 	}
 

--- a/apis/actions.github.com/v1alpha1/version.go
+++ b/apis/actions.github.com/v1alpha1/version.go
@@ -25,7 +25,7 @@ func parseSemver(v string) (p semver, ok bool) {
 	if v == "" {
 		return
 	}
-	p.major, v, ok = parseInt(v[:])
+	p.major, v, ok = parseInt(v)
 	if !ok {
 		return p, false
 	}

--- a/apis/actions.github.com/v1alpha1/version.go
+++ b/apis/actions.github.com/v1alpha1/version.go
@@ -1,0 +1,70 @@
+package v1alpha1
+
+func IsVersionAllowed(resourceVersion, buildVersion string) bool {
+	if buildVersion == "dev" {
+		return true
+	}
+
+	rv, ok := parseSemver(resourceVersion)
+	if !ok {
+		return false
+	}
+	bv, ok := parseSemver(buildVersion)
+	if !ok {
+		return false
+	}
+	return rv.major == bv.major && rv.minor == bv.minor
+}
+
+type semver struct {
+	major string
+	minor string
+}
+
+func parseSemver(v string) (p semver, ok bool) {
+	if v == "" {
+		return
+	}
+	p.major, v, ok = parseInt(v[:])
+	if !ok {
+		return p, false
+	}
+	if v == "" {
+		p.minor = "0"
+		return p, true
+	}
+	if v[0] != '.' {
+		return p, false
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		return p, false
+	}
+	if v == "" {
+		return p, true
+	}
+	if v[0] != '.' {
+		return p, false
+	}
+	if _, _, ok = parseInt(v[1:]); !ok {
+		return p, false
+	}
+	return p, true
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}

--- a/apis/actions.github.com/v1alpha1/version_test.go
+++ b/apis/actions.github.com/v1alpha1/version_test.go
@@ -44,6 +44,11 @@ func TestIsVersionAllowed(t *testing.T) {
 			buildVersion:    "0.11.0",
 			want:            true,
 		},
+		"arbitrary version match": {
+			resourceVersion: "abc",
+			buildVersion:    "abc",
+			want:            true,
+		},
 	}
 
 	for name, tc := range tt {

--- a/apis/actions.github.com/v1alpha1/version_test.go
+++ b/apis/actions.github.com/v1alpha1/version_test.go
@@ -1,0 +1,55 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/actions/actions-runner-controller/apis/actions.github.com/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsVersionAllowed(t *testing.T) {
+	t.Parallel()
+	tt := map[string]struct {
+		resourceVersion string
+		buildVersion    string
+		want            bool
+	}{
+		"dev should always be allowed": {
+			resourceVersion: "0.11.0",
+			buildVersion:    "dev",
+			want:            true,
+		},
+		"resourceVersion is not semver": {
+			resourceVersion: "dev",
+			buildVersion:    "0.11.0",
+			want:            false,
+		},
+		"buildVersion is not semver": {
+			resourceVersion: "0.11.0",
+			buildVersion:    "NA",
+			want:            false,
+		},
+		"major version mismatch": {
+			resourceVersion: "0.11.0",
+			buildVersion:    "1.11.0",
+			want:            false,
+		},
+		"minor version mismatch": {
+			resourceVersion: "0.11.0",
+			buildVersion:    "0.10.0",
+			want:            false,
+		},
+		"patch version mismatch": {
+			resourceVersion: "0.11.1",
+			buildVersion:    "0.11.0",
+			want:            true,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := v1alpha1.IsVersionAllowed(tc.resourceVersion, tc.buildVersion)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -151,7 +151,7 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, nil
 	}
 
-	if autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion] != build.Version {
+	if !v1alpha1.IsVersionAllowed(autoscalingRunnerSet.Labels[LabelKeyKubernetesVersion], build.Version) {
 		if err := r.Delete(ctx, autoscalingRunnerSet); err != nil {
 			log.Error(err, "Failed to delete autoscaling runner set on version mismatch",
 				"buildVersion", build.Version,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/actions/actions-runner-controller
 
 go 1.24.0
+
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.14.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
This change reduces the version requirements to allow for a patch version mismatch. Previously, the resource version of each `AutoscalingRunnerSet` had to match the build version.

This change allows the patch version mismatch.