### PR TITLE
Add startup probe to dind side-car

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -108,6 +108,14 @@ securityContext:
   privileged: true
 {{- if (ge (.Capabilities.KubeVersion.Minor | int) 29) }}
 restartPolicy: Always
+startupProbe:
+  exec:
+    command:
+      - docker
+      - info
+    initialDelaySeconds: 0
+    failureThreshold: 24
+    periodSeconds: 5
 {{- end }}
 volumeMounts:
   - name: work

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -286,18 +286,6 @@ template:
   ##       volumeMounts:
   ##         - name: dind-externals
   ##           mountPath: /home/runner/tmpDir
-  ##     containers:
-  ##     - name: runner
-  ##       image: ghcr.io/actions/actions-runner:latest
-  ##       command: ["/home/runner/run.sh"]
-  ##       env:
-  ##         - name: DOCKER_HOST
-  ##           value: unix:///var/run/docker.sock
-  ##       volumeMounts:
-  ##         - name: work
-  ##           mountPath: /home/runner/_work
-  ##         - name: dind-sock
-  ##           mountPath: /var/run
   ##     - name: dind
   ##       image: docker:dind
   ##       args:
@@ -309,13 +297,29 @@ template:
   ##           value: "123"
   ##       securityContext:
   ##         privileged: true
+  ##       restartPolicy: Always
+  ##       startupProbe:
+  ##         exec:
+  ##           command:
+  ##             - docker
+  ##             - info
+  ##           initialDelaySeconds: 0
+  ##           failureThreshold: 24
+  ##           periodSeconds: 5
+  ##     containers:
+  ##     - name: runner
+  ##       image: ghcr.io/actions/actions-runner:latest
+  ##       command: ["/home/runner/run.sh"]
+  ##       env:
+  ##         - name: DOCKER_HOST
+  ##           value: unix:///var/run/docker.sock
+  ##         - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+  ##           value: "120"
   ##       volumeMounts:
   ##         - name: work
   ##           mountPath: /home/runner/_work
   ##         - name: dind-sock
   ##           mountPath: /var/run
-  ##         - name: dind-externals
-  ##           mountPath: /home/runner/externals
   ##     volumes:
   ##     - name: work
   ##       emptyDir: {}


### PR DESCRIPTION
The startup probe was missing, ensuring that docker is fully initialised and running.

Moving to the sidecar is best described here: https://www.kenmuse.com/blog/using-kubernetes-native-sidecars-with-github-arc/

Thank you, @kenmuse, for pointing this out! :heart: 

Fixes #3600