### PR TITLE
Fix missing quote in helm chart templates

### DIFF
--- a/charts/actions-runner-controller/templates/_helpers.tpl
+++ b/charts/actions-runner-controller/templates/_helpers.tpl
@@ -52,7 +52,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $k, $v := .Values.labels }}
-{{ $k }}: {{ $v }}
+{{ $k }}: {{ $v | quote }}
 {{- end }}
 {{- end }}
 

--- a/contrib/examples/actions-runner/templates/_helpers.tpl
+++ b/contrib/examples/actions-runner/templates/_helpers.tpl
@@ -41,7 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $k, $v := .Values.labels }}
-{{ $k }}: {{ $v }}
+{{ $k }}: {{ $v | quote }}
 {{- end }}
 {{- end }}
 

--- a/contrib/examples/actions-runner/values.yaml
+++ b/contrib/examples/actions-runner/values.yaml
@@ -1,3 +1,5 @@
+labels: {}
+
 image:
   repository: summerwind/actions-runner
   tag: v2.290.1-ubuntu-20.04


### PR DESCRIPTION
Fixes missing `quote` on custom labels, in some places this was already present, but in `charts/actions-runner-controller/templates/_helpers.tpl` it was missing preventing values like `"false"` to be actually inserted into final YAML

After adding this fix, helm values like this should start working:
```yaml
labels:
  test: "false"
```

Previously it was failing with an error:
```
unable to decode "": json: cannot unmarshal bool into Go struct field ObjectMeta.metadata.labels of type string
```