### PR TITLE
Bump build-push-action to 6.18.0

### DIFF
--- a/.github/actions/setup-arc-e2e/action.yaml
+++ b/.github/actions/setup-arc-e2e/action.yaml
@@ -36,8 +36,8 @@ runs:
         driver-opts: image=moby/buildkit:v0.10.6
 
     - name: Build controller image
-      # https://github.com/docker/build-push-action/releases/tag/v6.15.0
-      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
+      # https://github.com/docker/build-push-action/releases/tag/v6.18.0
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
       with:
         file: Dockerfile
         platforms: linux/amd64

--- a/.github/workflows/gha-publish-chart.yaml
+++ b/.github/workflows/gha-publish-chart.yaml
@@ -93,8 +93,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push controller image
-        # https://github.com/docker/build-push-action/releases/tag/v6.15.0
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
+        # https://github.com/docker/build-push-action/releases/tag/v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -75,8 +75,8 @@ jobs:
           version: latest
 
       - name: Build controller image
-        # https://github.com/docker/build-push-action/releases/tag/v6.15.0
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
+        # https://github.com/docker/build-push-action/releases/tag/v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         if: steps.list-changed.outputs.changed == 'true'
         with:
           file: Dockerfile

--- a/.github/workflows/global-publish-canary.yaml
+++ b/.github/workflows/global-publish-canary.yaml
@@ -123,8 +123,8 @@ jobs:
 
       # Unstable builds - run at your own risk
       - name: Build and Push
-        # https://github.com/docker/build-push-action/releases/tag/v6.15.0
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
+        # https://github.com/docker/build-push-action/releases/tag/v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Uploading cache fails unless we bump the build-push-action