### PR TITLE
Fix image pull secrets list arguments in the chart

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-controller/templates/_helpers.tpl
@@ -129,11 +129,3 @@ Create the name of the service account to use
 {{- define "gha-runner-scale-set-controller.leaderElectionRoleBinding" -}}
 {{- include "gha-runner-scale-set-controller.fullname" . }}-leader-election
 {{- end }}
-
-{{- define "gha-runner-scale-set-controller.imagePullSecretsNames" -}}
-{{- $names := list }}
-{{- range $k, $v := . }}
-  {{- $names = append $names $v.name }}
-{{- end }}
-{{- $names | join ","}}
-{{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -54,7 +54,9 @@ spec:
         - "--leader-election-id={{ include "gha-runner-scale-set-controller.fullname" . }}"
         {{- end }}
         {{- with .Values.imagePullSecrets }}
-        - "--auto-scaler-image-pull-secrets={{ include "gha-runner-scale-set-controller.imagePullSecretsNames" . }}"
+        {{- range . }}
+        - "--auto-scaler-image-pull-secrets={{- .name -}}"
+        {{- end }}
         {{- end }}
         {{- with .Values.flags.logLevel }}
         - "--log-level={{ . }}"

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -683,7 +683,8 @@ func TestTemplate_ControllerDeployment_ForwardImagePullSecrets(t *testing.T) {
 
 	expectedArgs := []string{
 		"--auto-scaling-runner-set-only",
-		"--auto-scaler-image-pull-secrets=dockerhub,ghcr",
+		"--auto-scaler-image-pull-secrets=dockerhub",
+		"--auto-scaler-image-pull-secrets=ghcr",
 		"--log-level=debug",
 		"--log-format=text",
 		"--update-strategy=immediate",
@@ -1079,6 +1080,7 @@ func TestDeployment_excludeLabelPropagationPrefixes(t *testing.T) {
 	assert.Contains(t, container.Args, "--exclude-label-propagation-prefix=prefix.com/")
 	assert.Contains(t, container.Args, "--exclude-label-propagation-prefix=complete.io/label")
 }
+
 func TestNamespaceOverride(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Since the flag type is `stringSlice`, this PR fixes the way names are passed as flags to the controller.

Fixes #4159