### PR TITLE
Fix dind sidecar template

### DIFF
--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -166,11 +166,11 @@ spec:
       initContainers:
         {{- if eq $containerMode.type "dind" }}
       - name: init-dind-externals
-        {{- include "gha-runner-scale-set.dind-init-container" . | nindent 8 }}
-        {{- end }}
-        {{- if (ge (.Capabilities.KubeVersion.Minor | int) 29) }}
+          {{- include "gha-runner-scale-set.dind-init-container" . | nindent 8 }}
+          {{- if (ge (.Capabilities.KubeVersion.Minor | int) 29) }}
       - name: dind
-        {{- include "gha-runner-scale-set.dind-container" . | nindent 8 }}
+          {{- include "gha-runner-scale-set.dind-container" . | nindent 8 }}
+          {{- end }}
         {{- end }}
         {{- with .Values.template.spec.initContainers }}
       {{- toYaml . | nindent 6 }}

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -326,9 +326,16 @@ template:
   ##           command:
   ##             - docker
   ##             - info
-##           initialDelaySeconds: 0
-##           failureThreshold: 24
-##           periodSeconds: 5
+  ##         initialDelaySeconds: 0
+  ##         failureThreshold: 24
+  ##         periodSeconds: 5
+  ##       volumeMounts:
+  ##         - name: work
+  ##           mountPath: /home/runner/_work
+  ##         - name: dind-sock
+  ##           mountPath: /var/run
+  ##         - name: dind-externals
+  ##           mountPath: /home/runner/externals
   ##     containers:
   ##     - name: runner
   ##       image: ghcr.io/actions/actions-runner:latest


### PR DESCRIPTION
This PR fixes the helm template issue when containerMode is not set to dind so it does not add the dind sidecar because of a incorrectly placed {{ end }}

As well a fix to the values file to add the missing volumeMounts for the dind sidecar container template which the helm template does add in case of type "dind"

Fixes #4125 #4127 