### PR TITLE
Requeue if create pod returns already exists error

### DIFF
--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -193,10 +193,6 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			// create secret if not created
 			log.Info("Creating new ephemeral runner secret for jitconfig.")
 			if err := r.createSecret(ctx, ephemeralRunner, jitConfig, log); err != nil {
-				if kerrors.IsAlreadyExists(err) {
-					log.Info("Secret already exists. Requeing after 1 second to wait for the event")
-					return ctrl.Result{Requeue: true, RequeueAfter: 1 * time.Second}, nil
-				}
 				return ctrl.Result{}, fmt.Errorf("failed to create secret: %w", err)
 			}
 			log.Info("Created new ephemeral runner secret for jitconfig.")
@@ -280,7 +276,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return result, nil
 		case kerrors.IsAlreadyExists(err):
 			log.Info("Runner pod already exists. Waiting for the pod event to be received")
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
 		case kerrors.IsInvalid(err) || kerrors.IsForbidden(err):
 			log.Error(err, "Failed to create a pod due to unrecoverable failure")
 			errMessage := fmt.Sprintf("Failed to create the pod: %v", err)

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -193,6 +193,10 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			// create secret if not created
 			log.Info("Creating new ephemeral runner secret for jitconfig.")
 			if err := r.createSecret(ctx, ephemeralRunner, jitConfig, log); err != nil {
+				if kerrors.IsAlreadyExists(err) {
+					log.Info("Secret already exists. Requeing after 1 second to wait for the event")
+					return ctrl.Result{Requeue: true, RequeueAfter: 1 * time.Second}, nil
+				}
 				return ctrl.Result{}, fmt.Errorf("failed to create secret: %w", err)
 			}
 			log.Info("Created new ephemeral runner secret for jitconfig.")
@@ -268,13 +272,15 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			log.Error(err, "Failed to fetch the pod")
 			return ctrl.Result{}, err
 		}
+		log.Info("Ephemeral runner pod does not exist. Creating new ephemeral runner")
 
-		// Pod was not found. Create if the pod has never been created
-		log.Info("Creating new EphemeralRunner pod.")
 		result, err := r.createPod(ctx, ephemeralRunner, secret, log)
 		switch {
 		case err == nil:
 			return result, nil
+		case kerrors.IsAlreadyExists(err):
+			log.Info("Runner pod already exists. Waiting for the pod event to be received")
+			return ctrl.Result{}, nil
 		case kerrors.IsInvalid(err) || kerrors.IsForbidden(err):
 			log.Error(err, "Failed to create a pod due to unrecoverable failure")
 			errMessage := fmt.Sprintf("Failed to create the pod: %v", err)


### PR DESCRIPTION
There are situations when the newly created pod is not yet delivered through the watcher, causing subsequent reconciliations to issue a second create pod event.

This change tests for the condition, logs at the info level, and re-queues the event in 5s.
It is not necessary to do it for secrets since the secrets are not watched; therefore, the `GET` request was being issued directly.

It will reduce the noise in the log while backing off the reconciliation for a bit.