### PR TITLE
Enable secrets and configmaps caching in default mode

### DIFF
--- a/.github/workflows/gha-validate-chart.yaml
+++ b/.github/workflows/gha-validate-chart.yaml
@@ -4,12 +4,16 @@ on:
   pull_request:
     branches:
       - master
+      - mercari-master
     paths:
       - 'charts/**'
       - '.github/workflows/gha-validate-chart.yaml'
       - '!charts/actions-runner-controller/**'
       - '!**.md'
   push:
+    branches:
+      - master
+      - mercari-master
     paths:
       - 'charts/**'
       - '.github/workflows/gha-validate-chart.yaml'

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - mercari-master
     paths:
       - '.github/workflows/go.yaml'
       - '**.go'

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -79,6 +79,9 @@ spec:
         - "--listener-metrics-endpoint="
         - "--metrics-addr=0"
         {{- end }}
+        {{- with .Values.pprof }}
+        - "--pprof-addr={{ .controllerManagerAddr }}"
+        {{- end }}
         {{- range .Values.flags.excludeLabelPropagationPrefixes }}
         - "--exclude-label-propagation-prefix={{ . }}"
         {{- end }}
@@ -96,11 +99,18 @@ spec:
         {{- end }}
         command:
         - "/manager"
-        {{- with .Values.metrics }}
+        {{- if or .Values.metrics .Values.pprof }}
         ports:
+        {{- end}}
+        {{- with .Values.metrics }}
         - containerPort: {{regexReplaceAll ":([0-9]+)" .controllerManagerAddr "${1}"}}
           protocol: TCP
           name: metrics
+        {{- end }}
+        {{- with .Values.pprof }}
+        - containerPort: {{regexReplaceAll ":([0-9]+)" .controllerManagerAddr "${1}"}}
+          protocol: TCP
+          name: pprof
         {{- end }}
         env:
         - name: CONTROLLER_MANAGER_CONTAINER_IMAGE

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -82,6 +82,18 @@ spec:
         {{- range .Values.flags.excludeLabelPropagationPrefixes }}
         - "--exclude-label-propagation-prefix={{ . }}"
         {{- end }}
+        {{- with .Values.flags.maxConcurrentReconcilesForAutoscalingRunnerSet }}
+        - "--max-concurrent-reconciles-for-autoscaling-runner-set={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.maxConcurrentReconcilesForEphemeralRunnerSet }}
+        - "--max-concurrent-reconciles-for-ephemeral-runner-set={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.maxConcurrentReconcilesForEphemeralRunner }}
+        - "--max-concurrent-reconciles-for-ephemeral-runner={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.maxConcurrentReconcilesForAutoscalingListener }}
+        - "--max-concurrent-reconciles-for-autoscaling-listener={{ . }}"
+        {{- end }}
         command:
         - "/manager"
         {{- with .Values.metrics }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -103,6 +103,9 @@ spec:
         {{- with .Values.flags.clientGoRateLimiterBurst }}
         - "--client-go-rate-limiter-burst={{ . }}"
         {{- end }}
+        {{- with .Values.flags.disableWorkqueueBucketRateLimiter }}
+        - "--disable-workqueue-bucket-rate-limiter={{ . }}"
+        {{- end }}
         command:
         - "/manager"
         {{- if or .Values.metrics .Values.pprof }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
         {{- with .Values.flags.maxConcurrentReconcilesForAutoscalingListener }}
         - "--max-concurrent-reconciles-for-autoscaling-listener={{ . }}"
         {{- end }}
+        {{- with .Values.flags.clientGoRateLimiterQPS }}
+        - "--client-go-rate-limiter-qps={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.clientGoRateLimiterBurst }}
+        - "--client-go-rate-limiter-burst={{ . }}"
+        {{- end }}
         command:
         - "/manager"
         {{- if or .Values.metrics .Values.pprof }}

--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
@@ -127,6 +127,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
@@ -47,6 +47,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
@@ -108,6 +108,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -911,7 +911,7 @@ func TestTemplate_CreateManagerSingleNamespaceRole(t *testing.T) {
 
 	assert.Equal(t, "test-arc-gha-rs-controller-single-namespace", managerSingleNamespaceControllerRole.Name)
 	assert.Equal(t, namespaceName, managerSingleNamespaceControllerRole.Namespace)
-	assert.Equal(t, 10, len(managerSingleNamespaceControllerRole.Rules))
+	assert.Equal(t, 12, len(managerSingleNamespaceControllerRole.Rules))
 
 	output = helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/manager_single_namespace_watch_role.yaml"})
 
@@ -920,7 +920,7 @@ func TestTemplate_CreateManagerSingleNamespaceRole(t *testing.T) {
 
 	assert.Equal(t, "test-arc-gha-rs-controller-single-namespace-watch", managerSingleNamespaceWatchRole.Name)
 	assert.Equal(t, "demo", managerSingleNamespaceWatchRole.Namespace)
-	assert.Equal(t, 14, len(managerSingleNamespaceWatchRole.Rules))
+	assert.Equal(t, 16, len(managerSingleNamespaceWatchRole.Rules))
 }
 
 func TestTemplate_ManagerSingleNamespaceRoleBinding(t *testing.T) {

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -177,7 +177,7 @@ func TestTemplate_CreateManagerClusterRole(t *testing.T) {
 
 	assert.Empty(t, managerClusterRole.Namespace, "ClusterRole should not have a namespace")
 	assert.Equal(t, "test-arc-gha-rs-controller", managerClusterRole.Name)
-	assert.Equal(t, 16, len(managerClusterRole.Rules))
+	assert.Equal(t, 18, len(managerClusterRole.Rules))
 
 	_, err = helm.RenderTemplateE(t, options, helmChartPath, releaseName, []string{"templates/manager_single_namespace_controller_role.yaml"})
 	assert.ErrorContains(t, err, "could not find template templates/manager_single_namespace_controller_role.yaml in chart", "We should get an error because the template should be skipped")

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -130,3 +130,9 @@ flags:
   ## Labels that match prefix specified in the list are excluded from propagation.
   # excludeLabelPropagationPrefixes:
   #   - "argocd.argoproj.io/instance"
+
+  ## Defines the maximum number of concurrent reconciles for each reconciler.
+  # maxConcurrentReconcilesForAutoscalingRunnerSet: 1
+  # maxConcurrentReconcilesForEphemeralRunnerSet: 1
+  # maxConcurrentReconcilesForEphemeralRunner: 1
+  # maxConcurrentReconcilesForAutoscalingListener: 1

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -144,3 +144,4 @@ flags:
   ## Defines the client-go rate limiter parameters.
   # clientGoRateLimiterQPS: 20
   # clientGoRateLimiterBurst: 30
+  # disableWorkqueueBucketRateLimiter: false

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -140,3 +140,7 @@ flags:
   # maxConcurrentReconcilesForEphemeralRunnerSet: 1
   # maxConcurrentReconcilesForEphemeralRunner: 1
   # maxConcurrentReconcilesForAutoscalingListener: 1
+
+  ## Defines the client-go rate limiter parameters.
+  # clientGoRateLimiterQPS: 20
+  # clientGoRateLimiterBurst: 30

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -94,6 +94,10 @@ priorityClassName: ""
 #   listenerAddr: ":8080"
 #   listenerEndpoint: "/metrics"
 
+## To enable pprof, uncomment the following lines.
+# pprof:
+#   controllerManagerAddr: ":8081"
+
 flags:
   ## Log level can be set here with one of the following values: "debug", "info", "warn", "error".
   ## Defaults to "debug".

--- a/controllers/actions.github.com/autoscalinglistener_controller.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -54,6 +55,8 @@ type AutoscalingListenerReconciler struct {
 	// If it is set to "0", the metrics server is not started.
 	ListenerMetricsAddr     string
 	ListenerMetricsEndpoint string
+
+	MaxConcurrentReconciles int
 
 	ResourceBuilder
 }
@@ -730,6 +733,7 @@ func (r *AutoscalingListenerReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Watches(&rbacv1.Role{}, handler.EnqueueRequestsFromMapFunc(labelBasedWatchFunc)).
 		Watches(&rbacv1.RoleBinding{}, handler.EnqueueRequestsFromMapFunc(labelBasedWatchFunc)).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/controllers/actions.github.com/autoscalinglistener_controller_test.go
+++ b/controllers/actions.github.com/autoscalinglistener_controller_test.go
@@ -44,9 +44,10 @@ var _ = Describe("Test AutoScalingListener controller", func() {
 		configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 		controller := &AutoscalingListenerReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Log:    logf.Log,
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			MaxConcurrentReconciles: 1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -508,9 +509,10 @@ var _ = Describe("Test AutoScalingListener customization", func() {
 		configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 		controller := &AutoscalingListenerReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Log:    logf.Log,
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			MaxConcurrentReconciles: 1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -782,9 +784,10 @@ var _ = Describe("Test AutoScalingListener controller with proxy", func() {
 		configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 		controller := &AutoscalingListenerReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Log:    logf.Log,
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			MaxConcurrentReconciles: 1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -978,9 +981,10 @@ var _ = Describe("Test AutoScalingListener controller with template modification
 		configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 		controller := &AutoscalingListenerReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Log:    logf.Log,
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			MaxConcurrentReconciles: 1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -1094,9 +1098,10 @@ var _ = Describe("Test GitHub Server TLS configuration", func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to create configmap with root CAs")
 
 		controller := &AutoscalingListenerReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Log:    logf.Log,
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			MaxConcurrentReconciles: 1,
 		}
 		err = controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -79,6 +80,7 @@ type AutoscalingRunnerSetReconciler struct {
 	DefaultRunnerScaleSetListenerImagePullSecrets []string
 	UpdateStrategy                                UpdateStrategy
 	ActionsClient                                 actions.MultiClient
+	MaxConcurrentReconciles                       int
 	ResourceBuilder
 }
 
@@ -763,6 +765,7 @@ func (r *AutoscalingRunnerSetReconciler) SetupWithManager(mgr ctrl.Manager) erro
 			},
 		)).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -32,6 +32,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -81,6 +82,7 @@ type AutoscalingRunnerSetReconciler struct {
 	UpdateStrategy                                UpdateStrategy
 	ActionsClient                                 actions.MultiClient
 	MaxConcurrentReconciles                       int
+	WorkqueueRateLimiter                          workqueue.RateLimiter
 	ResourceBuilder
 }
 
@@ -765,7 +767,10 @@ func (r *AutoscalingRunnerSetReconciler) SetupWithManager(mgr ctrl.Manager) erro
 			},
 		)).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+			RateLimiter:             r.WorkqueueRateLimiter,
+		}).
 		Complete(r)
 }
 

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Test AutoScalingRunnerSet controller", Ordered, func() {
 			ControllerNamespace:                autoscalingNS.Name,
 			DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 			ActionsClient:                      fake.NewMultiClient(),
+			MaxConcurrentReconciles:            1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -704,6 +705,7 @@ var _ = Describe("Test AutoScalingController updates", Ordered, func() {
 						nil,
 					),
 				),
+				MaxConcurrentReconciles: 1,
 			}
 			err := controller.SetupWithManager(mgr)
 			Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -819,6 +821,7 @@ var _ = Describe("Test AutoscalingController creation failures", Ordered, func()
 				ControllerNamespace:                autoscalingNS.Name,
 				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 				ActionsClient:                      fake.NewMultiClient(),
+				MaxConcurrentReconciles:            1,
 			}
 			err := controller.SetupWithManager(mgr)
 			Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -945,6 +948,7 @@ var _ = Describe("Test client optional configuration", Ordered, func() {
 				ControllerNamespace:                autoscalingNS.Name,
 				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 				ActionsClient:                      actions.NewMultiClient(logr.Discard()),
+				MaxConcurrentReconciles:            1,
 			}
 
 			err := controller.SetupWithManager(mgr)
@@ -1128,6 +1132,7 @@ var _ = Describe("Test client optional configuration", Ordered, func() {
 				ControllerNamespace:                autoscalingNS.Name,
 				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 				ActionsClient:                      fake.NewMultiClient(),
+				MaxConcurrentReconciles:            1,
 			}
 			err = controller.SetupWithManager(mgr)
 			Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -1362,6 +1367,7 @@ var _ = Describe("Test external permissions cleanup", Ordered, func() {
 			ControllerNamespace:                autoscalingNS.Name,
 			DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 			ActionsClient:                      fake.NewMultiClient(),
+			MaxConcurrentReconciles:            1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -1520,6 +1526,7 @@ var _ = Describe("Test external permissions cleanup", Ordered, func() {
 			ControllerNamespace:                autoscalingNS.Name,
 			DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 			ActionsClient:                      fake.NewMultiClient(),
+			MaxConcurrentReconciles:            1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -1728,6 +1735,7 @@ var _ = Describe("Test resource version and build version mismatch", func() {
 			ControllerNamespace:                autoscalingNS.Name,
 			DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 			ActionsClient:                      fake.NewMultiClient(),
+			MaxConcurrentReconciles:            1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -49,9 +50,10 @@ const (
 // EphemeralRunnerReconciler reconciles a EphemeralRunner object
 type EphemeralRunnerReconciler struct {
 	client.Client
-	Log           logr.Logger
-	Scheme        *runtime.Scheme
-	ActionsClient actions.MultiClient
+	Log                     logr.Logger
+	Scheme                  *runtime.Scheme
+	ActionsClient           actions.MultiClient
+	MaxConcurrentReconciles int
 	ResourceBuilder
 }
 
@@ -828,6 +830,7 @@ func (r *EphemeralRunnerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&v1alpha1.EphemeralRunner{}).
 		Owns(&corev1.Pod{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -101,10 +101,11 @@ var _ = Describe("EphemeralRunner", func() {
 			configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 			controller = &EphemeralRunnerReconciler{
-				Client:        mgr.GetClient(),
-				Scheme:        mgr.GetScheme(),
-				Log:           logf.Log,
-				ActionsClient: fake.NewMultiClient(),
+				Client:                  mgr.GetClient(),
+				Scheme:                  mgr.GetScheme(),
+				Log:                     logf.Log,
+				ActionsClient:           fake.NewMultiClient(),
+				MaxConcurrentReconciles: 1,
 			}
 
 			err := controller.SetupWithManager(mgr)
@@ -681,6 +682,7 @@ var _ = Describe("EphemeralRunner", func() {
 						nil,
 					),
 				),
+				MaxConcurrentReconciles: 1,
 			}
 			err := controller.SetupWithManager(mgr)
 			Expect(err).To(BeNil(), "failed to setup controller")
@@ -737,10 +739,11 @@ var _ = Describe("EphemeralRunner", func() {
 			configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoScalingNS.Name)
 
 			controller = &EphemeralRunnerReconciler{
-				Client:        mgr.GetClient(),
-				Scheme:        mgr.GetScheme(),
-				Log:           logf.Log,
-				ActionsClient: fake.NewMultiClient(),
+				Client:                  mgr.GetClient(),
+				Scheme:                  mgr.GetScheme(),
+				Log:                     logf.Log,
+				ActionsClient:           fake.NewMultiClient(),
+				MaxConcurrentReconciles: 1,
 			}
 			err := controller.SetupWithManager(mgr)
 			Expect(err).To(BeNil(), "failed to setup controller")
@@ -901,10 +904,11 @@ var _ = Describe("EphemeralRunner", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create configmap with root CAs")
 
 			controller = &EphemeralRunnerReconciler{
-				Client:        mgr.GetClient(),
-				Scheme:        mgr.GetScheme(),
-				Log:           logf.Log,
-				ActionsClient: fake.NewMultiClient(),
+				Client:                  mgr.GetClient(),
+				Scheme:                  mgr.GetScheme(),
+				Log:                     logf.Log,
+				ActionsClient:           fake.NewMultiClient(),
+				MaxConcurrentReconciles: 1,
 			}
 
 			err = controller.SetupWithManager(mgr)

--- a/controllers/actions.github.com/ephemeralrunnerset_controller.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -55,6 +56,7 @@ type EphemeralRunnerSetReconciler struct {
 	PublishMetrics bool
 
 	MaxConcurrentReconciles int
+	WorkqueueRateLimiter    workqueue.RateLimiter
 
 	ResourceBuilder
 }
@@ -578,7 +580,10 @@ func (r *EphemeralRunnerSetReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		For(&v1alpha1.EphemeralRunnerSet{}).
 		Owns(&v1alpha1.EphemeralRunner{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+			RateLimiter:             r.WorkqueueRateLimiter,
+		}).
 		Complete(r)
 }
 

--- a/controllers/actions.github.com/ephemeralrunnerset_controller.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -52,6 +53,8 @@ type EphemeralRunnerSetReconciler struct {
 	ActionsClient actions.MultiClient
 
 	PublishMetrics bool
+
+	MaxConcurrentReconciles int
 
 	ResourceBuilder
 }
@@ -575,6 +578,7 @@ func (r *EphemeralRunnerSetReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		For(&v1alpha1.EphemeralRunnerSet{}).
 		Owns(&v1alpha1.EphemeralRunner{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/controllers/actions.github.com/ephemeralrunnerset_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller_test.go
@@ -48,10 +48,11 @@ var _ = Describe("Test EphemeralRunnerSet controller", func() {
 		configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 		controller := &EphemeralRunnerSetReconciler{
-			Client:        mgr.GetClient(),
-			Scheme:        mgr.GetScheme(),
-			Log:           logf.Log,
-			ActionsClient: fake.NewMultiClient(),
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			ActionsClient:           fake.NewMultiClient(),
+			MaxConcurrentReconciles: 1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -1098,10 +1099,11 @@ var _ = Describe("Test EphemeralRunnerSet controller with proxy settings", func(
 		configSecret = createDefaultSecret(GinkgoT(), k8sClient, autoscalingNS.Name)
 
 		controller := &EphemeralRunnerSetReconciler{
-			Client:        mgr.GetClient(),
-			Scheme:        mgr.GetScheme(),
-			Log:           logf.Log,
-			ActionsClient: actions.NewMultiClient(logr.Discard()),
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			ActionsClient:           actions.NewMultiClient(logr.Discard()),
+			MaxConcurrentReconciles: 1,
 		}
 		err := controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
@@ -1397,10 +1399,11 @@ var _ = Describe("Test EphemeralRunnerSet controller with custom root CA", func(
 		Expect(err).NotTo(HaveOccurred(), "failed to create configmap with root CAs")
 
 		controller := &EphemeralRunnerSetReconciler{
-			Client:        mgr.GetClient(),
-			Scheme:        mgr.GetScheme(),
-			Log:           logf.Log,
-			ActionsClient: actions.NewMultiClient(logr.Discard()),
+			Client:                  mgr.GetClient(),
+			Scheme:                  mgr.GetScheme(),
+			Log:                     logf.Log,
+			ActionsClient:           actions.NewMultiClient(logr.Discard()),
+			MaxConcurrentReconciles: 1,
 		}
 		err = controller.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred(), "failed to setup controller")

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		listenerMetricsEndpoint string
 
 		metricsAddr              string
+		pprofAddr                string
 		autoScalingRunnerSetOnly bool
 		enableLeaderElection     bool
 		disableAdmissionWebhook  bool
@@ -119,6 +120,7 @@ func main() {
 	flag.StringVar(&listenerMetricsAddr, "listener-metrics-addr", ":8080", "The address applied to AutoscalingListener metrics server")
 	flag.StringVar(&listenerMetricsEndpoint, "listener-metrics-endpoint", "/metrics", "The AutoscalingListener metrics server endpoint from which the metrics are collected")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-addr", "", "The address the pprof endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&leaderElectionId, "leader-election-id", "actions-runner-controller", "Controller id for leader election.")
@@ -243,6 +245,7 @@ func main() {
 				},
 			},
 		},
+		PprofBindAddress: pprofAddr,
 	})
 	if err != nil {
 		log.Error(err, "unable to start manager")

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/actions/actions-runner-controller/github/actions"
 	"github.com/actions/actions-runner-controller/logging"
 	"github.com/kelseyhightower/envconfig"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -238,16 +237,6 @@ func main() {
 	cfg.QPS = float32(rateLimiterQPS)
 	cfg.Burst = rateLimiterBurst
 
-	clientOptions := client.Options{}
-	if watchSingleNamespace == "" {
-		clientOptions.Cache = &client.CacheOptions{
-			DisableFor: []client.Object{
-				&corev1.Secret{},
-				&corev1.ConfigMap{},
-			},
-		}
-	}
-
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -260,7 +249,7 @@ func main() {
 		WebhookServer:    webhookServer,
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: leaderElectionId,
-		Client:           clientOptions,
+		Client:           client.Options{},
 		PprofBindAddress: pprofAddr,
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -234,6 +234,16 @@ func main() {
 	cfg.QPS = float32(rateLimiterQPS)
 	cfg.Burst = rateLimiterBurst
 
+	clientOptions := client.Options{}
+	if watchSingleNamespace == "" {
+		clientOptions.Cache = &client.CacheOptions{
+			DisableFor: []client.Object{
+				&corev1.Secret{},
+				&corev1.ConfigMap{},
+			},
+		}
+	}
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -246,14 +256,7 @@ func main() {
 		WebhookServer:    webhookServer,
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: leaderElectionId,
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{
-					&corev1.Secret{},
-					&corev1.ConfigMap{},
-				},
-			},
-		},
+		Client:           clientOptions,
 		PprofBindAddress: pprofAddr,
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -109,6 +109,9 @@ func main() {
 		maxConcurrentReconcilesForEphemeralRunnerSet   int
 		maxConcurrentReconcilesForEphemeralRunner      int
 		maxConcurrentReconcilesForAutoscalingListener  int
+
+		rateLimiterQPS   int
+		rateLimiterBurst int
 	)
 	var c github.Config
 	err = envconfig.Process("github", &c)
@@ -156,6 +159,8 @@ func main() {
 	flag.IntVar(&maxConcurrentReconcilesForEphemeralRunnerSet, "max-concurrent-reconciles-for-ephemeral-runner-set", 1, "The maximum number of concurrent reconciles for EphemeralRunnerSet.")
 	flag.IntVar(&maxConcurrentReconcilesForEphemeralRunner, "max-concurrent-reconciles-for-ephemeral-runner", 1, "The maximum number of concurrent reconciles for EphemeralRunner.")
 	flag.IntVar(&maxConcurrentReconcilesForAutoscalingListener, "max-concurrent-reconciles-for-autoscaling-listener", 1, "The maximum number of concurrent reconciles for AutoscalingListener.")
+	flag.IntVar(&rateLimiterQPS, "client-go-rate-limiter-qps", 20, "The QPS value of client-go rate limiter.")
+	flag.IntVar(&rateLimiterBurst, "client-go-rate-limiter-burst", 30, "The burst value of client-go rate limiter.")
 	flag.Parse()
 
 	runnerPodDefaults.RunnerImagePullSecrets = runnerImagePullSecrets
@@ -225,7 +230,11 @@ func main() {
 		})
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	cfg := ctrl.GetConfigOrDie()
+	cfg.QPS = float32(rateLimiterQPS)
+	cfg.Burst = rateLimiterBurst
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,


### PR DESCRIPTION
## Summary
- Remove the condition that disabled secrets and configmaps caching when watchSingleNamespace is empty
- Add necessary RBAC permissions for secrets and configmaps to gha-runner-scale-set-controller
- Allow all objects to be cached consistently in both single namespace and default modes

## Changes
- Remove cache disable logic for secrets/configmaps in main.go  
- Add secrets and configmaps list/watch permissions to cluster role
- Update test to reflect new permission count (16 -> 18 rules)

## Test plan
- [x] Helm template tests pass
- [ ] Integration tests with actual cluster
- [ ] Verify caching behavior in both modes