### PR TITLE
Fix indentation of startupProbe attributes in dind sidecar

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -113,9 +113,9 @@ startupProbe:
     command:
       - docker
       - info
-    initialDelaySeconds: 0
-    failureThreshold: 24
-    periodSeconds: 5
+  initialDelaySeconds: 0
+  failureThreshold: 24
+  periodSeconds: 5
 {{- end }}
 volumeMounts:
   - name: work

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -326,9 +326,9 @@ template:
   ##           command:
   ##             - docker
   ##             - info
-  ##           initialDelaySeconds: 0
-  ##           failureThreshold: 24
-  ##           periodSeconds: 5
+##           initialDelaySeconds: 0
+##           failureThreshold: 24
+##           periodSeconds: 5
   ##     containers:
   ##     - name: runner
   ##       image: ghcr.io/actions/actions-runner:latest


### PR DESCRIPTION
Fixes the indentation of startupProbe attributes to be at the same level of `exec` and not nested under, per the [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#probe-v1-core).

Fixes #4125

Tested chart install on a local k3s cluster with the following values:
```
githubConfigUrl: "https://github.com/YOUR_ORG/YOUR_REPO"
githubConfigSecret:
  github_token: "YOUR_GITHUB_PAT_TOKEN"
maxRunners: 3
minRunners: 0
containerMode:
  type: "dind"
controllerServiceAccount:
  name: "gha-runner-scale-set-gha-rs-controller"
  namespace: "default"%
```
```
> kubectl get autoscalingrunnersets
NAME                   MINIMUM RUNNERS   MAXIMUM RUNNERS   CURRENT RUNNERS   STATE   PENDING RUNNERS   RUNNING RUNNERS   FINISHED RUNNERS   DELETING RUNNERS
gha-runner-scale-set   0                 3
```