### PR TITLE
[Helm] Expose dind image

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -96,7 +96,8 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+image: {{ .Values.dind.image }}
+imagePullPolicy: {{ .Values.dind.imagePullPolicy }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -295,6 +295,11 @@ githubConfigSecret:
 #           3600.0,
 #         ]
 
+# if using dind - you can overwrite the image used
+dind:
+  image: docker:dind
+  imagePullPolicy: IfNotPresent
+
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
 template:


### PR DESCRIPTION
This image is not configurable. This seemed the simplest to expose this to be configurable. 

All other images are configurable but this one. I need to use an internal container registry, and hit this issue. 

Tried my best to come up with a sensible place to put this key and this is what I came up with. 

See issue here: https://github.com/actions/actions-runner-controller/issues/4232