### PR TITLE
Add ARMv7 support to actions-runner container images

### DIFF
--- a/runner/Makefile
+++ b/runner/Makefile
@@ -12,7 +12,7 @@ DOCKER_VERSION ?= 24.0.7
 
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
-	export PLATFORMS="linux/amd64,linux/arm64"
+	export PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
 endif
 
 # if IMG_RESULT is unspecified, by default the image will be pushed to registry

--- a/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
@@ -6,7 +6,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 # Docker and Docker Compose arguments
 ENV CHANNEL=stable
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 
 # Other arguments
 ARG DEBUG=false
@@ -25,6 +24,7 @@ RUN apt-get update -y \
     ca-certificates \
     curl \
     dnsutils \
+    dumb-init \
     ftp \
     git \
     iproute2 \
@@ -70,12 +70,6 @@ RUN set -eux; \
     adduser --system --ingroup dockremap dockremap; \
     echo 'dockremap:165536:65536' >> /etc/subuid; \
     echo 'dockremap:165536:65536' >> /etc/subgid
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
@@ -22,19 +22,19 @@ RUN apt-get update -y \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
     build-essential \
-    curl \
     ca-certificates \
+    curl \
     dnsutils \
     ftp \
     git \
     iproute2 \
-    iputils-ping \
     iptables \
+    iputils-ping \
     jq \
     libunwind8 \
     locales \
-    netcat \
     net-tools \
+    netcat \
     openssh-client \
     parallel \
     python3-pip \

--- a/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-20.04.dockerfile
@@ -136,6 +136,7 @@ RUN export SKIP_IPTABLES=1 \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /home/runner/.docker/cli-plugins \
     && curl -fLo /home/runner/.docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /home/runner/.docker/cli-plugins/docker-compose \

--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -114,6 +114,7 @@ RUN export SKIP_IPTABLES=1 \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /home/runner/.docker/cli-plugins \
     && curl -fLo /home/runner/.docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /home/runner/.docker/cli-plugins/docker-compose \

--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -20,8 +20,9 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
+    fuse-overlayfs \
     git \
     iproute2 \
     iptables \
@@ -30,7 +31,6 @@ RUN apt-get update -y \
     uidmap \
     unzip \
     zip \
-    fuse-overlayfs \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version

--- a/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-22.04.dockerfile
@@ -6,7 +6,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 # Docker and Docker Compose arguments
 ENV CHANNEL=stable
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 
 # Other arguments
@@ -22,6 +21,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    dumb-init \
     fuse-overlayfs \
     git \
     iproute2 \
@@ -48,12 +48,6 @@ RUN set -eux; \
     adduser --system --ingroup dockremap dockremap; \
     echo 'dockremap:165536:65536' >> /etc/subuid; \
     echo 'dockremap:165536:65536' >> /etc/subgid
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner-dind-rootless.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-24.04.dockerfile
@@ -114,6 +114,7 @@ RUN export SKIP_IPTABLES=1 \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /home/runner/.docker/cli-plugins \
     && curl -fLo /home/runner/.docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /home/runner/.docker/cli-plugins/docker-compose \

--- a/runner/actions-runner-dind-rootless.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-24.04.dockerfile
@@ -20,8 +20,9 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
+    fuse-overlayfs \
     git \
     iproute2 \
     iptables \
@@ -30,7 +31,6 @@ RUN apt-get update -y \
     uidmap \
     unzip \
     zip \
-    fuse-overlayfs \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version

--- a/runner/actions-runner-dind-rootless.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner-dind-rootless.ubuntu-24.04.dockerfile
@@ -6,7 +6,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 # Docker and Docker Compose arguments
 ENV CHANNEL=stable
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 
 # Other arguments
@@ -22,6 +21,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    dumb-init \
     fuse-overlayfs \
     git \
     iproute2 \
@@ -48,12 +48,6 @@ RUN set -eux; \
     adduser --system --ingroup dockremap dockremap; \
     echo 'dockremap:165536:65536' >> /etc/subuid; \
     echo 'dockremap:165536:65536' >> /etc/subgid
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner-dind.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-20.04.dockerfile
@@ -20,19 +20,19 @@ RUN apt-get update -y \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
     build-essential \
-    curl \
     ca-certificates \
+    curl \
     dnsutils \
     ftp \
     git \
     iproute2 \
-    iputils-ping \
     iptables \
+    iputils-ping \
     jq \
     libunwind8 \
     locales \
-    netcat \
     net-tools \
+    netcat \
     openssh-client \
     parallel \
     python3-pip \

--- a/runner/actions-runner-dind.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-20.04.dockerfile
@@ -95,6 +95,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armhf ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/${CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/* /usr/bin/ \
@@ -103,6 +104,7 @@ RUN set -vx; \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /usr/libexec/docker/cli-plugins \
     && curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \

--- a/runner/actions-runner-dind.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-20.04.dockerfile
@@ -7,7 +7,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 ARG CHANNEL=stable
 ARG DOCKER_VERSION=24.0.7
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 
 # Use 1001 and 121 for compatibility with GitHub-hosted runners
 ARG RUNNER_UID=1000
@@ -23,6 +22,7 @@ RUN apt-get update -y \
     ca-certificates \
     curl \
     dnsutils \
+    dumb-init \
     ftp \
     git \
     iproute2 \
@@ -65,12 +65,6 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner \
     && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 ENV HOME=/home/runner
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner-dind.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-22.04.dockerfile
@@ -7,7 +7,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 ARG CHANNEL=stable
 ARG DOCKER_VERSION=24.0.7
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 ARG DOCKER_GROUP_GID=121
 
@@ -19,6 +18,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    dumb-init \
     git \
     iptables \
     jq \
@@ -41,12 +41,6 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
     && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 ENV HOME=/home/runner
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner-dind.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-22.04.dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
     git \
     iptables \
     jq \

--- a/runner/actions-runner-dind.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-22.04.dockerfile
@@ -71,6 +71,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armhf ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/${CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/* /usr/bin/ \
@@ -79,6 +80,7 @@ RUN set -vx; \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /usr/libexec/docker/cli-plugins \
     && curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \

--- a/runner/actions-runner-dind.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-24.04.dockerfile
@@ -7,7 +7,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 ARG CHANNEL=stable
 ARG DOCKER_VERSION=24.0.7
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 ARG DOCKER_GROUP_GID=121
 
@@ -19,6 +18,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    dumb-init \
     git \
     iptables \
     jq \
@@ -41,12 +41,6 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
     && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 ENV HOME=/home/runner
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner-dind.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-24.04.dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
     git \
     iptables \
     jq \

--- a/runner/actions-runner-dind.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner-dind.ubuntu-24.04.dockerfile
@@ -71,6 +71,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armhf ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/${CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/* /usr/bin/ \
@@ -79,6 +80,7 @@ RUN set -vx; \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /usr/libexec/docker/cli-plugins \
     && curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \

--- a/runner/actions-runner.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner.ubuntu-20.04.dockerfile
@@ -7,7 +7,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 ARG CHANNEL=stable
 ARG DOCKER_VERSION=24.0.7
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 
 # Use 1001 and 121 for compatibility with GitHub-hosted runners
 ARG RUNNER_UID=1000
@@ -23,6 +22,7 @@ RUN apt-get update -y \
     ca-certificates \
     curl \
     dnsutils \
+    dumb-init \
     ftp \
     git \
     iproute2 \
@@ -61,12 +61,6 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner \
     && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 ENV HOME=/home/runner
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner.ubuntu-20.04.dockerfile
@@ -92,6 +92,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armhf ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/${CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/docker /usr/bin/docker \
@@ -100,6 +101,7 @@ RUN set -vx; \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /usr/libexec/docker/cli-plugins \
     && curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \

--- a/runner/actions-runner.ubuntu-20.04.dockerfile
+++ b/runner/actions-runner.ubuntu-20.04.dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update -y \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
     build-essential \
-    curl \
     ca-certificates \
+    curl \
     dnsutils \
     ftp \
     git \

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -69,6 +69,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armhf ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/${CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/docker /usr/bin/docker \
@@ -77,6 +78,7 @@ RUN set -vx; \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /usr/libexec/docker/cli-plugins \
     && curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -7,7 +7,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 ARG CHANNEL=stable
 ARG DOCKER_VERSION=24.0.7
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 ARG DOCKER_GROUP_GID=121
 
@@ -19,6 +18,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    dumb-init \
     git \
     jq \
     sudo \
@@ -38,12 +38,6 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
     && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 ENV HOME=/home/runner
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner.ubuntu-22.04.dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
     git \
     jq \
     sudo \

--- a/runner/actions-runner.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner.ubuntu-24.04.dockerfile
@@ -69,6 +69,7 @@ RUN set -vx; \
     export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armhf ; fi \
     && curl -fLo docker.tgz https://download.docker.com/linux/static/${CHANNEL}/${ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && install -o root -g root -m 755 docker/docker /usr/bin/docker \
@@ -77,6 +78,7 @@ RUN set -vx; \
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
+    && if [ "$ARCH" = "arm" ]; then export ARCH=armv7 ; fi \
     && mkdir -p /usr/libexec/docker/cli-plugins \
     && curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${ARCH} \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \

--- a/runner/actions-runner.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner.ubuntu-24.04.dockerfile
@@ -7,7 +7,6 @@ ARG RUNNER_CONTAINER_HOOKS_VERSION
 ARG CHANNEL=stable
 ARG DOCKER_VERSION=24.0.7
 ARG DOCKER_COMPOSE_VERSION=v2.23.0
-ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 ARG DOCKER_GROUP_GID=121
 
@@ -19,6 +18,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    dumb-init \
     git \
     jq \
     sudo \
@@ -38,12 +38,6 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
     && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
 
 ENV HOME=/home/runner
-
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
-    && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
-    && chmod +x /usr/bin/dumb-init
 
 ENV RUNNER_ASSETS_DIR=/runnertmp
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/runner/actions-runner.ubuntu-24.04.dockerfile
+++ b/runner/actions-runner.ubuntu-24.04.dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
     git \
     jq \
     sudo \


### PR DESCRIPTION
Sort package install lists alphabetically.

Use dumb-init from Ubuntu repositories: dumb-init is available in the Ubuntu package repositories, so let's use that. This makes adding new architectures easier.

For Ubuntu 20.04, this means a downgrade from 1.2.5 to 1.2.2. However, given that Ubuntu 20.04 reached the end of its support cycle in May 2025, this seems acceptable. The only regression is that dumb-init won't attempt to cd into the root directory in order to release the file descriptor for its current working directory, besides some fixes around the --help and --version flags.