### PR TITLE
Ensure ephemeral runner is deleted from the service on exit != 0

### DIFF
--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -336,6 +336,17 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				log.Error(err, "Failed to delete the ephemeral runner that has a job assigned but the pod has failed")
 				return ctrl.Result{}, err
 			}
+
+			actionsClient, err := r.GetActionsService(ctx, ephemeralRunner)
+			if err != nil {
+				log.Error(err, "Failed to get actions client for checking the job status")
+				return ctrl.Result{}, nil
+			}
+			if err := actionsClient.RemoveRunner(ctx, int64(ephemeralRunner.Status.RunnerId)); err != nil {
+				log.Error(err, "Failed to remove the runner from the service")
+				return ctrl.Result{}, nil
+			}
+
 			return ctrl.Result{}, nil
 		}
 		if err := r.deletePodAsFailed(ctx, ephemeralRunner, pod, log); err != nil {

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -337,6 +337,8 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				return ctrl.Result{}, err
 			}
 
+			log.Info("Deleted the ephemeral runner that has a job assigned but the pod has failed")
+			log.Info("Trying to remove the runner from the service")
 			actionsClient, err := r.GetActionsService(ctx, ephemeralRunner)
 			if err != nil {
 				log.Error(err, "Failed to get actions client for checking the job status")
@@ -346,7 +348,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				log.Error(err, "Failed to remove the runner from the service")
 				return ctrl.Result{}, nil
 			}
-
+			log.Info("Removed the runner from the service")
 			return ctrl.Result{}, nil
 		}
 		if err := r.deletePodAsFailed(ctx, ephemeralRunner, pod, log); err != nil {

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -341,7 +341,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			log.Info("Trying to remove the runner from the service")
 			actionsClient, err := r.GetActionsService(ctx, ephemeralRunner)
 			if err != nil {
-				log.Error(err, "Failed to get actions client for checking the job status")
+				log.Error(err, "Failed to get actions client for removing the runner from the service")
 				return ctrl.Result{}, nil
 			}
 			if err := actionsClient.RemoveRunner(ctx, int64(ephemeralRunner.Status.RunnerId)); err != nil {


### PR DESCRIPTION
When runner exits with exit code 1, make sure that it is removed from the API.
The assumption is:
1. The runner if exits with 0, means that the runner entrypoint was successful, therefore the runner successfully deregistered itself.
2. If the exit code is 1, it can be due to a disruption. The disruption could be caused either by a node or something else, which caused the runner not to deregister itself but get interrupted, or the entrypoint was wrong.
3. If the entrypoint was wrong, the delete request would cause an increase in API requests, but that is how it previously worked, so it would lead just to a slower reconcile loop. Since the entrypoint is mostly `run.sh`, which is shipped by the runner, this case is rare or unlikely to occur.
4. The more likely case is that the runner couldn't finish due to an interruption. Then, we would delete the runner but we also should clean it up from the service.