### PR TITLE
feat(charts): Allow customizing the dind image of the runner-scale-set

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -96,7 +96,7 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+image: {{ .Values.containerMode.dindImage | default "docker:dind" }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -116,6 +116,8 @@ githubConfigSecret:
 ## empty, and configuration should be applied to the template.
 # containerMode:
 #   type: "dind"  ## type can be set to dind or kubernetes
+#   ## Optional. To use a custom image for dind, set the image name here.
+#   dindImage: "docker:dind"
 #   ## the following is required when containerMode.type=kubernetes
 #   kubernetesModeWorkVolumeClaim:
 #     accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
# what

* Allow customizing the docker image used for the dind container.

# why

* To download it from different repositories or use a custom image.

# related issues

* https://github.com/actions/actions-runner-controller/issues/3709