### PR TITLE
Avoid nil point when config.Metrics is nil and expose all metrics if none are configured

### DIFF
--- a/cmd/ghalistener/app/app.go
+++ b/cmd/ghalistener/app/app.go
@@ -61,7 +61,7 @@ func New(config config.Config) (*App, error) {
 	}
 
 	if config.MetricsAddr != "" {
-		exporterConfig := metrics.ExporterConfig{
+		app.metrics = metrics.NewExporter(metrics.ExporterConfig{
 			ScaleSetName:      config.EphemeralRunnerSetName,
 			ScaleSetNamespace: config.EphemeralRunnerSetNamespace,
 			Enterprise:        ghConfig.Enterprise,
@@ -69,14 +69,9 @@ func New(config config.Config) (*App, error) {
 			Repository:        ghConfig.Repository,
 			ServerAddr:        config.MetricsAddr,
 			ServerEndpoint:    config.MetricsEndpoint,
+			Metrics:           config.Metrics,
 			Logger:            app.logger.WithName("metrics exporter"),
-		}
-
-		if config.Metrics != nil {
-			exporterConfig.Metrics = *config.Metrics
-		}
-
-		app.metrics = metrics.NewExporter(exporterConfig)
+		})
 	}
 
 	worker, err := worker.New(

--- a/cmd/ghalistener/app/app.go
+++ b/cmd/ghalistener/app/app.go
@@ -61,7 +61,7 @@ func New(config config.Config) (*App, error) {
 	}
 
 	if config.MetricsAddr != "" {
-		app.metrics = metrics.NewExporter(metrics.ExporterConfig{
+		exporterConfig := metrics.ExporterConfig{
 			ScaleSetName:      config.EphemeralRunnerSetName,
 			ScaleSetNamespace: config.EphemeralRunnerSetNamespace,
 			Enterprise:        ghConfig.Enterprise,
@@ -70,8 +70,13 @@ func New(config config.Config) (*App, error) {
 			ServerAddr:        config.MetricsAddr,
 			ServerEndpoint:    config.MetricsEndpoint,
 			Logger:            app.logger.WithName("metrics exporter"),
-			Metrics:           *config.Metrics,
-		})
+		}
+
+		if config.Metrics != nil {
+			exporterConfig.Metrics = *config.Metrics
+		}
+
+		app.metrics = metrics.NewExporter(exporterConfig)
 	}
 
 	worker, err := worker.New(

--- a/cmd/ghalistener/metrics/metrics.go
+++ b/cmd/ghalistener/metrics/metrics.go
@@ -155,134 +155,137 @@ type ExporterConfig struct {
 	Metrics           *v1alpha1.MetricsConfig
 }
 
+var defaultMetrics = v1alpha1.MetricsConfig{
+	Counters: map[string]*v1alpha1.CounterMetric{
+		MetricStartedJobsTotal: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyJobName,
+				labelKeyEventName,
+			},
+		},
+		MetricCompletedJobsTotal: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyJobName,
+				labelKeyEventName,
+				labelKeyJobResult,
+			},
+		},
+	},
+	Gauges: map[string]*v1alpha1.GaugeMetric{
+		MetricAssignedJobs: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+		MetricRunningJobs: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+		MetricRegisteredRunners: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+		MetricBusyRunners: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+		MetricMinRunners: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+		MetricMaxRunners: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+		MetricDesiredRunners: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+		MetricIdleRunners: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyRunnerScaleSetName,
+				labelKeyRunnerScaleSetNamespace,
+			},
+		},
+	},
+	Histograms: map[string]*v1alpha1.HistogramMetric{
+		MetricJobStartupDurationSeconds: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyJobName,
+				labelKeyEventName,
+			},
+			Buckets: defaultRuntimeBuckets,
+		},
+		MetricJobExecutionDurationSeconds: {
+			Labels: []string{
+				labelKeyEnterprise,
+				labelKeyOrganization,
+				labelKeyRepository,
+				labelKeyJobName,
+				labelKeyEventName,
+				labelKeyJobResult,
+			},
+			Buckets: defaultRuntimeBuckets,
+		},
+	},
+}
+
 func (e *ExporterConfig) defaults() {
 	if e.ServerAddr == "" {
-		e.Metrics = nil
-		return
+		e.ServerAddr = ":8080"
 	}
-	if e.Metrics != nil {
-		return
+	if e.ServerEndpoint == "" {
+		e.ServerEndpoint = "/metrics"
 	}
-
-	e.Metrics = &v1alpha1.MetricsConfig{
-		Counters: map[string]*v1alpha1.CounterMetric{
-			MetricStartedJobsTotal: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyJobName,
-					labelKeyEventName,
-				},
-			},
-			MetricCompletedJobsTotal: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyJobName,
-					labelKeyEventName,
-					labelKeyJobResult,
-				},
-			},
-		},
-		Gauges: map[string]*v1alpha1.GaugeMetric{
-			MetricAssignedJobs: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-			MetricRunningJobs: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-			MetricRegisteredRunners: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-			MetricBusyRunners: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-			MetricMinRunners: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-			MetricMaxRunners: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-			MetricDesiredRunners: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-			MetricIdleRunners: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyRunnerScaleSetName,
-					labelKeyRunnerScaleSetNamespace,
-				},
-			},
-		},
-		Histograms: map[string]*v1alpha1.HistogramMetric{
-			MetricJobStartupDurationSeconds: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyJobName,
-					labelKeyEventName,
-				},
-				Buckets: defaultRuntimeBuckets,
-			},
-			MetricJobExecutionDurationSeconds: {
-				Labels: []string{
-					labelKeyEnterprise,
-					labelKeyOrganization,
-					labelKeyRepository,
-					labelKeyJobName,
-					labelKeyEventName,
-					labelKeyJobResult,
-				},
-				Buckets: defaultRuntimeBuckets,
-			},
-		},
+	if e.Metrics == nil {
+		defaultMetrics := defaultMetrics
+		e.Metrics = &defaultMetrics
 	}
 }
 

--- a/cmd/ghalistener/metrics/metrics.go
+++ b/cmd/ghalistener/metrics/metrics.go
@@ -152,13 +152,145 @@ type ExporterConfig struct {
 	ServerAddr        string
 	ServerEndpoint    string
 	Logger            logr.Logger
-	Metrics           v1alpha1.MetricsConfig
+	Metrics           *v1alpha1.MetricsConfig
+}
+
+func (e *ExporterConfig) defaults() {
+	if e.ServerAddr == "" {
+		e.Metrics = nil
+		return
+	}
+	if e.Metrics != nil {
+		return
+	}
+
+	e.Metrics = &v1alpha1.MetricsConfig{
+		Counters: map[string]*v1alpha1.CounterMetric{
+			MetricStartedJobsTotal: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyJobName,
+					labelKeyEventName,
+				},
+			},
+			MetricCompletedJobsTotal: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyJobName,
+					labelKeyEventName,
+					labelKeyJobResult,
+				},
+			},
+		},
+		Gauges: map[string]*v1alpha1.GaugeMetric{
+			MetricAssignedJobs: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+			MetricRunningJobs: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+			MetricRegisteredRunners: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+			MetricBusyRunners: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+			MetricMinRunners: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+			MetricMaxRunners: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+			MetricDesiredRunners: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+			MetricIdleRunners: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyRunnerScaleSetName,
+					labelKeyRunnerScaleSetNamespace,
+				},
+			},
+		},
+		Histograms: map[string]*v1alpha1.HistogramMetric{
+			MetricJobStartupDurationSeconds: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyJobName,
+					labelKeyEventName,
+				},
+				Buckets: defaultRuntimeBuckets,
+			},
+			MetricJobExecutionDurationSeconds: {
+				Labels: []string{
+					labelKeyEnterprise,
+					labelKeyOrganization,
+					labelKeyRepository,
+					labelKeyJobName,
+					labelKeyEventName,
+					labelKeyJobResult,
+				},
+				Buckets: defaultRuntimeBuckets,
+			},
+		},
+	}
 }
 
 func NewExporter(config ExporterConfig) ServerExporter {
+	config.defaults()
 	reg := prometheus.NewRegistry()
 
-	metrics := installMetrics(config.Metrics, reg, config.Logger)
+	metrics := installMetrics(*config.Metrics, reg, config.Logger)
 
 	mux := http.NewServeMux()
 	mux.Handle(

--- a/cmd/ghalistener/metrics/metrics_test.go
+++ b/cmd/ghalistener/metrics/metrics_test.go
@@ -109,22 +109,22 @@ func TestNewExporter(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		wantMetrics := installMetrics(defaultMetrics, reg, config.Logger)
 
-		assert.Equal(t, len(wantMetrics.counters), len(exporter.metrics.counters))
+		assert.Equal(t, len(wantMetrics.counters), len(exporter.counters))
 		for k, v := range wantMetrics.counters {
-			assert.Contains(t, exporter.metrics.counters, k)
-			assert.Equal(t, v.config, exporter.metrics.counters[k].config)
+			assert.Contains(t, exporter.counters, k)
+			assert.Equal(t, v.config, exporter.counters[k].config)
 		}
 
-		assert.Equal(t, len(wantMetrics.gauges), len(exporter.metrics.gauges))
+		assert.Equal(t, len(wantMetrics.gauges), len(exporter.gauges))
 		for k, v := range wantMetrics.gauges {
-			assert.Contains(t, exporter.metrics.gauges, k)
-			assert.Equal(t, v.config, exporter.metrics.gauges[k].config)
+			assert.Contains(t, exporter.gauges, k)
+			assert.Equal(t, v.config, exporter.gauges[k].config)
 		}
 
-		assert.Equal(t, len(wantMetrics.histograms), len(exporter.metrics.histograms))
+		assert.Equal(t, len(wantMetrics.histograms), len(exporter.histograms))
 		for k, v := range wantMetrics.histograms {
-			assert.Contains(t, exporter.metrics.histograms, k)
-			assert.Equal(t, v.config, exporter.metrics.histograms[k].config)
+			assert.Contains(t, exporter.histograms, k)
+			assert.Equal(t, v.config, exporter.histograms[k].config)
 		}
 
 		require.NotNil(t, exporter.srv)
@@ -151,22 +151,22 @@ func TestNewExporter(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		wantMetrics := installMetrics(defaultMetrics, reg, config.Logger)
 
-		assert.Equal(t, len(wantMetrics.counters), len(exporter.metrics.counters))
+		assert.Equal(t, len(wantMetrics.counters), len(exporter.counters))
 		for k, v := range wantMetrics.counters {
-			assert.Contains(t, exporter.metrics.counters, k)
-			assert.Equal(t, v.config, exporter.metrics.counters[k].config)
+			assert.Contains(t, exporter.counters, k)
+			assert.Equal(t, v.config, exporter.counters[k].config)
 		}
 
-		assert.Equal(t, len(wantMetrics.gauges), len(exporter.metrics.gauges))
+		assert.Equal(t, len(wantMetrics.gauges), len(exporter.gauges))
 		for k, v := range wantMetrics.gauges {
-			assert.Contains(t, exporter.metrics.gauges, k)
-			assert.Equal(t, v.config, exporter.metrics.gauges[k].config)
+			assert.Contains(t, exporter.gauges, k)
+			assert.Equal(t, v.config, exporter.gauges[k].config)
 		}
 
-		assert.Equal(t, len(wantMetrics.histograms), len(exporter.metrics.histograms))
+		assert.Equal(t, len(wantMetrics.histograms), len(exporter.histograms))
 		for k, v := range wantMetrics.histograms {
-			assert.Contains(t, exporter.metrics.histograms, k)
-			assert.Equal(t, v.config, exporter.metrics.histograms[k].config)
+			assert.Contains(t, exporter.histograms, k)
+			assert.Equal(t, v.config, exporter.histograms[k].config)
 		}
 
 		require.NotNil(t, exporter.srv)
@@ -212,22 +212,22 @@ func TestNewExporter(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		wantMetrics := installMetrics(metricsConfig, reg, config.Logger)
 
-		assert.Equal(t, len(wantMetrics.counters), len(exporter.metrics.counters))
+		assert.Equal(t, len(wantMetrics.counters), len(exporter.counters))
 		for k, v := range wantMetrics.counters {
-			assert.Contains(t, exporter.metrics.counters, k)
-			assert.Equal(t, v.config, exporter.metrics.counters[k].config)
+			assert.Contains(t, exporter.counters, k)
+			assert.Equal(t, v.config, exporter.counters[k].config)
 		}
 
-		assert.Equal(t, len(wantMetrics.gauges), len(exporter.metrics.gauges))
+		assert.Equal(t, len(wantMetrics.gauges), len(exporter.gauges))
 		for k, v := range wantMetrics.gauges {
-			assert.Contains(t, exporter.metrics.gauges, k)
-			assert.Equal(t, v.config, exporter.metrics.gauges[k].config)
+			assert.Contains(t, exporter.gauges, k)
+			assert.Equal(t, v.config, exporter.gauges[k].config)
 		}
 
-		assert.Equal(t, len(wantMetrics.histograms), len(exporter.metrics.histograms))
+		assert.Equal(t, len(wantMetrics.histograms), len(exporter.histograms))
 		for k, v := range wantMetrics.histograms {
-			assert.Contains(t, exporter.metrics.histograms, k)
-			assert.Equal(t, v.config, exporter.metrics.histograms[k].config)
+			assert.Contains(t, exporter.histograms, k)
+			assert.Equal(t, v.config, exporter.histograms[k].config)
 		}
 
 		require.NotNil(t, exporter.srv)

--- a/cmd/ghalistener/metrics/metrics_test.go
+++ b/cmd/ghalistener/metrics/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInstallMetrics(t *testing.T) {
@@ -85,4 +86,180 @@ func TestInstallMetrics(t *testing.T) {
 	duration := got.histograms[MetricJobStartupDurationSeconds]
 	assert.Equal(t, duration.config.Labels, metricsConfig.Histograms[MetricJobStartupDurationSeconds].Labels)
 	assert.Equal(t, duration.config.Buckets, defaultRuntimeBuckets)
+}
+
+func TestNewExporter(t *testing.T) {
+	t.Run("with defaults metrics applied", func(t *testing.T) {
+		config := ExporterConfig{
+			ScaleSetName:      "test-scale-set",
+			ScaleSetNamespace: "test-namespace",
+			Enterprise:        "",
+			Organization:      "org",
+			Repository:        "repo",
+			ServerAddr:        ":6060",
+			ServerEndpoint:    "/metrics",
+			Logger:            logr.Discard(),
+			Metrics:           nil, // when metrics is nil, all default metrics should be registered
+		}
+
+		exporter, ok := NewExporter(config).(*exporter)
+		require.True(t, ok, "expected exporter to be of type *exporter")
+		require.NotNil(t, exporter)
+
+		reg := prometheus.NewRegistry()
+		wantMetrics := installMetrics(defaultMetrics, reg, config.Logger)
+
+		assert.Equal(t, len(wantMetrics.counters), len(exporter.metrics.counters))
+		for k, v := range wantMetrics.counters {
+			assert.Contains(t, exporter.metrics.counters, k)
+			assert.Equal(t, v.config, exporter.metrics.counters[k].config)
+		}
+
+		assert.Equal(t, len(wantMetrics.gauges), len(exporter.metrics.gauges))
+		for k, v := range wantMetrics.gauges {
+			assert.Contains(t, exporter.metrics.gauges, k)
+			assert.Equal(t, v.config, exporter.metrics.gauges[k].config)
+		}
+
+		assert.Equal(t, len(wantMetrics.histograms), len(exporter.metrics.histograms))
+		for k, v := range wantMetrics.histograms {
+			assert.Contains(t, exporter.metrics.histograms, k)
+			assert.Equal(t, v.config, exporter.metrics.histograms[k].config)
+		}
+
+		require.NotNil(t, exporter.srv)
+		assert.Equal(t, config.ServerAddr, exporter.srv.Addr)
+	})
+
+	t.Run("with default server URL", func(t *testing.T) {
+		config := ExporterConfig{
+			ScaleSetName:      "test-scale-set",
+			ScaleSetNamespace: "test-namespace",
+			Enterprise:        "",
+			Organization:      "org",
+			Repository:        "repo",
+			ServerAddr:        "", // empty ServerAddr should default to ":8080"
+			ServerEndpoint:    "",
+			Logger:            logr.Discard(),
+			Metrics:           nil, // when metrics is nil, all default metrics should be registered
+		}
+
+		exporter, ok := NewExporter(config).(*exporter)
+		require.True(t, ok, "expected exporter to be of type *exporter")
+		require.NotNil(t, exporter)
+
+		reg := prometheus.NewRegistry()
+		wantMetrics := installMetrics(defaultMetrics, reg, config.Logger)
+
+		assert.Equal(t, len(wantMetrics.counters), len(exporter.metrics.counters))
+		for k, v := range wantMetrics.counters {
+			assert.Contains(t, exporter.metrics.counters, k)
+			assert.Equal(t, v.config, exporter.metrics.counters[k].config)
+		}
+
+		assert.Equal(t, len(wantMetrics.gauges), len(exporter.metrics.gauges))
+		for k, v := range wantMetrics.gauges {
+			assert.Contains(t, exporter.metrics.gauges, k)
+			assert.Equal(t, v.config, exporter.metrics.gauges[k].config)
+		}
+
+		assert.Equal(t, len(wantMetrics.histograms), len(exporter.metrics.histograms))
+		for k, v := range wantMetrics.histograms {
+			assert.Contains(t, exporter.metrics.histograms, k)
+			assert.Equal(t, v.config, exporter.metrics.histograms[k].config)
+		}
+
+		require.NotNil(t, exporter.srv)
+		assert.Equal(t, exporter.srv.Addr, ":8080")
+	})
+
+	t.Run("with metrics configured", func(t *testing.T) {
+		metricsConfig := v1alpha1.MetricsConfig{
+			Counters: map[string]*v1alpha1.CounterMetric{
+				MetricStartedJobsTotal: {
+					Labels: []string{labelKeyRepository},
+				},
+			},
+			Gauges: map[string]*v1alpha1.GaugeMetric{
+				MetricAssignedJobs: {
+					Labels: []string{labelKeyRepository},
+				},
+			},
+			Histograms: map[string]*v1alpha1.HistogramMetric{
+				MetricJobExecutionDurationSeconds: {
+					Labels:  []string{labelKeyRepository},
+					Buckets: []float64{0.1, 1},
+				},
+			},
+		}
+
+		config := ExporterConfig{
+			ScaleSetName:      "test-scale-set",
+			ScaleSetNamespace: "test-namespace",
+			Enterprise:        "",
+			Organization:      "org",
+			Repository:        "repo",
+			ServerAddr:        ":6060",
+			ServerEndpoint:    "/metrics",
+			Logger:            logr.Discard(),
+			Metrics:           &metricsConfig,
+		}
+
+		exporter, ok := NewExporter(config).(*exporter)
+		require.True(t, ok, "expected exporter to be of type *exporter")
+		require.NotNil(t, exporter)
+
+		reg := prometheus.NewRegistry()
+		wantMetrics := installMetrics(metricsConfig, reg, config.Logger)
+
+		assert.Equal(t, len(wantMetrics.counters), len(exporter.metrics.counters))
+		for k, v := range wantMetrics.counters {
+			assert.Contains(t, exporter.metrics.counters, k)
+			assert.Equal(t, v.config, exporter.metrics.counters[k].config)
+		}
+
+		assert.Equal(t, len(wantMetrics.gauges), len(exporter.metrics.gauges))
+		for k, v := range wantMetrics.gauges {
+			assert.Contains(t, exporter.metrics.gauges, k)
+			assert.Equal(t, v.config, exporter.metrics.gauges[k].config)
+		}
+
+		assert.Equal(t, len(wantMetrics.histograms), len(exporter.metrics.histograms))
+		for k, v := range wantMetrics.histograms {
+			assert.Contains(t, exporter.metrics.histograms, k)
+			assert.Equal(t, v.config, exporter.metrics.histograms[k].config)
+		}
+
+		require.NotNil(t, exporter.srv)
+		assert.Equal(t, config.ServerAddr, exporter.srv.Addr)
+	})
+}
+
+func TestExporterConfigDefaults(t *testing.T) {
+	config := ExporterConfig{
+		ScaleSetName:      "test-scale-set",
+		ScaleSetNamespace: "test-namespace",
+		Enterprise:        "",
+		Organization:      "org",
+		Repository:        "repo",
+		ServerAddr:        "",
+		ServerEndpoint:    "",
+		Logger:            logr.Discard(),
+		Metrics:           nil, // when metrics is nil, all default metrics should be registered
+	}
+
+	config.defaults()
+	want := ExporterConfig{
+		ScaleSetName:      "test-scale-set",
+		ScaleSetNamespace: "test-namespace",
+		Enterprise:        "",
+		Organization:      "org",
+		Repository:        "repo",
+		ServerAddr:        ":8080",    // default server address
+		ServerEndpoint:    "/metrics", // default server endpoint
+		Logger:            logr.Discard(),
+		Metrics:           &defaultMetrics, // when metrics is nil, all default metrics should be registered
+	}
+
+	assert.Equal(t, want, config)
 }


### PR DESCRIPTION
When metrics are configured on the controller, but no metrics are applied to the scale set, the listener would panic with nil dereference error.

This change applies all metrics by default if metrics are configured, but no customisation is being done.

To avoid server errors in the future, defaults are applied to the server address and the default endpoint. This code path should not be hit by default, since the `app.go` decides if it should apply metrics based on the server address. But it made sense to use the default `:8080` port and `/metrics` endpoint in the default function to future-proof the code.

Fixes #3993