### PR TITLE
Grafana Dashboard: Add label filter to 'Active Workers' panel

### DIFF
--- a/docs/gha-runner-scale-set-controller/samples/grafana-dashboard/ARC-Autoscaling-Runner-Set-Monitoring.json
+++ b/docs/gha-runner-scale-set-controller/samples/grafana-dashboard/ARC-Autoscaling-Runner-Set-Monitoring.json
@@ -1847,7 +1847,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (controller) (controller_runtime_active_workers)",
+          "expr": "sum by (controller) (controller_runtime_active_workers{namespace=\"$SystemNamespace\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",


### PR DESCRIPTION
Adds `{namespace="$SystemNamespace"}` label filter to  panel to avoid showing all metrics from any controller runtime built controller

Before:
![image](https://github.com/user-attachments/assets/f33f0355-be58-46f9-af55-0e8a809032da)

After:
![image](https://github.com/user-attachments/assets/3007bf03-c530-4aa6-bb92-98dcaee79898)
